### PR TITLE
Relative path for assets

### DIFF
--- a/changelog.d/340.bugfix
+++ b/changelog.d/340.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where widgets would not load if hosted on a subpath (e.g. `/hookshot` instead of `/`)

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,7 @@ import preact from '@preact/preset-vite'
 export default defineConfig({
   plugins: [preact()],
   root: 'web',
-  base: '/widgetapi/v1/static/',
+  base: '',
   build: {
     outDir: '../public',
     emptyOutDir: true,


### PR DESCRIPTION
Because setting the path as an absolute will break people running things on not-the-default-path