### PR TITLE
Add a variant of BaseConnection that allows for state-configurable msgtypes

### DIFF
--- a/src/Connections/BaseConnection.ts
+++ b/src/Connections/BaseConnection.ts
@@ -1,4 +1,7 @@
 import { FormatUtil } from "../FormatUtil";
+import { IConnectionState } from ".";
+import { MatrixClient } from "matrix-bot-sdk";
+import { MatrixEvent } from "../MatrixEvent";
 
 /**
  * Base connection class from which all connections should extend from.
@@ -17,5 +20,36 @@ export abstract class BaseConnection {
 
     public get priority(): number {
         return -1;
+    }
+}
+
+export interface ChattyConnectionState extends IConnectionState {
+    msgtype?: string;
+}
+
+export abstract class ChattyConnection extends BaseConnection {
+    private msgtype: string|undefined;
+    constructor(
+        roomId: string,
+        stateKey: string,
+        canonicalStateType: string,
+        chattyState: ChattyConnectionState,
+        private client: MatrixClient,
+    ) {
+        super(roomId, stateKey, canonicalStateType);
+        this.msgtype = chattyState.msgtype;
+    }
+
+    public async onStateUpdate(event: MatrixEvent<unknown>): Promise<void> {
+        if (event.content && typeof event.content === 'object') {
+            this.msgtype = (event.content as any).msgtype;
+        }
+    }
+
+    public async sendMessage(content: any): Promise<string> {
+        return this.client.sendEvent(this.roomId, 'm.room.message', {
+            msgtype: this.msgtype || 'm.notice',
+            ...content
+        });
     }
 }


### PR DESCRIPTION
This is a prototype solution for https://github.com/matrix-org/matrix-hookshot/pull/315#discussion_r855187963.

The name is very much a WIP :) I didn't change BaseConnection itself since it'd be quite invasive and require changes all over the place. I'm not sure about the inheritance solution either – I wish Typescript had [roles](https://docs.raku.org/language/objects#Roles) :)

With this mixed in, an `msgtype` will optionally decide a type of the message sent to the channel, defaulting to m.notice – making it possible to have "loud" webhook/feed notifications without implementing it separately in each service.

CC @HarHarLinks 