### PR TITLE
Fix issue where GitLab support would break if GitHub wasn't also configured

### DIFF
--- a/changelog.d/362.bugfix
+++ b/changelog.d/362.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue that prevented GitLab repo connections from working if GitHub support is disabled.

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -155,8 +155,8 @@ export class GitLabRepoConnection extends CommandConnection {
         throw new ValidatorApiError(validator.errors);
     }
 
-    static async createConnectionForState(roomId: string, event: StateEvent<Record<string, unknown>>, {as, tokenStore, github, config}: InstantiateConnectionOpts) {
-        if (!github || !config.gitlab) {
+    static async createConnectionForState(roomId: string, event: StateEvent<Record<string, unknown>>, {as, tokenStore, config}: InstantiateConnectionOpts) {
+        if (!config.gitlab) {
             throw Error('GitLab is not configured');
         }
         const state = this.validateState(event.content, true);


### PR DESCRIPTION
Fixes #361 

We don't need to check for `github` when setting up GitLab.