### PR TITLE
Move webhooks from / to /webhook

### DIFF
--- a/changelog.d/227.feature
+++ b/changelog.d/227.feature
@@ -1,0 +1,1 @@
+Generic webhooks now listen for incoming hooks on `/webhooks`. Existing setups using `/` will continue to work, but should be migrated where possible. See [the documentation](https://matrix-org.github.io/matrix-hookshot/setup/webhooks.html#configuration) for more information.

--- a/changelog.d/227.feature
+++ b/changelog.d/227.feature
@@ -1,1 +1,1 @@
-Generic webhooks now listen for incoming hooks on `/webhooks`. Existing setups using `/` will continue to work, but should be migrated where possible. See [the documentation](https://matrix-org.github.io/matrix-hookshot/setup/webhooks.html#configuration) for more information.
+Generic webhooks now listen for incoming hooks on `/webhook`. Existing setups using `/` will continue to work, but should be migrated where possible. See [the documentation](https://matrix-org.github.io/matrix-hookshot/setup/webhooks.html#configuration) for more information.

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -55,9 +55,9 @@ generic:
   # (Optional) Support for generic webhook events. `allowJsTransformationFunctions` will allow users to write short transformation snippets in code, and thus is unsafe in untrusted environments
   #
   enabled: false
-  urlPrefix: https://example.com/mywebhookspath/
+  urlPrefix: https://example.com/webhooks/
   allowJsTransformationFunctions: false
-  userIdPrefix: webhooks_
+  waitForComplete: true
 figma:
   # (Optional) Configure this to enable Figma support
   #

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -57,7 +57,7 @@ generic:
   #
   #
   enabled: false
-  urlPrefix: https://example.com/webhooks/
+  urlPrefix: https://example.com/webhook/
   allowJsTransformationFunctions: false
   waitForComplete: false
 figma:

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -52,12 +52,14 @@ jira:
     client_secret: bar
     redirect_uri: https://example.com/bridge_oauth/
 generic:
-  # (Optional) Support for generic webhook events. `allowJsTransformationFunctions` will allow users to write short transformation snippets in code, and thus is unsafe in untrusted environments
+  # (Optional) Support for generic webhook events.
+  #'allowJsTransformationFunctions' will allow users to write short transformation snippets in code, and thus is unsafe in untrusted environments
+  #
   #
   enabled: false
   urlPrefix: https://example.com/webhooks/
   allowJsTransformationFunctions: false
-  waitForComplete: true
+  waitForComplete: false
 figma:
   # (Optional) Configure this to enable Figma support
   #

--- a/docs/setup/webhooks.md
+++ b/docs/setup/webhooks.md
@@ -12,6 +12,8 @@ generic:
   enabled: true
   urlPrefix: https://example.com/mywebhookspath/
   allowJsTransformationFunctions: false
+  waitForComplete: false
+  # userIdPrefix: webhook_
 ```
 
 <section class="notice">
@@ -27,6 +29,22 @@ The bridge listens for incoming webhooks requests on the host and port provided 
 webhook requests from `https://example.com/mywebhookspath` to the bridge (on `/webhook`), an example webhook URL would look like:
 `https://example.com/mywebhookspath/abcdef`.
 
+`waitForComplete` causes the bridge to wait until the webhook is processed before sending a response. Some services prefer you always
+respond with a 200 as soon as the webhook has entered processing (`false`) while others prefer to know if the resulting Matrix message
+has been sent (`true`). By default this is `false`.
+
+You may set a `userIdPrefix` to create a specific user for each new webhook connection in a room. For example, a connection with a name
+like `example` for a prefix of `webhook_` will create a user called `@webhook_example:example.com`. If you enable this option,
+you need to configure the user to be part of your registration file e.g.:
+
+```yaml
+# registration.yaml
+...
+namespaces:
+  users:
+    - regex: "@webhook_.+:example.com" # Where example.com is your domain name.
+      exclusive: true
+```
 
 ## Adding a webhook
 

--- a/docs/setup/webhooks.md
+++ b/docs/setup/webhooks.md
@@ -14,11 +14,19 @@ generic:
   allowJsTransformationFunctions: false
 ```
 
+<section class="notice">
+Previous versions of the bridge listened for requests on `/` rather than `/webhooks`. While this behaviour will continue to work,
+administators are advised to use `/webhooks`.
+</section>
+
+The webhooks listener listens on the path `/webhooks`.
+
 The bridge listens for incoming webhooks requests on the host and port provided in the [`listeners` config](../setup.md#listeners-configuration).
 
 `urlPrefix` describes the public facing URL of your webhook handler. For instance, if your load balancer redirected
-webhook requests from `https://example.com/mywebhookspath` to the bridge an example webhook URL would look like:
+webhook requests from `https://example.com/mywebhookspath` to the bridge (on `/webhooks`), an example webhook URL would look like:
 `https://example.com/mywebhookspath/abcdef`.
+
 
 ## Adding a webhook
 

--- a/docs/setup/webhooks.md
+++ b/docs/setup/webhooks.md
@@ -15,16 +15,16 @@ generic:
 ```
 
 <section class="notice">
-Previous versions of the bridge listened for requests on `/` rather than `/webhooks`. While this behaviour will continue to work,
-administators are advised to use `/webhooks`.
+Previous versions of the bridge listened for requests on `/` rather than `/webhook`. While this behaviour will continue to work,
+administators are advised to use `/webhook`.
 </section>
 
-The webhooks listener listens on the path `/webhooks`.
+The webhooks listener listens on the path `/webhook`.
 
 The bridge listens for incoming webhooks requests on the host and port provided in the [`listeners` config](../setup.md#listeners-configuration).
 
 `urlPrefix` describes the public facing URL of your webhook handler. For instance, if your load balancer redirected
-webhook requests from `https://example.com/mywebhookspath` to the bridge (on `/webhooks`), an example webhook URL would look like:
+webhook requests from `https://example.com/mywebhookspath` to the bridge (on `/webhook`), an example webhook URL would look like:
 `https://example.com/mywebhookspath/abcdef`.
 
 

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -260,7 +260,9 @@ export class BridgeConfig {
     public readonly gitlab?: BridgeConfigGitLab;
     @configKey("Configure this to enable Jira support. Only specify `url` if you are using a On Premise install (i.e. not atlassian.com)", true)
     public readonly jira?: BridgeConfigJira;
-    @configKey("Support for generic webhook events. `allowJsTransformationFunctions` will allow users to write short transformation snippets in code, and thus is unsafe in untrusted environments", true)
+    @configKey(`Support for generic webhook events.
+'allowJsTransformationFunctions' will allow users to write short transformation snippets in code, and thus is unsafe in untrusted environments
+`, true)
     public readonly generic?: BridgeGenericWebhooksConfig;
     @configKey("Configure this to enable Figma support", true)
     public readonly figma?: BridgeConfigFigma;

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -168,6 +168,7 @@ export interface BridgeGenericWebhooksConfig {
     urlPrefix: string;
     userIdPrefix?: string;
     allowJsTransformationFunctions?: boolean;
+    waitForComplete?: boolean;
 }
 
 interface BridgeWidgetConfig {

--- a/src/Config/Defaults.ts
+++ b/src/Config/Defaults.ts
@@ -75,9 +75,10 @@ export const DefaultConfig = new BridgeConfig({
     },
     generic: {
         enabled: false,
-        urlPrefix: "https://example.com/mywebhookspath/",
+        urlPrefix: "https://example.com/webhooks/",
         allowJsTransformationFunctions: false,
         userIdPrefix: "webhooks_",
+        waitForComplete: true,
     },
     figma: {
         publicUrl: "https://example.com/hookshot/",

--- a/src/Config/Defaults.ts
+++ b/src/Config/Defaults.ts
@@ -75,7 +75,7 @@ export const DefaultConfig = new BridgeConfig({
     },
     generic: {
         enabled: false,
-        urlPrefix: "https://example.com/webhooks/",
+        urlPrefix: "https://example.com/webhook/",
         allowJsTransformationFunctions: false,
         waitForComplete: false,
     },

--- a/src/Config/Defaults.ts
+++ b/src/Config/Defaults.ts
@@ -77,8 +77,7 @@ export const DefaultConfig = new BridgeConfig({
         enabled: false,
         urlPrefix: "https://example.com/webhooks/",
         allowJsTransformationFunctions: false,
-        userIdPrefix: "webhooks_",
-        waitForComplete: true,
+        waitForComplete: false,
     },
     figma: {
         publicUrl: "https://example.com/hookshot/",

--- a/src/Connections/GenericHook.ts
+++ b/src/Connections/GenericHook.ts
@@ -178,34 +178,43 @@ export class GenericHookConnection extends BaseConnection implements IConnection
         this.state = validatedConfig;
     }
 
-    public transformHookData(data: Record<string, unknown>|string): {plain: string, html?: string} {
+    public transformHookData(data: unknown): {plain: string, html?: string} {
         // Supported parameters https://developers.mattermost.com/integrate/incoming-webhooks/#parameters
         const msg: {plain: string, html?: string} = {plain: ""};
         if (typeof data === "string") {
             return {plain: `Received webhook data: ${data}`};
-        } else if (typeof data.text === "string") {
-            msg.plain = data.text;
-        } else {
+        } else if (typeof data !== "object") {
             msg.plain = "Received webhook data:\n\n" + "```json\n\n" + JSON.stringify(data, null, 2) + "\n\n```";
             msg.html = `<p>Received webhook data:</p><p><pre><code class=\\"language-json\\">${JSON.stringify(data, null, 2)}</code></pre></p>`
+            return msg;
         }
 
-        if (typeof data.html === "string") {
-            msg.html = data.html;
+        if (data === null) {
+            throw Error('`data` was null');
         }
 
-        if (typeof data.username === "string") {
+        const objectData = data as Record<string, unknown>;
+
+        if (typeof objectData.text === "string") {
+            msg.plain = objectData.text;
+        }
+
+        if (typeof objectData.html === "string") {
+            msg.html = objectData.html;
+        }
+
+        if (typeof objectData.username === "string") {
             // Create a matrix user for this person
-            msg.plain = `**${data.username}**: ${msg.plain}`
+            msg.plain = `**${objectData.username}**: ${msg.plain}`
             if (msg.html) {
-                msg.html = `<strong>${data.username}</strong>: ${msg.html}`;
+                msg.html = `<strong>${objectData.username}</strong>: ${msg.html}`;
             }
         }
         // TODO: Transform Slackdown into markdown.
         return msg;
     }
 
-    public executeTransformationFunction(data: Record<string, unknown>): {plain: string, html?: string}|null {
+    public executeTransformationFunction(data: unknown): {plain: string, html?: string}|null {
         if (!this.transformationFunction) {
             throw Error('Transformation function not defined');
         }
@@ -250,7 +259,12 @@ export class GenericHookConnection extends BaseConnection implements IConnection
         }
     }
 
-    public async onGenericHook(data: Record<string, unknown>) {
+    /**
+     * Processes an incoming generic hook
+     * @param data Structured data. This may either be a string, or an object.
+     * @returns `true` if the webhook completed, or `false` if it failed to complete 
+     */
+    public async onGenericHook(data: unknown): Promise<boolean> {
         log.info(`onGenericHook ${this.roomId} ${this.hookId}`);
         let content: {plain: string, html?: string};
         if (!this.transformationFunction) {
@@ -260,25 +274,27 @@ export class GenericHookConnection extends BaseConnection implements IConnection
                 const potentialContent = this.executeTransformationFunction(data);
                 if (potentialContent === null) {
                     // Explitly no action
-                    return;
+                    return true;
                 }
                 content = potentialContent;
             } catch (ex) {
                 log.warn(`Failed to run transformation function`, ex);
                 content = {plain: `Webhook received but failed to process via transformation function`};
+                return false;
             }
         }
 
         const sender = this.getUserId();
         await this.ensureDisplayname();
 
-        return this.messageClient.sendMatrixMessage(this.roomId, {
+        await this.messageClient.sendMatrixMessage(this.roomId, {
             msgtype: "m.notice",
             body: content.plain,
             formatted_body: content.html || md.renderInline(content.plain),
             format: "org.matrix.custom.html",
             "uk.half-shot.hookshot.webhook_data": data,
         }, 'm.room.message', sender);
+        return true;
 
     }
 

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -11,6 +11,7 @@ import { v4 as uuid } from "uuid";
 import { BridgeConfig, BridgePermissionLevel } from "../Config/Config";
 import markdown from "markdown-it";
 import { FigmaFileConnection } from "./FigmaFileConnection";
+import { URL } from "url";
 const md = new markdown();
 
 /**

--- a/src/generic/Router.ts
+++ b/src/generic/Router.ts
@@ -1,0 +1,64 @@
+import { MessageQueue } from "../MessageQueue";
+import express, { NextFunction, Request, Response, Router } from "express";
+import LogWrapper from "../LogWrapper";
+import { ApiError, ErrCode } from "../provisioning/api";
+import { GenericWebhookEvent, GenericWebhookEventResult } from "./types";
+
+const WEBHOOK_RESPONSE_TIMEOUT = 5000;
+
+const log = new LogWrapper('GenericWebhooksRouter');
+export class GenericWebhooksRouter {
+    constructor(private readonly queue: MessageQueue, private readonly deprecatedPath = false) { }
+
+    private onWebhook(req: Request<{hookId: string}, unknown, unknown, unknown>, res: Response<{ok: true}|{ok: false, error: string}>, next: NextFunction) {
+        if (!['PUT', 'GET', 'POST'].includes(req.method)) {
+            throw new ApiError("Wrong METHOD. Expecting PUT, GET or POST", ErrCode.MethodNotAllowed);
+        }
+    
+        let body;
+        if (req.method === 'GET') {
+            body = req.query;
+        } else {
+            body = req.body;
+        }
+    
+        this.queue.pushWait<GenericWebhookEvent, GenericWebhookEventResult>({
+            eventName: 'generic-webhook.event',
+            sender: "GithubWebhooks",
+            data: {
+                hookData: body,
+                hookId: req.params.hookId,
+            },
+        }, WEBHOOK_RESPONSE_TIMEOUT).then((response) => {
+            if (response.notFound) {
+                if (this.deprecatedPath) {
+                    // If the webhook wasn't found and we're on a deprecated path, ignore it.
+                    next();
+                    return;
+                }
+                res.status(404).send({ok: false, error: "Webhook not found"});
+            } else if (response.successful) {
+                res.status(200).send({ok: true});
+            } else if (response.successful === false) {
+                res.status(500).send({ok: false, error: "Failed to process webhook"});
+            } else {
+                res.status(202).send({ok: true});
+            }
+        }).catch((err) => {
+            log.error(`Failed to emit payload: ${err}`);
+            res.status(500).send({ok: false, error: "Failed to handle webhook"});
+        });
+    }
+
+    public getRouter() {
+        const router = Router();
+        router.all(
+            '/:hookId',
+            express.text({ type: 'text/*'}),
+            express.urlencoded({ extended: false }),
+            express.json(),
+            this.onWebhook.bind(this),
+        );
+        return router;
+    }
+}

--- a/src/generic/types.ts
+++ b/src/generic/types.ts
@@ -1,0 +1,9 @@
+export interface GenericWebhookEvent {
+    hookData: unknown;
+    hookId: string;
+}
+
+export interface GenericWebhookEventResult {
+    successful?: boolean|null;
+    notFound?: boolean;
+}

--- a/src/provisioning/api.ts
+++ b/src/provisioning/api.ts
@@ -59,6 +59,10 @@ export enum ErrCode {
      * A connection with similar configuration exists
      */
     ConflictingConnection =  "HS_CONFLICTING_CONNECTION",
+    /**
+     * The method used was invalid for this endpoint
+     */
+    MethodNotAllowed = "HS_METHOD_NOT_ALLOWED",
 }
 
 const ErrCodeToStatusCode: Record<ErrCode, number> = {
@@ -73,6 +77,7 @@ const ErrCodeToStatusCode: Record<ErrCode, number> = {
     HS_DISABLED_FEATURE: 500,
     HS_ADDITIONAL_ACTION_REQUIRED: 400,
     HS_CONFLICTING_CONNECTION: 409,
+    HS_METHOD_NOT_ALLOWED: 405,
 }
 
 export class ApiError extends Error {


### PR DESCRIPTION
The generic webhooks router currently listens on `/:hookId/` which means that while the request paths are short, it causes confusion when a user misconfigures their bridge and gets a 200 response regardless. This PR makes the bridge *prefer* `/webhook`, while still supporting `/:hookId`. 

In addition, the bridge now gives an appropriate 404 from both paths when a hookId is not found. The bridge *can* also be configured to wait until the webhook has finished processing before responding, although this behavior is off by default.