### PR TITLE
Fix link in AdminRoom

### DIFF
--- a/changelog.d/384.bugfix
+++ b/changelog.d/384.bugfix
@@ -1,0 +1,1 @@
+Fix malformed webhook link in AdminRoom

--- a/changelog.d/384.bugfix
+++ b/changelog.d/384.bugfix
@@ -1,1 +1,1 @@
-Fix malformed webhook link in AdminRoom
+Fix malformed webhook link in AdminRoom.

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -141,7 +141,7 @@ export class SetupConnection extends CommandConnection {
         const c = await GenericHookConnection.provisionConnection(this.roomId, userId, {name}, this.provisionOpts);
         const url = `${this.config.generic.urlPrefix}${this.config.generic.urlPrefix.endsWith('/') ? '' : '/'}${c.connection.hookId}`;
         const adminRoom = await this.getOrCreateAdminRoom(userId);
-        await adminRoom.sendNotice(md.renderInline(`You have bridged a webhook. Please configure your webhook source to use \`${url}\`.`));
+        await adminRoom.sendNotice(`You have bridged a webhook. Please configure your webhook source to use ${url}.`);
         return this.as.botClient.sendNotice(this.roomId, `Room configured to bridge webhooks. See admin room for secret url.`);
     }
 


### PR DESCRIPTION
The link in the AdminRoom is badly represented.
This will fix last part of #378 and #357.
I made this PR separatly from fix #379 cause I do not know if you prefer letting the client create the link (this PR) or force `<code></code>` tag (see https://github.com/psolyca/matrix-hookshot/commit/e1db4b2b140acff35c76c1ce86233be9acbbd72a).

EDIT: I have tested this with 3 different web client and the link is correctly created.

Signed-off-by: Damien Gaignon <damien.gaignon@gmail.com>