### PR TITLE
Automatically reconfigure GitHub notifications when a token is updated.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "matrix-hookshot"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "contrast",
  "hex",

--- a/changelog.d/388.bugfix
+++ b/changelog.d/388.bugfix
@@ -1,0 +1,1 @@
+GitHub admin room notifications will now continue to work if you reauthenticate with GitHub.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "rss-parser": "^3.12.0",
     "source-map-support": "^0.5.21",
     "string-argv": "^0.3.1",
+    "tiny-typed-emitter": "^2.1.0",
     "uuid": "^8.3.2",
     "vm2": "^3.9.6",
     "winston": "^3.3.3",

--- a/src/AdminRoom.ts
+++ b/src/AdminRoom.ts
@@ -60,7 +60,7 @@ export class AdminRoom extends AdminRoomCommandHandler {
         return this.widgetAccessToken === token;
     }
 
-    public notificationsEnabled(type: "github"|"gitlab", instanceName?: string) {
+    public notificationsEnabled(type: string, instanceName?: string) {
         if (type === "github") {
             return this.data.github?.notifications?.enabled;
         }

--- a/src/Notifications/GitHubWatcher.ts
+++ b/src/Notifications/GitHubWatcher.ts
@@ -34,14 +34,16 @@ export class GitHubWatcher extends EventEmitter implements NotificationWatcherTa
     private octoKit: Octokit;
     public failureCount = 0;
     private interval?: NodeJS.Timeout;
-    private lastReadTs = 0;
     public readonly type = "github";
     public readonly instanceUrl = undefined;
 
-    constructor(token: string, baseUrl: URL, public userId: string, public roomId: string, since: number, private participating = false) {
+    constructor(token: string, baseUrl: URL, public userId: string, public roomId: string, private lastReadTs: number, private participating = false) {
         super();
         this.octoKit =  GithubInstance.createUserOctokit(token, baseUrl);
-        this.lastReadTs = since;
+    }
+
+    public get since() {
+        return this.lastReadTs;
     }
 
     public start(intervalMs: number) {

--- a/src/Notifications/NotificationWatcherTask.ts
+++ b/src/Notifications/NotificationWatcherTask.ts
@@ -8,6 +8,7 @@ export interface NotificationWatcherTask extends EventEmitter {
     instanceUrl?: string;
     roomId: string;
     failureCount: number;
+    since: number;
     start(intervalMs: number): void;
     stop(): void;
 }

--- a/src/Notifications/UserNotificationWatcher.ts
+++ b/src/Notifications/UserNotificationWatcher.ts
@@ -79,13 +79,18 @@ Check your token is still valid, and then turn notifications back on.`, "m.notic
         }
         let task: NotificationWatcherTask;
         const key = UserNotificationWatcher.constructMapKey(data.userId, data.type, data.instanceUrl);
+        const existing = this.userIntervals.get(key);
+        const since = data.since || existing?.since;
+        if (since === undefined) {
+            throw Error('`since` value missing from data payload, and no previous since value exists');
+        }
         if (data.type === "github") {
             if (!this.config.github) {
                 throw Error('GitHub is not configured');
             }
-            task = new GitHubWatcher(data.token, this.config.github.baseUrl, data.userId, data.roomId, data.since, data.filterParticipating);
+            task = new GitHubWatcher(data.token, this.config.github.baseUrl, data.userId, data.roomId, since, data.filterParticipating);
         } else if (data.type === "gitlab" && data.instanceUrl) {
-            task = new GitLabWatcher(data.token, data.instanceUrl, data.userId, data.roomId, data.since);
+            task = new GitLabWatcher(data.token, data.instanceUrl, data.userId, data.roomId, since);
         } else {
             throw Error('Notification type not known');
         }

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -21,7 +21,7 @@ const log = new LogWrapper("Webhooks");
 export interface NotificationsEnableEvent {
     userId: string;
     roomId: string;
-    since: number;
+    since?: number;
     token: string;
     filterParticipating: boolean;
     type: "github"|"gitlab";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4816,6 +4816,13 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+rxjs@^7.5.2:
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.5.tgz#2ebad89af0f560f460ad5cc4213219e1f7dd4e9f"
+  integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -5206,6 +5213,11 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+tiny-typed-emitter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz#b3b027fdd389ff81a152c8e847ee2f5be9fad7b5"
+  integrity sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
@@ -5264,6 +5276,11 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -5307,6 +5324,13 @@ type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
+
+typed-emitter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/typed-emitter/-/typed-emitter-2.1.0.tgz#ca78e3d8ef1476f228f548d62e04e3d4d3fd77fb"
+  integrity sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==
+  optionalDependencies:
+    rxjs "^7.5.2"
 
 typescript@^4.5.2:
   version "4.5.4"


### PR DESCRIPTION
Fixes #387 

This makes the token store an emitter which emits an event when a token for a user is updated, allowing us to then emit a message to the watchers.