### PR TITLE
Mention `github login` and `github status` in docs

### DIFF
--- a/changelog.d/415.doc
+++ b/changelog.d/415.doc
@@ -1,0 +1,1 @@
+Mention the correct command for checking the status of GitHub authentication (`github status` instead of `github hastoken`).

--- a/changelog.d/415.doc
+++ b/changelog.d/415.doc
@@ -1,1 +1,1 @@
-Mention the correct command for checking the status of GitHub authentication (`github status` instead of `github hastoken`).
+Update GitHub authentication documentation: list the steps for OAuth login (`github login`), and mention the correct command for checking GitHub authentication status (`github status`).

--- a/docs/usage/auth.md
+++ b/docs/usage/auth.md
@@ -31,7 +31,7 @@ To authenticate with a personal access token:
 
 1. Send the generated token to the bridge by saying `github setpersonaltoken %your-token%`. You can redact
   the message afterwards if you like.
-1. The bridge will have connected you. You can check the status at any time by saying `github hastoken`
+1. The bridge will have connected you. You can check the status at any time by saying `github status`.
 
 ## GitLab
 

--- a/docs/usage/auth.md
+++ b/docs/usage/auth.md
@@ -31,7 +31,16 @@ To authenticate with a personal access token:
 
 1. Send the generated token to the bridge by saying `github setpersonaltoken %your-token%`. You can redact
   the message afterwards if you like.
-1. The bridge will have connected you. You can check the status at any time by saying `github status`.
+1. The bridge will have connected you.
+
+To authenticate via OAuth, you will need to have configured OAuth support in your config.yml, and have the endpoints required accessible from the internet.
+
+- Say `github login` to get the URL to authenticate via.
+- Click the URL sent by the bot.
+- Follow the steps, ensuring you authenticate with the right user.
+- If all goes well, you will now be connected.
+
+You can check the status of authenticated instances by saying `github status`.
 
 ## GitLab
 


### PR DESCRIPTION
instead of `github hastoken`, which was renamed.

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>