### PR TITLE
Allow the same GitLab repo to be bridged to multiple rooms

### DIFF
--- a/changelog.d/406.bugfix
+++ b/changelog.d/406.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where GitLab repos could not be bridged if they were already bridged to another room.

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -197,7 +197,7 @@ export class GitLabRepoConnection extends CommandConnection {
         const stateEventKey = `${validData.instance}/${validData.path}`;
         const connection = new GitLabRepoConnection(roomId, stateEventKey, as, validData, tokenStore, instance);
         const existingConnections = getAllConnectionsOfType(GitLabRepoConnection);
-        const existing = existingConnections.find(c => c.roomId === roomId && c.stateKey === connection.stateKey) as undefined|GitLabRepoConnection;
+        const existing = existingConnections.find(c => c.roomId === roomId && c.stateKey === connection.stateKey);
 
         if (existing) {
             throw new ApiError("A GitLab repo connection for this project already exists", ErrCode.ConflictingConnection, -1, {

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -197,7 +197,7 @@ export class GitLabRepoConnection extends CommandConnection {
         const stateEventKey = `${validData.instance}/${validData.path}`;
         const connection = new GitLabRepoConnection(roomId, stateEventKey, as, validData, tokenStore, instance);
         const existingConnections = getAllConnectionsOfType(GitLabRepoConnection);
-        const existing = existingConnections.find(c => c instanceof GitLabRepoConnection && c.stateKey === connection.stateKey) as undefined|GitLabRepoConnection;
+        const existing = existingConnections.find(c => c.roomId === roomId && c.stateKey === connection.stateKey) as undefined|GitLabRepoConnection;
 
         if (existing) {
             throw new ApiError("A GitLab repo connection for this project already exists", ErrCode.ConflictingConnection, -1, {


### PR DESCRIPTION
This was a mistake where we didn't correctly scope the filter to the same room.