### PR TITLE
Clear transformationFunction when state omits it.

### DIFF
--- a/src/Connections/GenericHook.ts
+++ b/src/Connections/GenericHook.ts
@@ -224,6 +224,8 @@ export class GenericHookConnection extends BaseConnection implements IConnection
             } catch (ex) {
                 await this.messageClient.sendMatrixText(this.roomId, 'Could not compile transformation function:' + ex);
             }
+        } else {
+            this.transformationFunction = undefined;
         }
         this.state = validatedConfig;
     }


### PR DESCRIPTION
Fixes #380 

If a transformation function was applied at some point to a webhook room, we never remove it when the state is updated. This was already fixable by restarting the bridge, but we can easily mark the function undefined.