### PR TITLE
Skip already handled GitHub events

### DIFF
--- a/changelog.d/429.bugfix
+++ b/changelog.d/429.bugfix
@@ -1,0 +1,1 @@
+Fix GitHub notices sometimes coming through multiple times if GitHub sends multiple copies of a webhook.


### PR DESCRIPTION
This is just a simple check to ensure we don't handle multiple events sent by GitHub by looking at the GUID provided. This is already pretty rare, but we've seen this happen rarely in the wild.

GitLab/JIRA don't support this as they don't provide a guid :s