### PR TITLE
Fail to start when widgets are configured without a listener

### DIFF
--- a/changelog.d/298.misc
+++ b/changelog.d/298.misc
@@ -1,0 +1,1 @@
+Fail to start when widgets are configured but no "widgets" listener is configured.

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -155,4 +155,8 @@ listeners:
     resources:
       - metrics
       - provisioning
+  - port: 9002
+    bindAddress: 0.0.0.0
+    resources:
+      - widgets
 

--- a/docs/advanced/widgets.md
+++ b/docs/advanced/widgets.md
@@ -60,6 +60,17 @@ Unless you know what you are doing, it is recommended to not include this key. T
 `branding` allows you to change the strings used for various bits of widget UI. At the moment you can:
  - Set `widgetTitle` to change the title of the widget that is created.
 
+In addition to setting up the widgets config, you must bind a listener for the widgets resource in your `listeners` config.
+
+```yaml
+listeners:
+  - port: 5069
+    bindAddress: 0.0.0.0
+    resources:
+      - widgets
+```
+
+See the [setup page](../setup#listeners-configuration) for more information on listeners.
 
 ### API
 

--- a/src/Config/Defaults.ts
+++ b/src/Config/Defaults.ts
@@ -120,6 +120,11 @@ export const DefaultConfig = new BridgeConfig({
             port: 9001,
             bindAddress: '127.0.0.1',
             resources: ['metrics', 'provisioning'],
+        },
+        {
+            port: 9002,
+            bindAddress: '0.0.0.0',
+            resources: ['widgets'],
         }
     ]
 }, {});

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -9,3 +9,9 @@ export class NotLoggedInError extends CommandError {
         super("User is not logged in", "You are not logged in");
     }
 }
+
+export class ConfigError extends Error {
+    constructor(public readonly configPath: string, public readonly msg?: string) {
+        super(`There was an error in the config (${configPath}): ${msg}`);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-hookshot/issues/288

This also:
- Causes the config validator to fail
- Improves the documentation by adding a note about listeners
- Converts existing config errors into `ConfigError` which helps with formatting.