### PR TITLE
Mention RSS/Atom feeds in the list of supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This bridge supports:
   - Commands (create new issues)
 - Generic webhooks
   - Webhooks (via GET, PUT or POST with optional transformation functions)
+- RSS/Atom feeds
+  - New entries
 
 ## Setup
 

--- a/changelog.d/389.doc
+++ b/changelog.d/389.doc
@@ -1,0 +1,1 @@
+Mention RSS/Atom feed support in the project's README.


### PR DESCRIPTION
While looking into adding an RSS feed into a room I first looked at hookshot's readme and thought it didn't support it because it made no mention of it.