### PR TITLE
Support versioning docs

### DIFF
--- a/.github/workflows/docs-latest.yml
+++ b/.github/workflows/docs-latest.yml
@@ -24,4 +24,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           keep_files: true
           publish_dir: ./book
-          destination_dir: ./
+          destination_dir: ./latest

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -1,0 +1,32 @@
+name: Build docs
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get release tag
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: '0.4.11'
+
+      - name: Set version of docs
+        run: echo 'window.HOOKSHOT_VERSION = "${{ env.RELEASE_VERSION }}";' > ./docs/_site/version.js
+
+      - run: mdbook build
+
+      - name: Deploy latest
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          keep_files: true
+          publish_dir: ./book
+          destination_dir: ./${{ env.RELEASE_VERSION }}

--- a/book.toml
+++ b/book.toml
@@ -22,3 +22,8 @@ git-repository-url = "https://github.com/matrix-org/matrix-hookshot"
 additional-css = [
     "docs/_site/style.css"
 ]
+
+additional-js = [
+    "docs/_site/main.js",
+    "docs/_site/version.js"
+]

--- a/changelog.d/258.feature
+++ b/changelog.d/258.feature
@@ -1,1 +1,0 @@
-Hosted documentation now features a version selector.

--- a/changelog.d/258.feature
+++ b/changelog.d/258.feature
@@ -1,0 +1,1 @@
+Hosted documentation now features a version selector.

--- a/docs/_site/main.js
+++ b/docs/_site/main.js
@@ -1,0 +1,36 @@
+window.addEventListener("load", () => {
+    const scrollbox = document.querySelector(".sidebar-scrollbox");
+    scrollbox.innerHTML = `<div class="version-box"><span>Version: </span></div>${scrollbox.innerHTML}`;
+    const currentVersion = window.HOOKSHOT_VERSION || 'latest';
+
+    const selectElement = document.createElement("select");
+    
+    fetch("https://api.github.com/repos/matrix-org/matrix-hookshot/releases", {
+        cache: "force-cache",
+    }).then(res => 
+        res.json()
+    ).then(releases => {
+        selectElement.innerHTML = "";
+        for (const version of ['latest', ...releases.map(r => r.tag_name).filter(s => s !== "0.1.0")]) {
+            const option = document.createElement("option");
+            option.innerHTML = version;
+            selectElement.add(option);
+            if (currentVersion === version) {
+                option.setAttribute('selected', '');
+            }
+        }
+    }).catch(ex => {
+        console.error("Failed to fetch version data", ex);
+    })
+    
+    const option = document.createElement("option");
+    option.innerHTML = 'loading...';
+    selectElement.add(option);
+
+    selectElement.addEventListener('change', (event) => {
+        const versionlessPath = window.location.pathname.split('/').slice(2).join('/');
+        window.location = `${window.location.origin}/${event.target.value}/${versionlessPath}`;
+    });
+
+    document.querySelector(".version-box").appendChild(selectElement);
+});

--- a/docs/_site/version.js
+++ b/docs/_site/version.js
@@ -1,0 +1,2 @@
+// This is modified by the build script
+window.HOOKSHOT_VERSION = "latest";


### PR DESCRIPTION
Fixes #231 

This PR changes our CI to compile seperate `/latest` and `/X.Y.Z` documentation sets. This also adds a version selector to the documentation page.

![image](https://user-images.githubusercontent.com/2072976/160812237-c0384fcc-f785-442f-8815-82615b177290.png)
