### PR TITLE
Disable GET for webhooks (unless configured)

### DIFF
--- a/changelog.d/397.removal
+++ b/changelog.d/397.removal
@@ -1,0 +1,2 @@
+Generic webhooks will no longer respond to `GET` requests by default. Users should consider using the `POST` or `PUT` methods instead.
+`GET` support can be enabled using the config flag `generic.enableHttpGet`.

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -77,6 +77,7 @@ generic:
   #
   #
   enabled: false
+  enableHttpGet: false
   urlPrefix: https://example.com/webhook/
   userIdPrefix: _webhooks_
   allowJsTransformationFunctions: false

--- a/docs/setup/webhooks.md
+++ b/docs/setup/webhooks.md
@@ -13,6 +13,7 @@ generic:
   urlPrefix: https://example.com/mywebhookspath/
   allowJsTransformationFunctions: false
   waitForComplete: false
+  enableHttpGet: false
   # userIdPrefix: webhook_
 ```
 
@@ -32,6 +33,9 @@ webhook requests from `https://example.com/mywebhookspath` to the bridge (on `/w
 `waitForComplete` causes the bridge to wait until the webhook is processed before sending a response. Some services prefer you always
 respond with a 200 as soon as the webhook has entered processing (`false`) while others prefer to know if the resulting Matrix message
 has been sent (`true`). By default this is `false`.
+
+`enableHttpGet` means that webhooks can be triggered by `GET` requests, in addition to `POST` and `PUT`. This was previously on by default,
+but is now disabled due to concerns mentioned below.
 
 You may set a `userIdPrefix` to create a specific user for each new webhook connection in a room. For example, a connection with a name
 like `example` for a prefix of `webhook_` will create a user called `@webhook_example:example.com`. If you enable this option,
@@ -56,9 +60,7 @@ To add a webhook to your room:
 
 ## Webhook Handling
 
-Hookshot handles HTTP requests with a method of `GET`, `POST` or `PUT`.
-
-If the request is a `GET` request, the query parameters are assumed to be the body. Otherwise, the body of the request should be a JSON payload.
+Hookshot handles `POST` and `PUT` HTTP requests by default.
 
 If the body contains a `text` key, then that key will be used as a message body in Matrix (aka `body`). This text will be automatically converted from Markdown to HTML (unless
 a `html` key is provided.).
@@ -68,6 +70,11 @@ If the body contains a `html` key, then that key will be used as the HTML messag
 If the body *also* contains a `username` key, then the message will be prepended by the given username. This will be prepended to both `text` and `html`.
 
 If the body does NOT contain a `text` field, the full JSON payload will be sent to the room. This can be adapted into a message by creating a **JavaScript transformation function**.
+
+### GET requests
+
+In previous versions of hookshot, it would also handle the `GET` HTTP method. This was disabled due to concerns that it was too easy for the webhook to be
+inadvetently triggered by URL preview features in clients and servers. If you still need this functionality, you can enable it in the config.
 
 ## JavaScript Transformations
 

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -256,7 +256,7 @@ export interface BridgeGenericWebhooksConfigYAML {
     userIdPrefix?: string;
     allowJsTransformationFunctions?: boolean;
     waitForComplete?: boolean;
-    enableHttpGet: boolean;
+    enableHttpGet?: boolean;
 }
 
 export class BridgeConfigGenericWebhooks {

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -256,6 +256,7 @@ export interface BridgeGenericWebhooksConfigYAML {
     userIdPrefix?: string;
     allowJsTransformationFunctions?: boolean;
     waitForComplete?: boolean;
+    enableHttpGet: boolean;
 }
 
 export class BridgeConfigGenericWebhooks {
@@ -264,11 +265,13 @@ export class BridgeConfigGenericWebhooks {
     public readonly userIdPrefix?: string;
     public readonly allowJsTransformationFunctions?: boolean;
     public readonly waitForComplete?: boolean;
+    public readonly enableHttpGet: boolean;
     constructor(yaml: BridgeGenericWebhooksConfigYAML) {
         if (typeof yaml.urlPrefix !== "string") {
             throw new ConfigError("generic.urlPrefix", "is not defined or not a string");
         }
         this.enabled = yaml.enabled || false;
+        this.enableHttpGet = yaml.enableHttpGet || false;
         this.urlPrefix = yaml.urlPrefix;
         this.userIdPrefix = yaml.userIdPrefix;
         this.allowJsTransformationFunctions = yaml.allowJsTransformationFunctions;

--- a/src/Config/Defaults.ts
+++ b/src/Config/Defaults.ts
@@ -91,11 +91,12 @@ export const DefaultConfig = new BridgeConfig({
         },
     },
     generic: {
-        enabled: false,
-        urlPrefix: "https://example.com/webhook/",
         allowJsTransformationFunctions: false,
+        enabled: false,
+        enableHttpGet: false,
+        urlPrefix: "https://example.com/webhook/",
+        userIdPrefix: "_webhooks_",
         waitForComplete: false,
-        userIdPrefix: "_webhooks_"
     },
     figma: {
         publicUrl: "https://example.com/hookshot/",

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -62,9 +62,9 @@ export class Webhooks extends EventEmitter {
             this.expressRouter.use('/figma', new FigmaWebhooksRouter(this.config.figma, this.queue).getRouter());
         }
         if (this.config.generic) {
-            this.expressRouter.use('/webhook', new GenericWebhooksRouter(this.queue).getRouter());
+            this.expressRouter.use('/webhook', new GenericWebhooksRouter(this.queue, false, this.config.generic.enableHttpGet).getRouter());
             // TODO: Remove old deprecated endpoint
-            this.expressRouter.use(new GenericWebhooksRouter(this.queue, true).getRouter());
+            this.expressRouter.use(new GenericWebhooksRouter(this.queue, true, this.config.generic.enableHttpGet).getRouter());
         }
         this.expressRouter.use(express.json({
             verify: this.verifyRequest.bind(this),

--- a/src/generic/Router.ts
+++ b/src/generic/Router.ts
@@ -8,11 +8,15 @@ const WEBHOOK_RESPONSE_TIMEOUT = 5000;
 
 const log = new LogWrapper('GenericWebhooksRouter');
 export class GenericWebhooksRouter {
-    constructor(private readonly queue: MessageQueue, private readonly deprecatedPath = false) { }
+    constructor(private readonly queue: MessageQueue, private readonly deprecatedPath = false, private readonly allowGet: boolean) { }
 
     private onWebhook(req: Request<{hookId: string}, unknown, unknown, unknown>, res: Response<{ok: true}|{ok: false, error: string}>, next: NextFunction) {
+        if (req.method === "GET" && !this.allowGet) {
+            throw new ApiError("Invalid Method. Expecting PUT or POST", ErrCode.MethodNotAllowed);
+        }
+
         if (!['PUT', 'GET', 'POST'].includes(req.method)) {
-            throw new ApiError("Wrong METHOD. Expecting PUT, GET or POST", ErrCode.MethodNotAllowed);
+            throw new ApiError("Invalid Method. Expecting PUT, GET or POST", ErrCode.MethodNotAllowed);
         }
     
         let body;

--- a/src/generic/Router.ts
+++ b/src/generic/Router.ts
@@ -11,6 +11,7 @@ export class GenericWebhooksRouter {
     constructor(private readonly queue: MessageQueue, private readonly deprecatedPath = false, private readonly allowGet: boolean) { }
 
     private onWebhook(req: Request<{hookId: string}, unknown, unknown, unknown>, res: Response<{ok: true}|{ok: false, error: string}>, next: NextFunction) {
+
         if (req.method === "GET" && !this.allowGet) {
             throw new ApiError("Invalid Method. Expecting PUT or POST", ErrCode.MethodNotAllowed);
         }


### PR DESCRIPTION
Fixes #395 

After polling the room, it sounds like most people don't need GET. The ones that do can enable the secret config flag to allow it, but in the general case it seems safe to be off by default.