### PR TITLE
Fix GitHub and GitLab ghost user intent creation

### DIFF
--- a/changelog.d/303.bugfix
+++ b/changelog.d/303.bugfix
@@ -1,0 +1,1 @@
+Fix GitHub / GitLab issue rooms breaking due to being unable to generate ghost users.

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -32,6 +32,10 @@ github:
     showIssueRoomLink: false
     hotlinkIssues:
       prefix: "#"
+  userIdPrefix:
+    # (Optional) Prefix used when creating ghost users for GitHub accounts.
+    #
+    _github_
 gitlab:
   # (Optional) Configure this to enable GitLab support
   #
@@ -40,6 +44,10 @@ gitlab:
       url: https://gitlab.com
   webhook:
     secret: secrettoken
+  userIdPrefix:
+    # (Optional) Prefix used when creating ghost users for GitLab accounts.
+    #
+    _gitlab_
 figma:
   # (Optional) Configure this to enable Figma support
   #

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -417,7 +417,7 @@ export class Bridge {
         );
 
         this.queue.on<GitHubWebhookTypes.DiscussionCreatedEvent>("github.discussion.created", async ({data}) => {
-            if (!this.github) {
+            if (!this.github || !this.config.github) {
                 return;
             }
             const spaces = connManager.getConnectionsForGithubRepoDiscussion(data.repository.owner.login, data.repository.name);
@@ -439,6 +439,7 @@ export class Bridge {
                         this.tokenStore,
                         this.commentProcessor,
                         this.messageClient,
+                        this.config.github,
                     );
                     connManager.push(discussionConnection);
                 } catch (ex) {
@@ -1093,6 +1094,9 @@ export class Bridge {
             }
         });
         adminRoom.on("open.gitlab-issue", async (issueInfo: GetIssueOpts, res: GetIssueResponse, instanceName: string, instance: GitLabInstance) => {
+            if (!this.config.gitlab) {
+                return;
+            }
             const [ connection ] = this.connectionManager?.getConnectionsForGitLabIssue(instance, issueInfo.projects, issueInfo.issue) || [];
             if (connection) {
                 return this.as.botClient.inviteUser(adminRoom.userId, connection.roomId);
@@ -1105,7 +1109,8 @@ export class Bridge {
                 this.as,
                 this.tokenStore, 
                 this.commentProcessor,
-                this.messageClient
+                this.messageClient,
+                this.config.gitlab,
             );
             this.connectionManager?.push(newConnection);
             return this.as.botClient.inviteUser(adminRoom.userId, newConnection.roomId);

--- a/src/Config/Defaults.ts
+++ b/src/Config/Defaults.ts
@@ -65,7 +65,8 @@ export const DefaultConfig = new BridgeConfig({
             hotlinkIssues: {
                 prefix: "#"
             }
-        }
+        },
+        userIdPrefix: "_github_",
     },
     gitlab: {
         instances: {
@@ -75,7 +76,8 @@ export const DefaultConfig = new BridgeConfig({
         },
         webhook: {
             secret: "secrettoken",
-        }
+        },
+        userIdPrefix: "_gitlab_",
     },
     jira: {
         webhook: {

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -149,13 +149,13 @@ export class ConnectionManager {
         }
 
         if (GitHubDiscussionConnection.EventTypes.includes(state.type)) {
-            if (!this.github) {
+            if (!this.github || !this.config.github) {
                 throw Error('GitHub is not configured');
             }
             this.assertStateAllowed(state, "github");
             return new GitHubDiscussionConnection(
                 roomId, this.as, state.content, state.stateKey, this.tokenStore, this.commentProcessor,
-                this.messageClient,
+                this.messageClient, this.config.github,
             );
         }
     
@@ -171,12 +171,15 @@ export class ConnectionManager {
         }
 
         if (GitHubIssueConnection.EventTypes.includes(state.type)) {
-            if (!this.github) {
+            if (!this.github || !this.config.github) {
                 throw Error('GitHub is not configured');
             }
             
             this.assertStateAllowed(state, "github");
-            const issue = new GitHubIssueConnection(roomId, this.as, state.content, state.stateKey || "", this.tokenStore, this.commentProcessor, this.messageClient, this.github);
+            const issue = new GitHubIssueConnection(
+                roomId, this.as, state.content, state.stateKey || "", this.tokenStore,
+                this.commentProcessor, this.messageClient, this.github, this.config.github,
+            );
             await issue.syncIssueState();
             return issue;
         }
@@ -206,7 +209,7 @@ export class ConnectionManager {
         }
 
         if (GitLabIssueConnection.EventTypes.includes(state.type)) {
-            if (!this.config.gitlab) {
+            if (!this.github || !this.config.gitlab) {
                 throw Error('GitLab is not configured');
             }
             this.assertStateAllowed(state, "gitlab");
@@ -219,7 +222,9 @@ export class ConnectionManager {
                 this.tokenStore,
                 this.commentProcessor,
                 this.messageClient,
-                instance);
+                instance,
+                this.config.gitlab,
+            );
         }
 
         if (JiraProjectConnection.EventTypes.includes(state.type)) {

--- a/src/IntentUtils.ts
+++ b/src/IntentUtils.ts
@@ -4,8 +4,9 @@ import axios from "axios";
 
 const log = new LogWrapper("IntentUtils");
 
-export async function getIntentForUser(user: {avatarUrl?: string, login: string}, as: Appservice) {
-    const intent = as.getIntentForSuffix(user.login);
+export async function getIntentForUser(user: {avatarUrl?: string, login: string}, as: Appservice, prefix: string) {
+    const domain = as.botUserId.split(":")[1];
+    const intent = as.getIntentForUserId(`@${prefix}${user.login}:${domain}`);
     const displayName = `${user.login}`;
     // Verify up-to-date profile
     let profile;


### PR DESCRIPTION
This has been broken for a while, as we were relying on the bot-sdk's native support for userId generation. However, this is broken because we use have several userId prefixes in use. As a bonus, both GitHub and GitLab prefix's are now configurable.