### PR TITLE
Don't claim unsupported events as supported

### DIFF
--- a/changelog.d/305.doc
+++ b/changelog.d/305.doc
@@ -1,0 +1,1 @@
+List only actually supported events in GitLab docs

--- a/docs/setup/gitlab.md
+++ b/docs/setup/gitlab.md
@@ -30,7 +30,6 @@ You should use the value of `webhook.secret` from your config as your "Secret to
 
 You should add the events you wish to trigger on. Hookshot currently supports:
 
-- Push events
 - Tag events
 - Issues events
 - Merge request events


### PR DESCRIPTION
until #252 is resolved, claiming this as supported is hella confusing (#191). Provided I understand the situation correctly.

I would revise your other points but I don't really understand your event definitions on a whim, so you might update this change with an eye on that.