### PR TITLE
Send webhook URLs to the admin room

### DIFF
--- a/changelog.d/265.feature
+++ b/changelog.d/265.feature
@@ -1,0 +1,1 @@
+Webhooks created via `!hookshot webhook` now have their secret URLs sent to the admin room with the user, rather than posted in the bridged room.

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -12,6 +12,7 @@ import { BridgeConfig, BridgePermissionLevel } from "../Config/Config";
 import markdown from "markdown-it";
 import { FigmaFileConnection } from "./FigmaFileConnection";
 import { URL } from "url";
+import { AdminRoom } from "../AdminRoom";
 const md = new markdown();
 
 /**
@@ -27,6 +28,7 @@ export class SetupConnection extends CommandConnection {
         private readonly as: Appservice,
         private readonly tokenStore: UserTokenStore,
         private readonly config: BridgeConfig,
+        private readonly getOrCreateAdminRoom: (userId: string) => Promise<AdminRoom>,
         private readonly githubInstance?: GithubInstance,) {
             super(
                 roomId,
@@ -118,7 +120,9 @@ export class SetupConnection extends CommandConnection {
         const url = `${this.config.generic.urlPrefix}${this.config.generic.urlPrefix.endsWith('/') ? '' : '/'}${hookId}`;
         await GenericHookConnection.ensureRoomAccountData(this.roomId, this.as, hookId, name);
         await this.as.botClient.sendStateEvent(this.roomId, GenericHookConnection.CanonicalEventType, name, {hookId, name});
-        return this.as.botClient.sendHtmlNotice(this.roomId, md.renderInline(`Room configured to bridge webhooks. Please configure your webhook source to use \`${url}\``));
+        const adminRoom = await this.getOrCreateAdminRoom(userId);
+        await adminRoom.sendNotice(`You have bridged a webhook. Please configure your webhook source to use \`${url}\``);
+        return this.as.botClient.sendHtmlNotice(this.roomId, md.renderInline(`Room configured to bridge webhooks. See admin room for secret url.`));
     }
 
     @botCommand("figma file", "Bridge a Figma file to the room", ["url"], [], true)


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-hookshot/issues/161

This simply posts the webhook url to the admin room of the user (creating one if necessary)