### PR TITLE
Allow uppercase log levels

### DIFF
--- a/changelog.d/250.misc
+++ b/changelog.d/250.misc
@@ -1,0 +1,1 @@
+Uppercase values for `logging.level` are now allowed, although lowercase values are preferred.

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -312,6 +312,8 @@ export class BridgeConfig {
         this.logging = configData.logging || {
             level: "info",
         }
+        // To allow DEBUG as well as debug
+        this.logging.level = this.logging.level.toLowerCase();
         this.permissions = configData.permissions || [{
             actor: this.bridge.domain,
             services: [{

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -16,7 +16,7 @@ export const ValidLogLevelStrings = [
     LogLevel.INFO.toString(),
     LogLevel.DEBUG.toString(),
     LogLevel.TRACE.toString(),
-];
+].map(l => l.toLowerCase());
 
 // Maps to permission_level_to_int in permissions.rs
 export enum BridgePermissionLevel {

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -1,6 +1,6 @@
 import YAML from "yaml";
 import { promises as fs } from "fs";
-import { IAppserviceRegistration, MatrixClient } from "matrix-bot-sdk";
+import { IAppserviceRegistration, LogLevel, MatrixClient } from "matrix-bot-sdk";
 import * as assert from "assert";
 import { configKey, hideKey } from "./Decorators";
 import { BridgeConfigListener, ResourceTypeArray } from "../ListenerService";
@@ -9,6 +9,14 @@ import { BridgeConfigActorPermission, BridgePermissions } from "../libRs";
 import LogWrapper from "../LogWrapper";
 
 const log = new LogWrapper("Config");
+
+export const ValidLogLevelStrings = [
+    LogLevel.ERROR.toString(),
+    LogLevel.WARN.toString(),
+    LogLevel.INFO.toString(),
+    LogLevel.DEBUG.toString(),
+    LogLevel.TRACE.toString(),
+];
 
 // Maps to permission_level_to_int in permissions.rs
 export enum BridgePermissionLevel {
@@ -309,11 +317,16 @@ export class BridgeConfig {
         this.queue = configData.queue || {
             monolithic: true,
         };
+
         this.logging = configData.logging || {
             level: "info",
         }
         // To allow DEBUG as well as debug
         this.logging.level = this.logging.level.toLowerCase();
+        if (!ValidLogLevelStrings.includes(this.logging.level)) {
+            throw Error(`'logging.level' is not valid. Must be one of ${ValidLogLevelStrings.join(', ')}`)
+        }
+
         this.permissions = configData.permissions || [{
             actor: this.bridge.domain,
             services: [{


### PR DESCRIPTION
Even though they aren't strictly valid, it seems to be a common mistake that people will use `DEBUG` instead of `debug`. To make life easier, let's put it through `toLowerCase`. For extra points, the Config now validates the log level.