### PR TITLE
Drop support for Node 12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [12, 14, 16]
+        node_version: [14, 16]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node_version }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-hookshot"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 
 [lib]

--- a/changelog.d/228.removal
+++ b/changelog.d/228.removal
@@ -1,0 +1,1 @@
+Drop support for Node.JS 12. Administrators are advised to upgrade to at least Node.JS 14.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -11,7 +11,7 @@ may increase depending on the traffic and the number of rooms bridged.
 
 ## Local installation 
 
-This bridge requires at least Node 12 (though 16 is preferred), and Rust installed.
+This bridge requires at least Node 14 (though 16 is preferred), and Rust installed.
 
 To install Node.JS, [nvm](https://github.com/nvm-sh/nvm) is a good option.
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "name": "matrix-hookshot-rs"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "scripts": {
     "build:web": "snowpack build",
@@ -74,7 +74,7 @@
     "@types/micromatch": "^4.0.1",
     "@types/mime": "^2.0.3",
     "@types/mocha": "^9.0.0",
-    "@types/node": "^12",
+    "@types/node": "^14",
     "@types/node-emoji": "^1.8.1",
     "@types/uuid": "^8.3.3",
     "@typescript-eslint/eslint-plugin": "^5.4.0",

--- a/src/UserTokenStore.ts
+++ b/src/UserTokenStore.ts
@@ -4,7 +4,7 @@ import { Intent } from "matrix-bot-sdk";
 import { promises as fs } from "fs";
 import { publicEncrypt, privateDecrypt } from "crypto";
 import LogWrapper from "./LogWrapper";
-import { CLOUD_INSTANCE, CLOUD_INSTANCE as JIRA_CLOUD_INSTANCE, isJiraCloudInstance, JiraClient } from "./Jira/Client";
+import { CLOUD_INSTANCE, isJiraCloudInstance, JiraClient } from "./Jira/Client";
 import { JiraStoredToken } from "./Jira/Types";
 import { BridgeConfig, BridgeConfigJiraOnPremOAuth, BridgePermissionLevel } from "./Config/Config";
 import { v4 as uuid } from "uuid";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,10 @@
 {
+  "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
     "incremental": true,
-    "target": "ES2019",
-    "module": "commonjs",
     "declaration": false,
     "outDir": "./lib",
     "rootDir": "./src",
-    "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -940,10 +940,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.2.tgz#a4c07d47ff737e8ee7e586fe636ff0e1ddff070a"
   integrity sha512-JepeIUPFDARgIs0zD/SKPgFsJEAF0X5/qO80llx59gOxFTboS9Amv3S+QfB7lqBId5sFXJ99BN0J6zFRvL9dDA==
 
-"@types/node@^12":
-  version "12.20.38"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.38.tgz#74801983c0558a7a31a4ead18bce2edded2b0e2f"
-  integrity sha512-NxmtBRGipjx1B225OeMdI+CQmLbYqvvmYbukDTJGDgzIDgPQ1EcjGmYxGhOk5hTBqeB558S6RgHSpq2iiqifAQ==
+"@types/node@^14":
+  version "14.18.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.12.tgz#0d4557fd3b94497d793efd4e7d92df2f83b4ef24"
+  integrity sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
Node 12 becomes EOL in April https://nodejs.org/en/about/releases/