### PR TITLE
Dockerfile: Move --pure-lockfile to yarn (install) 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN apt-get update && apt-get install -y build-essential cmake
 
 # Workaround: Need to install esbuild manually https://github.com/evanw/esbuild/issues/462#issuecomment-771328459
-RUN yarn --ignore-scripts
+RUN yarn --ignore-scripts --pure-lockfile
 RUN node node_modules/esbuild/install.js
-RUN yarn build --pure-lockfile
+RUN yarn build
 
 
 # Stage 1: The actual container

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y build-essential cmake
 # Workaround: Need to install esbuild manually https://github.com/evanw/esbuild/issues/462#issuecomment-771328459
 RUN yarn --ignore-scripts --pure-lockfile
 RUN node node_modules/esbuild/install.js
-RUN RUST_LOG=cargo=debug yarn build
+RUN yarn build
 
 
 # Stage 1: The actual container

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y build-essential cmake
 # Workaround: Need to install esbuild manually https://github.com/evanw/esbuild/issues/462#issuecomment-771328459
 RUN yarn --ignore-scripts --pure-lockfile
 RUN node node_modules/esbuild/install.js
-RUN yarn build
+RUN RUST_LOG=cargo=debug yarn build
 
 
 # Stage 1: The actual container


### PR DESCRIPTION
This seems like a mistake we made when we split the install and build steps (due to the esbuild flakiness).