### PR TITLE
Revert "Add docker auto-build for ARM64"

### DIFF
--- a/.github/workflows/docker-hub-latest.yml
+++ b/.github/workflows/docker-hub-latest.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   DOCKER_NAMESPACE: halfshot
-  PLATFORMS: linux/amd64,linux/arm64
+  PLATFORMS: linux/amd64
   # Only push if this is main, otherwise we just want to build
   PUSH: ${{ github.ref == 'refs/heads/main' }}
 
@@ -17,17 +17,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Build image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v2
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/docker-hub-release.yml
+++ b/.github/workflows/docker-hub-release.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   DOCKER_NAMESPACE: halfshot
-  PLATFORMS: linux/amd64,linux/arm64
+  PLATFORMS: linux/amd64
 
 jobs:
   docker-release:
@@ -18,17 +18,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Get release tag
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Build image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v2
         with:
           context: .
           file: ./Dockerfile

--- a/changelog.d/373.feature
+++ b/changelog.d/373.feature
@@ -1,1 +1,0 @@
-Add support for ARM64 docker images.


### PR DESCRIPTION
Reverts matrix-org/matrix-hookshot#373

Fixes #390. Sadly https://github.com/matrix-org/matrix-rust-sdk-bindings does not compile successfully on arm64. Cargo runs, but is killed (assumed to be resource pressure) when running in GitHub actions. It looks to be a problem for arm64 because no binarys are packaged for its architecture in the npm package.

The up and coming refactor in matrix-bot-sdk to use the rust-sdk directly might mean we can re-enable arm64 builds again, but at this moment in time it's simply too much of a time sink to work out why a binding layer we do not use (but, because the bot-sdk makes it a required dependency, we have to build it anyway) fails to compile.