### PR TITLE
Allow overriding the results of an openID lookup for widgets for local development.

### DIFF
--- a/changelog.d/326.feature
+++ b/changelog.d/326.feature
@@ -1,0 +1,1 @@
+Add `widgets.openIdOverrides` config option for developers to statically define server name <-> federation endpoints for openId lookups.

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -146,6 +146,10 @@ widgets:
   publicUrl: http://example.com/widgetapi/v1/static
   branding:
     widgetTitle: Hookshot Configuration
+  openIdOverrides:
+    # For testing only: A set of homeserver servernames mapped to their Server-Server API endpoints. This can be used if your local homeserver doesn't lookup via SRV or .well-known.
+    #
+    my-local-server: {}
 permissions:
   # (Optional) Permissions for using the bridge. See docs/setup.md#permissions for help
   #

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -146,10 +146,6 @@ widgets:
   publicUrl: http://example.com/widgetapi/v1/static
   branding:
     widgetTitle: Hookshot Configuration
-  openIdOverrides:
-    # For testing only: A set of homeserver servernames mapped to their Server-Server API endpoints. This can be used if your local homeserver doesn't lookup via SRV or .well-known.
-    #
-    my-local-server: {}
 permissions:
   # (Optional) Permissions for using the bridge. See docs/setup.md#permissions for help
   #

--- a/docs/advanced/widgets.md
+++ b/docs/advanced/widgets.md
@@ -42,6 +42,8 @@ widgets:
   publicUrl: http://example.com/widgetapi/v1/static
   branding:
     widgetTitle: Hookshot Configuration
+#  openIdOverrides:
+#    my-local-server: {}
 ```
 
 The admin room feature is still very barebones so while it's included here for completeness, most instances
@@ -59,6 +61,9 @@ Unless you know what you are doing, it is recommended to not include this key. T
 
 `branding` allows you to change the strings used for various bits of widget UI. At the moment you can:
  - Set `widgetTitle` to change the title of the widget that is created.
+
+`openIdOverrides` allows you to configure the correct federation endpoints for a given set of Matrix server names. This is useful if you are
+testing/developing hookshot in a local dev environment. Production environments should not use this configuration.
 
 In addition to setting up the widgets config, you must bind a listener for the widgets resource in your `listeners` config.
 

--- a/docs/advanced/widgets.md
+++ b/docs/advanced/widgets.md
@@ -42,8 +42,8 @@ widgets:
   publicUrl: http://example.com/widgetapi/v1/static
   branding:
     widgetTitle: Hookshot Configuration
-#  openIdOverrides:
-#    my-local-server: {}
+  openIdOverrides:
+    my-local-server: "http://localhost"
 ```
 
 The admin room feature is still very barebones so while it's included here for completeness, most instances
@@ -63,7 +63,10 @@ Unless you know what you are doing, it is recommended to not include this key. T
  - Set `widgetTitle` to change the title of the widget that is created.
 
 `openIdOverrides` allows you to configure the correct federation endpoints for a given set of Matrix server names. This is useful if you are
-testing/developing hookshot in a local dev environment. Production environments should not use this configuration.
+testing/developing hookshot in a local dev environment. Production environments should not use this configuration (as their Matrix server name
+should be resolvable). The config takes a mapping of Matrix server name => base path for federation.
+E.g. if your server name was `my-local-server` and you federation was readable via http://localhost/_matrix/federation,
+you would put configure `my-local-server: "http://localhost`.
 
 In addition to setting up the widgets config, you must bind a listener for the widgets resource in your `listeners` config.
 

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -270,7 +270,8 @@ export class BridgeWidgetConfig {
     public readonly branding: {
         widgetTitle: string,
     }
-    @configKey("For testing only: A set of homeserver servernames mapped to their Server-Server API endpoints. This can be used if your local homeserver doesn't lookup via SRV or .well-known.")
+
+    @hideKey()
     public readonly openIdOverrides?: Record<string, URL>;
     constructor(yaml: BridgeWidgetConfigYAML) {
         this.addToAdminRooms = yaml.addToAdminRooms || false;

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -257,6 +257,7 @@ interface BridgeWidgetConfigYAML {
     branding?: {
         widgetTitle: string,
     }
+    openIdOverrides?: Record<string, string>;
 }
 
 export class BridgeWidgetConfig {
@@ -269,6 +270,8 @@ export class BridgeWidgetConfig {
     public readonly branding: {
         widgetTitle: string,
     }
+    @configKey("For testing only: A set of homeserver servernames mapped to their Server-Server API endpoints. This can be used if your local homeserver doesn't lookup via SRV or .well-known.")
+    public readonly openIdOverrides?: Record<string, URL>;
     constructor(yaml: BridgeWidgetConfigYAML) {
         this.addToAdminRooms = yaml.addToAdminRooms || false;
         this.disallowedIpRanges = yaml.disallowedIpRanges;
@@ -283,6 +286,12 @@ export class BridgeWidgetConfig {
         this.branding = yaml.branding || {
             widgetTitle: "Hookshot Configuration"
         };
+        if (yaml.openIdOverrides) {
+            this.openIdOverrides = {};
+            for (const [serverName, urlStr] of Object.entries(yaml.openIdOverrides)) {
+                this.openIdOverrides[serverName] = new URL(urlStr);
+            }
+        }
     }
 }
 
@@ -508,6 +517,10 @@ export class BridgeConfig {
         const hasWidgetListener = !!this.listeners.find(l => l.resources.includes('widgets'));
         if (this.widgets && !hasWidgetListener) {
             throw new ConfigError(`listeners`, "You have enabled the widgets feature, but not included a widgets listener.");
+        }
+
+        if (this.widgets && this.widgets.openIdOverrides) {
+            log.warn("The `widgets.openIdOverrides` config value SHOULD NOT be used in a production environment.")
         }
     }
 

--- a/src/Config/Defaults.ts
+++ b/src/Config/Defaults.ts
@@ -42,9 +42,6 @@ export const DefaultConfig = new BridgeConfig({
         branding: {
             widgetTitle: "Hookshot Configuration"
         },
-        openIdOverrides: {
-            "my-local-server": "http://localhost:8008"
-        }
     },
     bot: {
         displayname: "GitHub Bot",

--- a/src/Config/Defaults.ts
+++ b/src/Config/Defaults.ts
@@ -41,6 +41,9 @@ export const DefaultConfig = new BridgeConfig({
         disallowedIpRanges: DefaultDisallowedIpRanges,
         branding: {
             widgetTitle: "Hookshot Configuration"
+        },
+        openIdOverrides: {
+            "my-local-server": "http://localhost:8008"
         }
     },
     bot: {

--- a/src/Widgets/BridgeWidgetApi.ts
+++ b/src/Widgets/BridgeWidgetApi.ts
@@ -30,6 +30,7 @@ export class BridgeWidgetApi {
             expressApp,
             widgetTokenPrefix: "hookshot_",
             disallowedIpRanges: config.widgets?.disallowedIpRanges,
+            openIdOverride: config.widgets?.openIdOverrides,
         });
         this.api.addRoute("get", "/v1/state", this.getRoomState.bind(this));
         this.api.addRoute("get", '/v1/config/sections', this.getConfigSections.bind(this));


### PR DESCRIPTION
This is a config option I'd only expect to be used in dev environments, but it basically allows you to map a server hostname to a federation S-S API path for local dev so you don't need a working federated environment to test changes. It's a bit niche, but I've found it useful.