### PR TITLE
Fix GitHub refresh tokens not refreshing

### DIFF
--- a/changelog.d/307.bugfix
+++ b/changelog.d/307.bugfix
@@ -1,0 +1,2 @@
+Fix GitHub tokens not being refreshed on expiry when using OAuth support.
+Rename the `github hastoken` to `github status`.

--- a/src/Github/GithubInstance.ts
+++ b/src/Github/GithubInstance.ts
@@ -54,7 +54,7 @@ export class GithubInstance {
             refresh_token: refreshToken,
             grant_type: 'refresh_token',
         })}`);
-        return accessTokenRes.data;
+        return qs.decode(accessTokenRes.data) as unknown as GitHubOAuthTokenResponse;
     }
 
     public getSafeOctokitForRepo(orgName: string, repoName?: string) {

--- a/src/UserTokenStore.ts
+++ b/src/UserTokenStore.ts
@@ -155,7 +155,7 @@ export class UserTokenStore {
         if (senderToken.expires_in && senderToken.expires_in < date) {
             log.info(`GitHub access token for ${userId} has expired ${senderToken.expires_in} < ${date}, attempting refresh`);
             if (!this.config.github?.oauth) {
-                throw Error('GitHub oauth not configured, cannot refresh token');
+                throw new TokenError(TokenErrorCode.EXPIRED, "GitHub oauth not configured, cannot refresh token");
             }
             if (senderToken.refresh_token && senderToken.refresh_token_expires_in && senderToken?.refresh_token_expires_in > date) {
                 // Needs a refresh.
@@ -175,7 +175,7 @@ export class UserTokenStore {
                 
             } else {
                 log.error(`GitHub access token for ${userId} has expired, and the refresh token is stale or not given`);
-                throw Error('Token is expired, cannot refresh');
+                throw new TokenError(TokenErrorCode.EXPIRED, `GitHub access token for ${userId} has expired, and the refresh token is stale or not given`);
             }
         }
         return senderToken.access_token;

--- a/src/UserTokenStore.ts
+++ b/src/UserTokenStore.ts
@@ -15,6 +15,7 @@ import { JiraCloudOAuth } from "./Jira/oauth/CloudOAuth";
 import { JiraOnPremOAuth } from "./Jira/oauth/OnPremOAuth";
 import { JiraOnPremClient } from "./Jira/client/OnPremClient";
 import { JiraCloudClient } from "./Jira/client/CloudClient";
+import { TokenError, TokenErrorCode } from "./errors";
 
 const ACCOUNT_DATA_TYPE = "uk.half-shot.matrix-hookshot.github.password-store:";
 const ACCOUNT_DATA_GITLAB_TYPE = "uk.half-shot.matrix-hookshot.gitlab.password-store:";
@@ -164,6 +165,9 @@ export class UserTokenStore {
                     this.config.github?.oauth?.client_id,
                     this.config.github?.oauth?.client_secret,
                 );
+                if (!senderToken.access_token) {
+                    throw Error('Refresh token response had the wrong response format!');
+                }
                 senderToken = {
                     access_token: refreshResult.access_token,
                     expires_in: refreshResult.expires_in && ((parseInt(refreshResult.expires_in) * 1000) + date),
@@ -172,7 +176,6 @@ export class UserTokenStore {
                     refresh_token_expires_in: refreshResult.refresh_token_expires_in && ((parseInt(refreshResult.refresh_token_expires_in) * 1000)  + date),
                 } as GitHubOAuthToken;
                 await this.storeUserToken("github", userId, JSON.stringify(senderToken));
-                
             } else {
                 log.error(`GitHub access token for ${userId} has expired, and the refresh token is stale or not given`);
                 throw new TokenError(TokenErrorCode.EXPIRED, `GitHub access token for ${userId} has expired, and the refresh token is stale or not given`);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -15,3 +15,13 @@ export class ConfigError extends Error {
         super(`There was an error in the config (${configPath}): ${msg}`);
     }
 }
+
+
+export enum TokenErrorCode {
+    EXPIRED = "The token has expired."
+}
+export class TokenError extends Error {
+    constructor(public readonly code: TokenErrorCode, public readonly innerError: string) {
+        super(code);
+    } 
+}


### PR DESCRIPTION
Whenever a token expires, we try to refresh it. Sadly, we didn't check the response format of the refresh request which was turning up as a querystring. This meant that we were inadvertently saving tokens as empty objects, and therefore everyone's token would eventually break.

This also changes the `github hastoken` command into `github status`, which is better as it doesn't presume the type of token you are using.