### PR TITLE
Generic webhook transform: allow specifying msgtype

### DIFF
--- a/changelog.d/282.feature
+++ b/changelog.d/282.feature
@@ -1,0 +1,1 @@
+Allow specifying msgtype for generic webhook transformations.

--- a/docs/setup/webhooks.md
+++ b/docs/setup/webhooks.md
@@ -109,6 +109,7 @@ The `v2` api expects an object to be returned from the `result` variable.
   "empty": true|false, // Should the webhook be ignored and no output returned. The default is false (plain must be provided).
   "plain": "Some text", // The plaintext value to be used for the Matrix message.
   "html": "<b>Some</b> text", // The HTML value to be used for the Matrix message. If not provided, plain will be interpreted as markdown.
+  "msgtype": "some.type", // The message type, such as m.notice or m.text, to be used for the Matrix message. If not provided, m.notice will be used.
 }
 ```
 


### PR DESCRIPTION
So we can send noisy m.text notifications.

Addresses the jstransform part of https://github.com/matrix-org/matrix-hookshot/issues/179.

Signed-off-by: Tobias Büttner <dev@spiritcroc.de>