### PR TITLE
Fix floating values breaking generic webhooks

### DIFF
--- a/docs/setup/webhooks.md
+++ b/docs/setup/webhooks.md
@@ -56,6 +56,7 @@ To add a webhook to your room:
 
 ## Webhook Handling
 
+
 Hookshot handles HTTP requests with a method of `GET`, `POST` or `PUT`.
 
 If the request is a `GET` request, the query parameters are assumed to be the body. Otherwise, the body of the request should be a JSON payload.
@@ -68,6 +69,16 @@ If the body contains a `html` key, then that key will be used as the HTML messag
 If the body *also* contains a `username` key, then the message will be prepended by the given username. This will be prepended to both `text` and `html`.
 
 If the body does NOT contain a `text` field, the full JSON payload will be sent to the room. This can be adapted into a message by creating a **JavaScript transformation function**.
+
+Hookshot will insert the full content of the body into a key under the Matrix event called `uk.half-shot.hookshot.webhook_data`, which may be useful if you have
+other integrations that would like to make use of the raw request body.
+
+<section class="notice">
+Matrix does NOT support floating point values in JSON, so the <code>uk.half-shot.hookshot.webhook_data</code> field will automatically convert any float values
+to a string representation of that value. This change is <strong>not applied</strong> to the JavaScript transformation <code>data</code>
+variable, so it will contain proper float values.
+</section>
+
 
 ## JavaScript Transformations
 

--- a/src/MatrixSender.ts
+++ b/src/MatrixSender.ts
@@ -1,6 +1,5 @@
 import { BridgeConfig } from "./Config/Config";
 import { MessageQueue, createMessageQueue } from "./MessageQueue";
-import { MatrixEventContent, MatrixMessageContent } from "./MatrixEvent";
 import { Appservice, IAppserviceRegistration, MemoryStorageProvider } from "matrix-bot-sdk";
 import LogWrapper from "./LogWrapper";
 import { v4 as uuid } from "uuid";
@@ -11,7 +10,7 @@ export interface IMatrixSendMessage {
     sender: string|null;
     type: string;
     roomId: string;
-    content: MatrixEventContent;
+    content: Record<string, unknown>;
 }
 
 export interface IMatrixSendMessageResponse {
@@ -86,11 +85,11 @@ export class MessageSenderClient {
         return this.sendMatrixMessage(roomId, {
             msgtype,
             body: text,
-        } as MatrixMessageContent, "m.room.message", sender);
+        }, "m.room.message", sender);
     }
 
     public async sendMatrixMessage(roomId: string,
-                                   content: MatrixEventContent, eventType = "m.room.message",
+                                   content: unknown, eventType = "m.room.message",
                                    sender: string|null = null): Promise<string> {
         const result = await this.queue.pushWait<IMatrixSendMessage, IMatrixSendMessageResponse|IMatrixSendMessageFailedResponse>({
             eventName: "matrix.message",
@@ -99,7 +98,7 @@ export class MessageSenderClient {
                 roomId,
                 type: eventType,
                 sender,
-                content,
+                content: content as Record<string, undefined>,
             },
         });
 

--- a/tests/connections/GenericHookTest.ts
+++ b/tests/connections/GenericHookTest.ts
@@ -2,8 +2,8 @@
 import { expect } from "chai";
 import { BridgeConfigGenericWebhooks, BridgeGenericWebhooksConfigYAML } from "../../src/Config/Config";
 import { GenericHookConnection, GenericHookConnectionState } from "../../src/Connections/GenericHook";
-import { MessageSenderClient } from "../../src/MatrixSender";
-import { createMessageQueue, MessageQueue } from "../../src/MessageQueue";
+import { MessageSenderClient, IMatrixSendMessage } from "../../src/MatrixSender";
+import { LocalMQ } from "../../src/MessageQueue/LocalMQ";
 import { AppserviceMock } from "../utils/AppserviceMock";
 
 const ROOM_ID = "!foo:bar";
@@ -13,25 +13,23 @@ const V2TFFunction = "result = {plain: `The answer to '${data.question}' is ${da
 
 function createGenericHook(state: GenericHookConnectionState = {
     name: "some-name"
-}, config: BridgeGenericWebhooksConfigYAML = { enabled: true, urlPrefix: "https://example.com/webhookurl"}): [GenericHookConnection, MessageQueue] {
-    const mq = createMessageQueue({
-            monolithic: true
-    });
+}, config: BridgeGenericWebhooksConfigYAML = { enabled: true, urlPrefix: "https://example.com/webhookurl"}): [GenericHookConnection, LocalMQ] {
+    const mq = new LocalMQ();
     mq.subscribe('*');
     const messageClient = new MessageSenderClient(mq);
     const connection =  new GenericHookConnection(ROOM_ID, state, "foobar", "foobar", messageClient, new BridgeConfigGenericWebhooks(config), AppserviceMock.create())
     return [connection, mq];
 }
 
-function handleMessage(mq: MessageQueue) {
-    return new Promise(r => mq.on('matrix.message', (msg) => {
+function handleMessage(mq: LocalMQ): Promise<IMatrixSendMessage> {
+    return new Promise(r => mq.once('matrix.message', (msg) => {
         mq.push({
             eventName: 'response.matrix.message',
             messageId: msg.messageId,
             sender: 'TestSender',
             data: { 'eventId': '$foo:bar' },
         });
-        r(msg.data);
+        r(msg.data as IMatrixSendMessage);
     })); 
 }
 
@@ -176,5 +174,43 @@ describe("GenericHookConnection", () => {
             },
             type: 'm.room.message',
         });
+    });
+    it("will handle a message containing floats", async () => {
+        const [connection, mq] = createGenericHook();
+        let messagePromise = handleMessage(mq);
+        await connection.onGenericHook({ simple: 1.2345 });
+        let message = await messagePromise;
+        expect(message.roomId).to.equal(ROOM_ID);
+        expect(message.sender).to.equal(connection.getUserId());
+        expect(message.content["uk.half-shot.hookshot.webhook_data"]).to.deep.equal({ simple: "1.2345" });
+
+        messagePromise = handleMessage(mq);
+        await connection.onGenericHook({
+            a: {
+                deep: {
+                    object: {
+                        containing: 1.2345
+                    }
+                }
+            }
+        });
+        message = await messagePromise;
+        expect(message.roomId).to.equal(ROOM_ID);
+        expect(message.sender).to.equal(connection.getUserId());
+        expect(message.content["uk.half-shot.hookshot.webhook_data"]).to.deep.equal({ a: { deep: { object: { containing: "1.2345" }}} });
+
+        messagePromise = handleMessage(mq);
+        await connection.onGenericHook({
+            an_array_of: [1.2345, 6.789],
+            floats: true,
+        });
+        message = await messagePromise;
+        expect(message.roomId).to.equal(ROOM_ID);
+        expect(message.sender).to.equal(connection.getUserId());
+        expect(message.content["uk.half-shot.hookshot.webhook_data"]).to.deep.equal({
+            an_array_of: ["1.2345", "6.789"],
+            floats: true,
+        });
+
     });
 })


### PR DESCRIPTION
This fixes #386 and preserves the float by converting it to a string. We also now actually reference the event key in the documentation too.