### PR TITLE
Disallow some empty config URL settings

### DIFF
--- a/changelog.d/412.bugfix
+++ b/changelog.d/412.bugfix
@@ -1,0 +1,1 @@
+Disallow empty values for the `widgets.publicUrl` and `generic.urlPrefix` configuration settings.

--- a/changelog.d/412.bugfix
+++ b/changelog.d/412.bugfix
@@ -1,1 +1,1 @@
-Disallow empty values for the `widgets.publicUrl` and `generic.urlPrefix` configuration settings.
+Disallow empty and invalid values for the `widgets.publicUrl` and `generic.urlPrefix` configuration settings.

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -144,7 +144,7 @@ widgets:
     - fec0::/10
   roomSetupWidget:
     addOnInvite: false
-  publicUrl: http://example.com/widgetapi/v1/static
+  publicUrl: http://example.com/widgetapi/v1/static/
   branding:
     widgetTitle: Hookshot Configuration
 permissions:

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -1183,7 +1183,7 @@ export class Bridge {
             return this.as.botClient.inviteUser(adminRoom.userId, newConnection.roomId);
         });
         this.adminRooms.set(roomId, adminRoom);
-        if (this.config.widgets?.addToAdminRooms && this.config.widgets.publicUrl) {
+        if (this.config.widgets?.addToAdminRooms) {
             await SetupWidget.SetupAdminRoomConfigWidget(roomId, this.as.botIntent, this.config.widgets);
         }
         log.debug(`Set up ${roomId} as an admin room for ${adminRoom.userId}`);

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -265,19 +265,24 @@ export interface BridgeGenericWebhooksConfigYAML {
 
 export class BridgeConfigGenericWebhooks {
     public readonly enabled: boolean;
-    public readonly urlPrefix: URL;
+
+    @hideKey()
+    public readonly parsedUrlPrefix: URL;
+    public readonly urlPrefix: () => string;
+
     public readonly userIdPrefix?: string;
     public readonly allowJsTransformationFunctions?: boolean;
     public readonly waitForComplete?: boolean;
     public readonly enableHttpGet: boolean;
     constructor(yaml: BridgeGenericWebhooksConfigYAML) {
+        this.enabled = yaml.enabled || false;
+        this.enableHttpGet = yaml.enableHttpGet || false;
         try {
-            this.urlPrefix = makePrefixedUrl(yaml.urlPrefix);
+            this.parsedUrlPrefix = makePrefixedUrl(yaml.urlPrefix);
+            this.urlPrefix = () => { return this.parsedUrlPrefix.href; }
         } catch (err) {
             throw new ConfigError("generic.urlPrefix", "is not defined or not a valid URL");
         }
-        this.enabled = yaml.enabled || false;
-        this.enableHttpGet = yaml.enableHttpGet || false;
         this.userIdPrefix = yaml.userIdPrefix;
         this.allowJsTransformationFunctions = yaml.allowJsTransformationFunctions;
         this.waitForComplete = yaml.waitForComplete;
@@ -310,7 +315,11 @@ interface BridgeWidgetConfigYAML {
 
 export class BridgeWidgetConfig {
     public readonly addToAdminRooms: boolean;
-    public readonly publicUrl: URL;
+
+    @hideKey()
+    public readonly parsedPublicUrl: URL;
+    public readonly publicUrl: () => string;
+
     public readonly roomSetupWidget?: {
         addOnInvite?: boolean;
     };
@@ -329,7 +338,8 @@ export class BridgeWidgetConfig {
             throw new ConfigError("widgets.disallowedIpRanges", "must be a string array");
         }
         try {
-            this.publicUrl = makePrefixedUrl(yaml.publicUrl)
+            this.parsedPublicUrl = makePrefixedUrl(yaml.publicUrl)
+            this.publicUrl = () => { return this.parsedPublicUrl.href; }
         } catch (err) {
             throw new ConfigError("widgets.publicUrl", "is not defined or not a valid URL");
         }

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -267,7 +267,7 @@ export class BridgeConfigGenericWebhooks {
     public readonly waitForComplete?: boolean;
     public readonly enableHttpGet: boolean;
     constructor(yaml: BridgeGenericWebhooksConfigYAML) {
-        if (typeof yaml.urlPrefix !== "string") {
+        if (typeof yaml.urlPrefix !== "string" || !yaml.urlPrefix) {
             throw new ConfigError("generic.urlPrefix", "is not defined or not a string");
         }
         this.enabled = yaml.enabled || false;
@@ -323,7 +323,7 @@ export class BridgeWidgetConfig {
         if (yaml.disallowedIpRanges !== undefined && (!Array.isArray(yaml.disallowedIpRanges) || !yaml.disallowedIpRanges.every(s => typeof s === "string"))) {
             throw new ConfigError("widgets.disallowedIpRanges", "must be a string array");
         }
-        if (typeof yaml.publicUrl !== "string") {
+        if (typeof yaml.publicUrl !== "string" || !yaml.publicUrl) {
             throw new ConfigError("widgets.publicUrl", "is not defined or not a string");
         }
         this.publicUrl = yaml.publicUrl;

--- a/src/Config/Defaults.ts
+++ b/src/Config/Defaults.ts
@@ -143,11 +143,16 @@ function renderSection(doc: YAML.Document, obj: Record<string, unknown>, parentN
         if (keyIsHidden(obj, key)) {
             return;
         }
-        
+
         let newNode: Node;
         if (typeof value === "object" && !Array.isArray(value)) {
             newNode = YAML.createNode({});
             renderSection(doc, value as Record<string, unknown>, newNode as YAMLSeq);
+        } else if (typeof value === "function") {
+            if (value.length !== 0) {
+                throw Error("Only zero-argument functions are allowed as config values");
+            }
+            newNode = YAML.createNode(value());
         } else {
             newNode = YAML.createNode(value);
         }

--- a/src/Connections/GenericHook.ts
+++ b/src/Connections/GenericHook.ts
@@ -404,7 +404,7 @@ export class GenericHookConnection extends BaseConnection implements IConnection
                 name: this.state.name,
             },
             ...(showSecrets ? { secrets: {
-                url: new URL(this.hookId, this.config.urlPrefix),
+                url: new URL(this.hookId, this.config.parsedUrlPrefix),
                 hookId: this.hookId,
             } as GenericHookSecrets} : undefined)
         }

--- a/src/Connections/GenericHook.ts
+++ b/src/Connections/GenericHook.ts
@@ -27,7 +27,7 @@ export interface GenericHookSecrets {
     /**
      * The public URL for the webhook.
      */
-    url: string;
+    url: URL;
     /**
      * The hookId of the webhook.
      */
@@ -404,7 +404,7 @@ export class GenericHookConnection extends BaseConnection implements IConnection
                 name: this.state.name,
             },
             ...(showSecrets ? { secrets: {
-                url: `${this.config.urlPrefix}${this.config.urlPrefix.endsWith('/') ? '' : '/'}${this.hookId}`,
+                url: new URL(this.hookId, this.config.urlPrefix),
                 hookId: this.hookId,
             } as GenericHookSecrets} : undefined)
         }

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -139,7 +139,7 @@ export class SetupConnection extends CommandConnection {
             throw new CommandError("Bad webhook name", "A webhook name must be between 3-64 characters.");
         }
         const c = await GenericHookConnection.provisionConnection(this.roomId, userId, {name}, this.provisionOpts);
-        const url = `${this.config.generic.urlPrefix}${this.config.generic.urlPrefix.endsWith('/') ? '' : '/'}${c.connection.hookId}`;
+        const url = new URL(c.connection.hookId, this.config.generic.urlPrefix);
         const adminRoom = await this.getOrCreateAdminRoom(userId);
         await adminRoom.sendNotice(`You have bridged a webhook. Please configure your webhook source to use ${url}.`);
         return this.as.botClient.sendNotice(this.roomId, `Room configured to bridge webhooks. See admin room for secret url.`);

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -139,7 +139,7 @@ export class SetupConnection extends CommandConnection {
             throw new CommandError("Bad webhook name", "A webhook name must be between 3-64 characters.");
         }
         const c = await GenericHookConnection.provisionConnection(this.roomId, userId, {name}, this.provisionOpts);
-        const url = new URL(c.connection.hookId, this.config.generic.urlPrefix);
+        const url = new URL(c.connection.hookId, this.config.generic.parsedUrlPrefix);
         const adminRoom = await this.getOrCreateAdminRoom(userId);
         await adminRoom.sendNotice(`You have bridged a webhook. Please configure your webhook source to use ${url}.`);
         return this.as.botClient.sendNotice(this.roomId, `Room configured to bridge webhooks. See admin room for secret url.`);

--- a/src/Widgets/SetupWidget.ts
+++ b/src/Widgets/SetupWidget.ts
@@ -54,7 +54,7 @@ export class SetupWidget {
                 "id": stateKey,
                 "name": config.branding.widgetTitle,
                 "type": "m.custom",
-                "url": `${config?.publicUrl}/#/?kind=${kind}&roomId=$matrix_room_id&widgetId=$matrix_widget_id`,
+                "url": `${config.publicUrl}/#/?kind=${kind}&roomId=$matrix_room_id&widgetId=$matrix_widget_id`,
                 "waitForIframeLoad": true,
             }
         );

--- a/src/Widgets/SetupWidget.ts
+++ b/src/Widgets/SetupWidget.ts
@@ -54,7 +54,7 @@ export class SetupWidget {
                 "id": stateKey,
                 "name": config.branding.widgetTitle,
                 "type": "m.custom",
-                "url": `${config.publicUrl}/#/?kind=${kind}&roomId=$matrix_room_id&widgetId=$matrix_widget_id`,
+                "url": new URL(`#/?kind=${kind}&roomId=$matrix_room_id&widgetId=$matrix_widget_id`, config.publicUrl).href,
                 "waitForIframeLoad": true,
             }
         );

--- a/src/Widgets/SetupWidget.ts
+++ b/src/Widgets/SetupWidget.ts
@@ -54,7 +54,7 @@ export class SetupWidget {
                 "id": stateKey,
                 "name": config.branding.widgetTitle,
                 "type": "m.custom",
-                "url": new URL(`#/?kind=${kind}&roomId=$matrix_room_id&widgetId=$matrix_widget_id`, config.publicUrl).href,
+                "url": new URL(`#/?kind=${kind}&roomId=$matrix_room_id&widgetId=$matrix_widget_id`, config.parsedPublicUrl).href,
                 "waitForIframeLoad": true,
             }
         );


### PR DESCRIPTION
If these settings are meant to be unspecified, then their entire parent
sections (`widgets` & `generic`) should be unspecified.

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>