### PR TITLE
Priority ordering for connections

### DIFF
--- a/changelog.d/293.feature
+++ b/changelog.d/293.feature
@@ -1,0 +1,1 @@
+Allow priority ordering of connections by setting a `priorty: number` key in the state event content.

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -773,6 +773,9 @@ export class Bridge {
                 } catch (ex) {
                     log.warn(`Connection ${connection.toString()} failed to handle message:`, ex);
                 }
+                if (handled) {
+                    return;
+                }
             }
             if (!handled && this.config.checkPermissionAny(event.sender, BridgePermissionLevel.manageConnections)) {
                 // Divert to the setup room code if we didn't match any of these

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -378,7 +378,7 @@ export class ConnectionManager {
     }
 
     public getAllConnectionsForRoom(roomId: string): IConnection[] {
-        return this.connections.filter(c => c.roomId === roomId);
+        return this.connections.filter(c => c.roomId === roomId).sort((a,b) => b.priority - a.priority);
     }
 
     public getInterestedForRoomState(roomId: string, eventType: string, stateKey: string): IConnection[] {

--- a/src/Connections/BaseConnection.ts
+++ b/src/Connections/BaseConnection.ts
@@ -14,4 +14,8 @@ export abstract class BaseConnection {
     public get connectionId(): string {
         return FormatUtil.hashId(`${this.roomId}/${this.canonicalStateType}/${this.stateKey}`);
     }
+
+    public get priority(): number {
+        return -1;
+    }
 }

--- a/src/Connections/FigmaFileConnection.ts
+++ b/src/Connections/FigmaFileConnection.ts
@@ -2,14 +2,14 @@ import { Appservice, MatrixClient } from "matrix-bot-sdk";
 import markdownit from "markdown-it";
 import { FigmaPayload } from "../figma/types";
 import { BaseConnection } from "./BaseConnection";
-import { IConnection } from ".";
+import { IConnection, IConnectionState } from ".";
 import LogWrapper from "../LogWrapper";
 import { IBridgeStorageProvider } from "../Stores/StorageProvider";
 import { BridgeConfigFigma } from "../Config/Config";
 
 const log = new LogWrapper("FigmaFileConnection");
 
-export interface FigmaFileConnectionState {
+export interface FigmaFileConnectionState extends IConnectionState {
     fileId?: string;
     instanceName?: string;
 }
@@ -53,6 +53,10 @@ export class FigmaFileConnection extends BaseConnection implements IConnection {
 
     public get instanceName() {
         return this.state.instanceName;
+    }
+
+    public get priority(): number {
+        return this.state.priority || super.priority;
     }
 
     public async handleNewComment(payload: FigmaPayload) {

--- a/src/Connections/GenericHook.ts
+++ b/src/Connections/GenericHook.ts
@@ -1,4 +1,4 @@
-import { IConnection } from "./IConnection";
+import { IConnection, IConnectionState } from "./IConnection";
 import LogWrapper from "../LogWrapper";
 import { MessageSenderClient } from "../MatrixSender"
 import markdownit from "markdown-it";
@@ -10,7 +10,7 @@ import { ApiError, ErrCode } from "../api";
 import { BaseConnection } from "./BaseConnection";
 import { GetConnectionsResponseItem } from "../provisioning/api";
 import { BridgeConfigGenericWebhooks } from "../Config/Config";
-export interface GenericHookConnectionState {
+export interface GenericHookConnectionState extends IConnectionState {
     /**
      * This is ONLY used for display purposes, but the account data value is used to prevent misuse.
      */
@@ -137,6 +137,10 @@ export class GenericHookConnection extends BaseConnection implements IConnection
             if (state.transformationFunction && config.allowJsTransformationFunctions) {
                 this.transformationFunction = new Script(state.transformationFunction);
             }
+        }
+
+        public get priority(): number {
+            return this.state.priority || super.priority;
         }
 
 

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -3,7 +3,7 @@ import { Appservice, IRichReplyMetadata } from "matrix-bot-sdk";
 import { BotCommands, botCommand, compileBotCommands } from "../BotCommands";
 import { CommentProcessor } from "../CommentProcessor";
 import { FormatUtil } from "../FormatUtil";
-import { IConnection } from "./IConnection";
+import { IConnection, IConnectionState } from "./IConnection";
 import { IssuesOpenedEvent, IssuesReopenedEvent, IssuesEditedEvent, PullRequestOpenedEvent, IssuesClosedEvent, PullRequestClosedEvent, PullRequestReadyForReviewEvent, PullRequestReviewSubmittedEvent, ReleaseCreatedEvent, IssuesLabeledEvent, IssuesUnlabeledEvent } from "@octokit/webhooks-types";
 import { MatrixMessageContent, MatrixEvent, MatrixReactionContent } from "../MatrixEvent";
 import { MessageSenderClient } from "../MatrixSender";
@@ -32,7 +32,7 @@ interface IQueryRoomOpts {
     githubInstance: GithubInstance;
 }
 
-export interface GitHubRepoConnectionOptions {
+export interface GitHubRepoConnectionOptions extends IConnectionState {
     ignoreHooks?: AllowedEventsNames[],
     commandPrefix?: string;
     showIssueRoomLink?: boolean;
@@ -49,7 +49,7 @@ export interface GitHubRepoConnectionOptions {
         labels: string[];
     };
 }
-export interface GitHubRepoConnectionState extends GitHubRepoConnectionOptions{
+export interface GitHubRepoConnectionState extends GitHubRepoConnectionOptions {
     org: string;
     repo: string;
 }
@@ -320,6 +320,10 @@ export class GitHubRepoConnection extends CommandConnection implements IConnecti
 
     public get repo() {
         return this.state.repo.toLowerCase();
+    }
+
+    public get priority(): number {
+        return this.state.priority || super.priority;
     }
 
     public async onStateUpdate(stateEv: MatrixEvent<unknown>) {

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -9,8 +9,9 @@ import LogWrapper from "../LogWrapper";
 import { GitLabInstance } from "../Config/Config";
 import { IGitLabWebhookMREvent, IGitLabWebhookReleaseEvent, IGitLabWebhookTagPushEvent, IGitLabWebhookWikiPageEvent } from "../Gitlab/WebhookTypes";
 import { CommandConnection } from "./CommandConnection";
+import { IConnectionState } from "./IConnection";
 
-export interface GitLabRepoConnectionState {
+export interface GitLabRepoConnectionState extends IConnectionState {
     instance: string;
     path: string;
     ignoreHooks?: string[],
@@ -61,6 +62,10 @@ export class GitLabRepoConnection extends CommandConnection {
 
     public get path() {
         return this.state.path?.toString();
+    }
+
+    public get priority(): number {
+        return this.state.priority || super.priority;
     }
 
     public async onStateUpdate(stateEv: MatrixEvent<unknown>) {

--- a/src/Connections/IConnection.ts
+++ b/src/Connections/IConnection.ts
@@ -5,11 +5,18 @@ import { IRichReplyMetadata } from "matrix-bot-sdk";
 import { BridgePermissionLevel } from "../Config/Config";
 
 export type PermissionCheckFn = (service: string, level: BridgePermissionLevel) => boolean;
+
+export interface IConnectionState {
+    priority?: number;
+}
+
 export interface IConnection {
     /**
      * The roomId that this connection serves.
      */
     roomId: string;
+
+    priority: number;
 
     /**
      * The unique connection ID. This is a opaque hash of the roomId, connection type and state key.


### PR DESCRIPTION
Fixes #291 

This PR allows connections to specify the priority in the command handling system, so that connections with a higher priority are handled first. This allows you to set a default connection in a room when you have multiple connection types.