### PR TITLE
Stringify provision connection data object in logs

### DIFF
--- a/changelog.d/404.bugfix
+++ b/changelog.d/404.bugfix
@@ -1,0 +1,1 @@
+Stringify provision connection data object in logs.

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -70,7 +70,7 @@ export class ConnectionManager extends EventEmitter {
      * @returns The resulting connection.
      */
     public async provisionConnection(roomId: string, userId: string, type: string, data: Record<string, unknown>): Promise<IConnection> {
-        log.info(`Looking to provision connection for ${roomId} ${type} for ${userId} with ${data}`);
+        log.info(`Looking to provision connection for ${roomId} ${type} for ${userId} with data ${JSON.stringify(data)}`);
         const connectionType = ConnectionDeclarations.find(c => c.EventTypes.includes(type));
         if (connectionType?.provisionConnection) {
             if (!this.config.checkPermission(userId, connectionType.ServiceCategory, BridgePermissionLevel.manageConnections)) {


### PR DESCRIPTION
Otherwise, it may get logged as [object Object]

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>