### PR TITLE
Share code for tracking config via state events

### DIFF
--- a/changelog.d/418.misc
+++ b/changelog.d/418.misc
@@ -1,0 +1,1 @@
+Refactor the way room state is tracked for room-specific configuration, to increase code reuse.

--- a/src/Connections/CommandConnection.ts
+++ b/src/Connections/CommandConnection.ts
@@ -35,9 +35,7 @@ export abstract class CommandConnection<StateType extends IConnectionState = ICo
         this.state = this.validateConnectionState(stateEv.content);
     }
 
-    protected validateConnectionState(content: unknown): StateType {
-        return content as StateType;
-    }
+    protected abstract validateConnectionState(content: unknown): StateType;
 
     public async onMessageEvent(ev: MatrixEvent<MatrixMessageContent>, checkPermission: PermissionCheckFn) {
         const commandResult = await handleCommand(

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -415,6 +415,10 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
         return this.state.priority || super.priority;
     }
 
+    protected validateConnectionState(content: unknown) {
+        return content as GitHubRepoConnectionState;
+    }
+
     public isInterestedInStateEvent(eventType: string, stateKey: string) {
         return GitHubRepoConnection.EventTypes.includes(eventType) && this.stateKey === stateKey;
     }

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -36,7 +36,6 @@ interface IQueryRoomOpts {
 
 export interface GitHubRepoConnectionOptions extends IConnectionState {
     ignoreHooks?: AllowedEventsNames[],
-    commandPrefix?: string;
     showIssueRoomLink?: boolean;
     prDiff?: {
         enabled: boolean;
@@ -212,7 +211,7 @@ function compareEmojiStrings(e0: string, e1: string, e0Index = 0) {
  * Handles rooms connected to a GitHub repo.
  */
 @Connection
-export class GitHubRepoConnection extends CommandConnection implements IConnection {
+export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnectionState> implements IConnection {
 
 	static validateState(state: Record<string, unknown>, isExistingState = false): GitHubRepoConnectionState {
         const validator = new Ajv().compile(ConnectionStateSchema);
@@ -368,7 +367,7 @@ export class GitHubRepoConnection extends CommandConnection implements IConnecti
 
     constructor(roomId: string,
         private readonly as: Appservice,
-        private state: GitHubRepoConnectionState,
+        state: GitHubRepoConnectionState,
         private readonly tokenStore: UserTokenStore,
         stateKey: string,
         private readonly githubInstance: GithubInstance,
@@ -378,10 +377,11 @@ export class GitHubRepoConnection extends CommandConnection implements IConnecti
                 roomId,
                 stateKey,
                 GitHubRepoConnection.CanonicalEventType,
+                state,
                 as.botClient,
                 GitHubRepoConnection.botCommands,
                 GitHubRepoConnection.helpMessage,
-                state.commandPrefix || "!gh",
+                "!gh",
                 "github",
             );
     }
@@ -413,10 +413,6 @@ export class GitHubRepoConnection extends CommandConnection implements IConnecti
 
     public get priority(): number {
         return this.state.priority || super.priority;
-    }
-
-    public async onStateUpdate(stateEv: MatrixEvent<unknown>) {
-        this.state = stateEv.content as GitHubRepoConnectionState;
     }
 
     public isInterestedInStateEvent(eventType: string, stateKey: string) {

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -3,7 +3,7 @@
 import { UserTokenStore } from "../UserTokenStore";
 import { Appservice, StateEvent } from "matrix-bot-sdk";
 import { BotCommands, botCommand, compileBotCommands } from "../BotCommands";
-import { MatrixEvent, MatrixMessageContent } from "../MatrixEvent";
+import { MatrixMessageContent } from "../MatrixEvent";
 import markdown from "markdown-it";
 import LogWrapper from "../LogWrapper";
 import { BridgeConfigGitLab, GitLabInstance } from "../Config/Config";

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -9,7 +9,7 @@ import LogWrapper from "../LogWrapper";
 import { BridgeConfigGitLab, GitLabInstance } from "../Config/Config";
 import { IGitLabWebhookMREvent, IGitLabWebhookNoteEvent, IGitLabWebhookPushEvent, IGitLabWebhookReleaseEvent, IGitLabWebhookTagPushEvent, IGitLabWebhookWikiPageEvent } from "../Gitlab/WebhookTypes";
 import { CommandConnection } from "./CommandConnection";
-import { Connection, IConnectionState, InstantiateConnectionOpts, ProvisionConnectionOpts } from "./IConnection";
+import { Connection, IConnection, IConnectionState, InstantiateConnectionOpts, ProvisionConnectionOpts } from "./IConnection";
 import { GetConnectionsResponseItem } from "../provisioning/api";
 import { ErrCode, ApiError, ValidatorApiError } from "../api"
 import { AccessLevel } from "../Gitlab/Types";
@@ -129,7 +129,7 @@ export interface GitLabTargetFilter {
  * Handles rooms connected to a GitLab repo.
  */
 @Connection
-export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnectionState> {
+export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnectionState> implements IConnection {
     static readonly CanonicalEventType = "uk.half-shot.matrix-hookshot.gitlab.repository";
     static readonly LegacyCanonicalEventType = "uk.half-shot.matrix-github.gitlab.repository";
 

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -303,6 +303,10 @@ export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnection
         return this.state.priority || super.priority;
     }
 
+    protected validateConnectionState(content: unknown) {
+        return content as GitLabRepoConnectionState;
+    }
+
     public isInterestedInStateEvent(eventType: string, stateKey: string) {
         return GitLabRepoConnection.EventTypes.includes(eventType) && this.stateKey === stateKey;
     }

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -19,7 +19,6 @@ export interface GitLabRepoConnectionState extends IConnectionState {
     instance: string;
     path: string;
     ignoreHooks?: AllowedEventsNames[],
-    commandPrefix?: string;
     pushTagsRegex?: string,
     includingLabels?: string[];
     excludingLabels?: string[];
@@ -130,7 +129,7 @@ export interface GitLabTargetFilter {
  * Handles rooms connected to a GitLab repo.
  */
 @Connection
-export class GitLabRepoConnection extends CommandConnection {
+export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnectionState> {
     static readonly CanonicalEventType = "uk.half-shot.matrix-hookshot.gitlab.repository";
     static readonly LegacyCanonicalEventType = "uk.half-shot.matrix-github.gitlab.repository";
 
@@ -277,17 +276,18 @@ export class GitLabRepoConnection extends CommandConnection {
     constructor(roomId: string,
         stateKey: string,
         private readonly as: Appservice,
-        private state: GitLabRepoConnectionState,
+        state: GitLabRepoConnectionState,
         private readonly tokenStore: UserTokenStore,
         private readonly instance: GitLabInstance) {
             super(
                 roomId,
                 stateKey,
                 GitLabRepoConnection.CanonicalEventType,
+                state,
                 as.botClient,
                 GitLabRepoConnection.botCommands,
                 GitLabRepoConnection.helpMessage,
-                state.commandPrefix || "!gl",
+                "!gl",
                 "gitlab",
             )
             if (!state.path || !state.instance) {
@@ -301,11 +301,6 @@ export class GitLabRepoConnection extends CommandConnection {
 
     public get priority(): number {
         return this.state.priority || super.priority;
-    }
-
-    public async onStateUpdate(stateEv: MatrixEvent<unknown>) {
-        const state = stateEv.content as GitLabRepoConnectionState;
-        this.state = state;
     }
 
     public isInterestedInStateEvent(eventType: string, stateKey: string) {

--- a/src/Connections/IConnection.ts
+++ b/src/Connections/IConnection.ts
@@ -14,6 +14,7 @@ export type PermissionCheckFn = (service: string, level: BridgePermissionLevel) 
 
 export interface IConnectionState {
     priority?: number;
+    commandPrefix?: string;
 }
 
 export interface IConnection {

--- a/src/Connections/JiraProject.ts
+++ b/src/Connections/JiraProject.ts
@@ -7,7 +7,7 @@ import markdownit from "markdown-it";
 import { generateJiraWebLinkFromIssue } from "../Jira";
 import { JiraProject } from "../Jira/Types";
 import { botCommand, BotCommands, compileBotCommands } from "../BotCommands";
-import { MatrixEvent, MatrixMessageContent } from "../MatrixEvent";
+import { MatrixMessageContent } from "../MatrixEvent";
 import { CommandConnection } from "./CommandConnection";
 import { UserTokenStore } from "../UserTokenStore";
 import { CommandError, NotLoggedInError } from "../errors";

--- a/src/Connections/JiraProject.ts
+++ b/src/Connections/JiraProject.ts
@@ -23,7 +23,7 @@ export interface JiraProjectConnectionState extends IConnectionState {
     events?: JiraAllowedEventsNames[],
 }
 
-function validateJiraConnectionState(state: JiraProjectConnectionState) {
+function validateJiraConnectionState(state: unknown) {
     const {url, commandPrefix, events, priority} = state as JiraProjectConnectionState;
     if (url === undefined) {
         throw new ApiError("Expected a 'url' property", ErrCode.BadValue);
@@ -179,7 +179,7 @@ export class JiraProjectConnection extends CommandConnection<JiraProjectConnecti
     }
 
     protected validateConnectionState(content: unknown) {
-        return validateJiraConnectionState(super.validateConnectionState(content));
+        return validateJiraConnectionState(content);
     }
 
     public async onJiraIssueCreated(data: JiraIssueEvent) {

--- a/src/Connections/JiraProject.ts
+++ b/src/Connections/JiraProject.ts
@@ -19,12 +19,12 @@ const JiraAllowedEvents: JiraAllowedEventsNames[] = ["issue.created"];
 export interface JiraProjectConnectionState extends IConnectionState {
     // legacy field, prefer url
     id?: string;
-    url?: string;
+    url: string;
     events?: JiraAllowedEventsNames[],
 }
 
-function validateJiraConnectionState(state: unknown) {
-    const {url, commandPrefix, events, priority} = state as JiraProjectConnectionState;
+function validateJiraConnectionState(state: unknown): JiraProjectConnectionState {
+    const {url, commandPrefix, events, priority} = state as Partial<JiraProjectConnectionState>;
     if (url === undefined) {
         throw new ApiError("Expected a 'url' property", ErrCode.BadValue);
     }
@@ -82,7 +82,7 @@ export class JiraProjectConnection extends CommandConnection<JiraProjectConnecti
         if (!jiraResourceClient) {
             throw new ApiError("User is not authenticated with this JIRA instance", ErrCode.ForbiddenUser);
         }
-        const connection = new JiraProjectConnection(roomId, as, data, validData.url, tokenStore);
+        const connection = new JiraProjectConnection(roomId, as, validData, validData.url, tokenStore);
         log.debug(`projectKey for ${validData.url} is ${connection.projectKey}`);
         if (!connection.projectKey) {
             throw Error('Expected projectKey to be defined');

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -41,6 +41,8 @@ export class SetupConnection extends CommandConnection {
                 roomId,
                 "",
                 "",
+                // TODO Consider storing room-specific config in state.
+                {},
                 provisionOpts.as.botClient,
                 SetupConnection.botCommands,
                 SetupConnection.helpMessage,

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -12,7 +12,7 @@ import { URL } from "url";
 import { SetupWidget } from "../Widgets/SetupWidget";
 import { AdminRoom } from "../AdminRoom";
 import { GitLabRepoConnection } from "./GitlabRepo";
-import { ProvisionConnectionOpts } from "./IConnection";
+import { IConnectionState, ProvisionConnectionOpts } from "./IConnection";
 import LogWrapper from "../LogWrapper";
 const md = new markdown();
 const log = new LogWrapper("SetupConnection");
@@ -32,6 +32,11 @@ export class SetupConnection extends CommandConnection {
 
     private get as() {
         return this.provisionOpts.as;
+    }
+
+    protected validateConnectionState(content: unknown) {
+        log.warn("SetupConnection has no state to be validated");
+        return content as IConnectionState;
     }
 
     constructor(public readonly roomId: string,


### PR DESCRIPTION
This should prevent forgetting to add state event handlers in new or
existing connection types.