### PR TITLE
Only set Content-Type if we send a body

### DIFF
--- a/changelog.d/272.bugfix
+++ b/changelog.d/272.bugfix
@@ -1,1 +1,1 @@
-Bridge API: Don't sent HTTP header Content-Type: application/json when there is no body
+Bridge API: Don't sent HTTP header Content-Type: application/json when there is no body.

--- a/changelog.d/272.bugfix
+++ b/changelog.d/272.bugfix
@@ -1,0 +1,1 @@
+Bridge API: Don't sent HTTP header Content-Type: application/json when there is no body

--- a/web/BridgeAPI.ts
+++ b/web/BridgeAPI.ts
@@ -17,8 +17,11 @@ export default class BridgeAPI {
             method,
             body: body ? JSON.stringify(body) : undefined,
             headers: {
-                'Content-Type': 'application/json',
                 'Authorization': `Bearer ${this.accessToken}`,
+                // Only set Content-Type if we send a body
+                ...(!!body && {
+                    'Content-Type': 'application/json',
+                }),
             },
         });
         if (req.status === 204) {


### PR DESCRIPTION
Only set "Content-Type" if we are sending a JSON body.

`undefined` (or empty string) aren't valid JSON, so it might make naïve web servers fail. 