### PR TITLE
Add a warning when no action is given for GitLab

### DIFF
--- a/changelog.d/398.doc
+++ b/changelog.d/398.doc
@@ -1,0 +1,1 @@
+Mention that the GitLab test hooks button doesn't send properly formed requests in all cases, and should not be relied upon when testing Hookshot.

--- a/docs/setup/gitlab.md
+++ b/docs/setup/gitlab.md
@@ -25,6 +25,14 @@ You should generate a webhook `secret` (e.g. `pwgen -n 64 -s 1`) and then use th
 The `publicUrl` must be the URL where GitLab webhook events are received (i.e. the path to `/`
 for your `webhooks` listener).
 
+
+<section class="warning">
+The GitLab hooks "test" button allows you to check that your webhooks are configured properly. The
+merge request, issue and release notifications lack a <code>action</code> field in the body of the
+request which means they <strong>won't show up in the room</strong>. You can check the logs to see
+if the request made it through, however. 
+</section>
+
 ## Adding a repository
 
 You can now follow the guide on [authenticating with GitLab](../usage/auth.md), and then [bridging a room](../usage/room_configuration/gitlab_project.md#setting-up)

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -81,9 +81,17 @@ export class Webhooks extends EventEmitter {
     private onGitLabPayload(body: IGitLabWebhookEvent) {
         if (body.object_kind === "merge_request") {
             const action = (body as unknown as IGitLabWebhookMREvent).object_attributes.action;
+            if (!action) {
+                log.warn("Got gitlab.merge_request but no action field, which usually means someone pressed the test webhooks button.");
+                return null;
+            }
             return `gitlab.merge_request.${action}`;
         } else if (body.object_kind === "issue") {
             const action = (body as unknown as IGitLabWebhookIssueStateEvent).object_attributes.action;
+            if (!action) {
+                log.warn("Got gitlab.issue but no action field, which usually means someone pressed the test webhooks button.");
+                return null;
+            }
             return `gitlab.issue.${action}`;
         } else if (body.object_kind === "note") {
             return `gitlab.note.created`;
@@ -93,6 +101,10 @@ export class Webhooks extends EventEmitter {
             return "gitlab.wiki_page";
         } else if (body.object_kind === "release") {
             const action = (body as unknown as IGitLabWebhookReleaseEvent).action;
+            if (!action) {
+                log.warn("Got gitlab.release but no action field, which usually means someone pressed the test webhooks button.");
+                return null;
+            }
             return `gitlab.release.${action}`;
         } else if (body.object_kind === "push") {
             return `gitlab.push`;


### PR DESCRIPTION
GitLab test webhooks send a notification that isn't properly formed (missing an `action`). As a result, we can't handle them but users get frustrated that their notifications seemingly aren't working. They are, it's just that GitLab don't actually respect their own schema.

Instead, let's log a warning which can at least inform the admins that things are working but we can't handle the notification.