### PR TITLE
Don't say nothing to no GitHub connections

### DIFF
--- a/changelog.d/416.bugfix
+++ b/changelog.d/416.bugfix
@@ -1,0 +1,1 @@
+Post a non-empty message in response to `github list-connections` when no connections are present.

--- a/src/AdminRoom.ts
+++ b/src/AdminRoom.ts
@@ -234,7 +234,7 @@ export class AdminRoom extends AdminRoomCommandHandler {
             connections.repos.length > 0       ? `Repositories:\n${reposFormatted}`      : '',
             connections.issues.length > 0      ? `Issues:\n${issuesFormatted}`           : '',
             connections.discussions.length > 0 ? `Discussions:\n${discussionsFormatted}` : '',
-        ].filter(v => !!v).join('\n\n') || 'No Github bridges';
+        ].filter(v => !!v).join('\n\n') || 'No GitHub bridges';
 
         return this.botIntent.sendEvent(this.roomId,{
             msgtype: "m.notice",

--- a/src/AdminRoom.ts
+++ b/src/AdminRoom.ts
@@ -234,7 +234,7 @@ export class AdminRoom extends AdminRoomCommandHandler {
             connections.repos.length > 0       ? `Repositories:\n${reposFormatted}`      : '',
             connections.issues.length > 0      ? `Issues:\n${issuesFormatted}`           : '',
             connections.discussions.length > 0 ? `Discussions:\n${discussionsFormatted}` : '',
-        ].join('\n\n') || 'No Github bridges';
+        ].filter(v => !!v).join('\n\n') || 'No Github bridges';
 
         return this.botIntent.sendEvent(this.roomId,{
             msgtype: "m.notice",


### PR DESCRIPTION
`join`ing an array of empty strings with a non-empty separator makes the resulting string truthy, thus the condition for printing "No Github bridges" was never met.