### PR TITLE
Support notifying on gitlab review comments

### DIFF
--- a/changelog.d/314.feature
+++ b/changelog.d/314.feature
@@ -1,0 +1,1 @@
+Send a notice when a GitLab merge request gets some review comments.

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -399,9 +399,14 @@ export class Bridge {
             } as GitHubOAuthToken));
         });
 
-        this.bindHandlerToQueue<IGitLabWebhookNoteEvent, GitLabIssueConnection>(
+        this.bindHandlerToQueue<IGitLabWebhookNoteEvent, GitLabIssueConnection|GitLabRepoConnection>(
             "gitlab.note.created",
-            (data) => connManager.getConnectionsForGitLabIssueWebhook(data.repository.homepage, data.issue.iid), 
+            (data) => { 
+                const iid = data.issue?.iid || data.merge_request?.iid;
+                return [
+                    ...( iid ? connManager.getConnectionsForGitLabIssueWebhook(data.repository.homepage, iid) : []), 
+                    ...connManager.getConnectionsForGitLabRepo(data.project.path_with_namespace),
+                ]},
             (c, data) => c.onCommentCreated(data),
         );
 

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -870,7 +870,6 @@ ${event.release.body}`;
             format: "org.matrix.custom.html",
         });
     }
-
     public async onEvent(evt: MatrixEvent<unknown>) {
         const octokit = await this.tokenStore.getOctokitForUser(evt.sender);
         if (!octokit) {

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -7,7 +7,7 @@ import { MatrixEvent, MatrixMessageContent } from "../MatrixEvent";
 import markdown from "markdown-it";
 import LogWrapper from "../LogWrapper";
 import { GitLabInstance } from "../Config/Config";
-import { IGitLabWebhookMREvent, IGitLabWebhookPushEvent, IGitLabWebhookReleaseEvent, IGitLabWebhookTagPushEvent, IGitLabWebhookWikiPageEvent } from "../Gitlab/WebhookTypes";
+import { IGitLabNote, IGitLabWebhookMREvent, IGitLabWebhookNoteEvent, IGitLabWebhookPushEvent, IGitLabWebhookReleaseEvent, IGitLabWebhookTagPushEvent, IGitLabWebhookWikiPageEvent } from "../Gitlab/WebhookTypes";
 import { CommandConnection } from "./CommandConnection";
 import { IConnectionState } from "./IConnection";
 
@@ -24,6 +24,8 @@ export interface GitLabRepoConnectionState extends IConnectionState {
 const log = new LogWrapper("GitLabRepoConnection");
 const md = new markdown();
 
+const MRRCOMMENT_DEBOUNCE_MS = 5000;
+
 /**
  * Handles rooms connected to a github repo.
  */
@@ -38,6 +40,8 @@ export class GitLabRepoConnection extends CommandConnection {
     
     static botCommands: BotCommands;
     static helpMessage: (cmdPrefix?: string | undefined) => MatrixMessageContent;
+
+    private readonly debounceMRComments = new Map<string, {comments: number, author: string, timeout: NodeJS.Timeout}>();
 
     constructor(roomId: string,
         stateKey: string,
@@ -291,6 +295,60 @@ ${data.description}`;
             format: "org.matrix.custom.html",
         });
     }
+
+    public async onCommentCreated(event: IGitLabWebhookNoteEvent) {
+        if (this.shouldSkipHook('merge_request.review', 'merge_request.review.comments')) {
+            return;
+        }
+        log.info(`onCommentCreated ${this.roomId} ${this.toString()} ${event.merge_request?.iid} ${event.object_attributes.id}`);
+        const uniqueId = `${event.merge_request?.iid}/${event.object_attributes.author_id}`;
+
+        if (!event.merge_request || event.object_attributes.noteable_type !== "MergeRequest") {
+            // Not a MR comment
+            return;
+        }
+
+        if (event.object_attributes.author_id === event.merge_request.author_id) {
+            // If it's the same author, ignore
+            return;
+        }
+
+        const mergeRequest = event.merge_request;
+
+        const renderFn = () => {
+            const result = this.debounceMRComments.get(uniqueId);
+            if (!result) {
+                // Always defined, but for type checking purposes.
+                return;
+            }
+            const orgRepoName = event.project.path_with_namespace;
+            const comments = result.comments > 1 ? `${result.comments} comments` : '1 comment';
+            const content = `**${result.author}** reviewed MR [${orgRepoName}#${mergeRequest.iid}](${mergeRequest.url}): "${mergeRequest.title}" with ${comments}`;
+            this.as.botIntent.sendEvent(this.roomId, {
+                msgtype: "m.notice",
+                body: content,
+                formatted_body: md.renderInline(content),
+                format: "org.matrix.custom.html",
+            }).catch(ex  => {
+                log.error('Failed to send onCommentCreated message', ex);
+            });
+        };
+
+        const existing = this.debounceMRComments.get(uniqueId);
+        if (existing) {
+            clearTimeout(existing.timeout);
+            existing.comments = existing.comments + 1;
+            existing.timeout = setTimeout(renderFn, MRRCOMMENT_DEBOUNCE_MS);
+        } else {
+            this.debounceMRComments.set(uniqueId, {
+                comments: 1,
+                author: event.user.name,
+                timeout: setTimeout(renderFn, MRRCOMMENT_DEBOUNCE_MS),
+            })
+        }
+
+    }
+
 
     public toString() {
         return `GitLabRepo ${this.instance.url}/${this.path}`;

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -322,7 +322,7 @@ ${data.description}`;
                 return;
             }
             const orgRepoName = event.project.path_with_namespace;
-            const comments = result.comments > 1 ? `${result.comments} comments` : '1 comment';
+            const comments = result.comments !== 1 ? `${result.comments} comments` : '1 comment';
             const content = `**${result.author}** reviewed MR [${orgRepoName}#${mergeRequest.iid}](${mergeRequest.url}): "${mergeRequest.title}" with ${comments}`;
             this.as.botIntent.sendEvent(this.roomId, {
                 msgtype: "m.notice",

--- a/src/Gitlab/WebhookTypes.ts
+++ b/src/Gitlab/WebhookTypes.ts
@@ -169,22 +169,23 @@ export interface IGitLabWebhookReleaseEvent {
     }
 }
 
+export interface IGitLabNote {
+    id: number;
+    note: string;
+    noteable_type: 'MergeRequest';
+    author_id: number;
+    noteable_id: number;
+    description: string;
+}
+
 export interface IGitLabWebhookNoteEvent {
     user: IGitlabUser;
     event_type: string;
     project: IGitlabProject;
-    issue: IGitlabIssue;
-    repository: {
-        name: string;
-        url: string;
-        description: string;
-        homepage: string;
-    };
-    object_attributes: {
-        id: number;
-        noteable_id: number;
-        description: string;
-    }
+    issue?: IGitlabIssue;
+    repository: IGitlabRepository;
+    object_attributes: IGitLabNote;
+    merge_request?: IGitlabMergeRequest;
 }
 export interface IGitLabWebhookIssueStateEvent {
     user: IGitlabUser;


### PR DESCRIPTION
This one was a bit tricky. GitLab doesn't have a notion of "review comments" so we've had to play a bit of a game to make it work like we have on GitHub.

Specifically, we determine a GitLab review by the following:
- Did a note come in for a Merge Request
- Was the note *not* from the original MR author

We also batch together several notes for the same MR into one matrix message if several of them arrive in a short period of time (5s), since GitLab sends the review comments at the same time.

I'm not particularly happy with this approach, but I think it's probably better than not having them.