### PR TITLE
Use node:16-slim for final image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ COPY --from=builder /src/public/ /bin/matrix-hookshot/public/
 COPY --from=builder /src/package.json /bin/matrix-hookshot/
 COPY --from=builder /src/yarn.lock /bin/matrix-hookshot/
 WORKDIR /bin/matrix-hookshot
-RUN yarn --production --pure-lockfile && yarn cache clean
+# --ignore-scripts so we don't try to build
+RUN yarn --ignore-scripts --production --pure-lockfile && yarn cache clean
 
 VOLUME /data
 EXPOSE 9993

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN node node_modules/esbuild/install.js
 RUN yarn build --pure-lockfile
 
 # Stage 1: The actual container
-FROM node:16
+FROM node:16-slim
 
 COPY --from=builder /src/lib/ /bin/matrix-hookshot/
 COPY --from=builder /src/public/ /bin/matrix-hookshot/public/

--- a/changelog.d/336.misc
+++ b/changelog.d/336.misc
@@ -1,0 +1,1 @@
+The docker image has been shrunk by 78%, and now takes up 300MB.


### PR DESCRIPTION
This saves us quuuuite a lot of space on the image. To the tune of 1.37GB -> 300MB