### PR TITLE
Remove connections from a room when the bot leaves

### DIFF
--- a/changelog.d/257.bugfix
+++ b/changelog.d/257.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where the bridge bot would rejoin a room after being removed.

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -180,6 +180,10 @@ export class Bridge {
             return this.onRoomEvent(roomId, event);
         });
 
+        this.as.on("room.leave", async (roomId, event) => {
+            return this.onRoomLeave(roomId, event);
+        });
+
         this.as.on("room.join", async (roomId, event) => {
             return this.onRoomJoin(roomId, event);
         });
@@ -669,6 +673,20 @@ export class Bridge {
         }
     }
 
+
+    private async onRoomLeave(roomId: string, event: MatrixEvent<MatrixMemberContent>) {
+        if (event.state_key !== this.as.botUserId) {
+            // Only interested in bot leaves.
+            return;
+        }
+        // If the bot has left the room, we want to vape all connections for that room.
+        try {
+            await this.connectionManager?.removeConnectionsForRoom(roomId);
+        } catch (ex) {
+            log.warn(`Failed to remove connections on leave for ${roomId}`);
+        }
+    }
+
     private async onRoomMessage(roomId: string, event: MatrixEvent<MatrixMessageContent>) {
         if (!this.connectionManager) {
             // Not ready yet.
@@ -787,7 +805,7 @@ export class Bridge {
             for (const connection of existingConnections) {
                 try {
                     if (event.content.disabled === true) {
-                        await this.connectionManager.removeConnection(connection.roomId, connection.connectionId);
+                        await this.connectionManager.purgeConnection(connection.roomId, connection.connectionId);
                     } else {
                         connection.onStateUpdate?.(event);
                     }

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -387,8 +387,8 @@ export class ConnectionManager {
         return this.connections.find((c) => c.connectionId === connectionId && c.roomId === roomId);
     }
 
-    public async removeConnection(roomId: string, connectionId: string) {
-        const connection = this.connections.find((c) => c.connectionId === connectionId && c.roomId);
+    public async purgeConnection(roomId: string, connectionId: string) {
+        const connection = this.connections.find((c) => c.connectionId === connectionId && c.roomId == roomId);
         if (!connection) {
             throw Error("Connection not found");
         }
@@ -402,6 +402,16 @@ export class ConnectionManager {
             log.info(`No more connections in ${roomId}, leaving room`);
             await this.as.botIntent.leaveRoom(roomId);
         }
+    }
+
+    /**
+     * Removes connections for a room from memory. This does NOT remove the state
+     * event from the room.
+     * @param roomId 
+     */
+    public async removeConnectionsForRoom(roomId: string) {
+        log.info(`Removing all connections from ${roomId}`);
+        this.connections = this.connections.filter((c) => c.roomId !== roomId);
     }
 
     public registerProvisioningConnection(connType: {getProvisionerDetails: (botUserId: string) => GetConnectionTypeResponseItem}) {

--- a/src/provisioning/provisioner.ts
+++ b/src/provisioning/provisioner.ts
@@ -235,7 +235,7 @@ export class Provisioner {
             if (!connection.onRemove) {
                 return next(new ApiError("Connection does not support removal", ErrCode.UnsupportedOperation));
             }
-            await this.connMan.removeConnection(req.params.roomId, req.params.connectionId);
+            await this.connMan.purgeConnection(req.params.roomId, req.params.connectionId);
             res.send({ok: true});
         } catch (ex) {
             return next(ex);


### PR DESCRIPTION
Fixes #255 

This doesn't purge the state events (that needs to be done with a more forceful action like a command), but crucially when the bot parts the room, all the connections in that room stop working so the bot doesn't try to rejoin and carry on.