### PR TITLE
Reorder dockerfile to optimize rebuilds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@
 # as musl doesn't support cdylib
 FROM node:16 AS builder
 
-COPY . /src
-WORKDIR /src
-
 # We need rustup so we have a sensible rust version, the version packed with bullsye is too old
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
 ENV PATH="/root/.cargo/bin:${PATH}"
@@ -14,8 +11,14 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 # See https://github.com/matrix-org/matrix-rust-sdk-bindings/blob/main/crates/matrix-sdk-crypto-nodejs/release/Dockerfile.linux#L5-L6
 RUN apt-get update && apt-get install -y build-essential cmake
 
-# Workaround: Need to install esbuild manually https://github.com/evanw/esbuild/issues/462#issuecomment-771328459
+WORKDIR /src
+
+COPY package.json yarn.lock ./
 RUN yarn --ignore-scripts --pure-lockfile
+
+COPY . ./
+
+# Workaround: Need to install esbuild manually https://github.com/evanw/esbuild/issues/462#issuecomment-771328459
 RUN node node_modules/esbuild/install.js
 RUN yarn build
 
@@ -23,17 +26,18 @@ RUN yarn build
 # Stage 1: The actual container
 FROM node:16-slim
 
-COPY --from=builder /src/lib/ /bin/matrix-hookshot/
-COPY --from=builder /src/public/ /bin/matrix-hookshot/public/
-COPY --from=builder /src/package.json /bin/matrix-hookshot/
-COPY --from=builder /src/yarn.lock /bin/matrix-hookshot/
 WORKDIR /bin/matrix-hookshot
+
+COPY --from=builder /src/yarn.lock /src/package.json ./
 
 # --ignore-scripts so we don't try to build
 RUN yarn --ignore-scripts --production --pure-lockfile && yarn cache clean
 
 # Copy rust bindings for crypto, since we built them in the previous step.
 COPY --from=builder /src/node_modules/@turt2live/matrix-sdk-crypto-nodejs /bin/matrix-hookshot/node_modules/@turt2live/matrix-sdk-crypto-nodejs
+
+COPY --from=builder /src/lib ./
+COPY --from=builder /src/public ./public
 
 VOLUME /data
 EXPOSE 9993

--- a/changelog.d/438.misc
+++ b/changelog.d/438.misc
@@ -1,0 +1,1 @@
+Optimize docker image rebuilds.


### PR DESCRIPTION
Optimizes docker image rebuilds following a code change, by installing dependencies before copying code so those layers can be cached. This speeds up cycles of build image -> code change -> build image again.

In my local testing, it's about 60s faster:

## Before
<details>
<summary>
No layers cached
</summary>

```
[+] Building 186.4s (22/22) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                   0.0s
 => => transferring dockerfile: 37B                                                                                                                    0.0s
 => [internal] load .dockerignore                                                                                                                      0.0s
 => => transferring context: 34B                                                                                                                       0.0s
 => [internal] load metadata for docker.io/library/node:16-slim                                                                                        0.2s
 => [internal] load metadata for docker.io/library/node:16                                                                                             0.2s
 => [internal] load build context                                                                                                                      0.0s
 => => transferring context: 20.92kB                                                                                                                   0.0s
 => CACHED [stage-1 1/8] FROM docker.io/library/node:16-slim@sha256:34a3b4b7c2704ce52372c42b9b7945b41fe8eb98d74e8af472add0b599b6e1ff                   0.0s
 => CACHED [builder 1/8] FROM docker.io/library/node:16@sha256:1ed1e17ccabb09038cfb8a965337ebcda51ef9e9d32082164c502d44d9731a02                        0.0s
 => [builder 2/8] COPY . /src                                                                                                                          0.1s
 => [builder 3/8] WORKDIR /src                                                                                                                         0.0s
 => [builder 4/8] RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal                                                                  11.2s
 => [builder 5/8] RUN apt-get update && apt-get install -y build-essential cmake                                                                       3.8s
 => [builder 6/8] RUN yarn --ignore-scripts --pure-lockfile                                                                                           23.1s
 => [builder 7/8] RUN node node_modules/esbuild/install.js                                                                                             0.2s
 => [builder 8/8] RUN yarn build                                                                                                                     115.9s
 => [stage-1 2/8] COPY --from=builder /src/lib/ /bin/matrix-hookshot/                                                                                  0.0s
 => [stage-1 3/8] COPY --from=builder /src/public/ /bin/matrix-hookshot/public/                                                                        0.0s
 => [stage-1 4/8] COPY --from=builder /src/package.json /bin/matrix-hookshot/                                                                          0.0s
 => [stage-1 5/8] COPY --from=builder /src/yarn.lock /bin/matrix-hookshot/                                                                             0.0s
 => [stage-1 6/8] WORKDIR /bin/matrix-hookshot                                                                                                         0.0s
 => [stage-1 7/8] RUN yarn --ignore-scripts --production --pure-lockfile && yarn cache clean                                                          22.9s
 => [stage-1 8/8] COPY --from=builder /src/node_modules/@turt2live/matrix-sdk-crypto-nodejs /bin/matrix-hookshot/node_modules/@turt2live/matrix-sdk-c  2.6s
 => exporting to image                                                                                                                                 3.8s
 => => exporting layers                                                                                                                                3.8s
 => => writing image sha256:8cbb1cdcf359c5fe20a9d00516a2a2590ef4a579f02250c8766df7c447dfde01                                                           0.0s
 => => naming to docker.io/library/hookshot                                                                                                            0.0s
```
</details>

## After
<details>
<summary>
All cached except build steps
</summary>

```
[+] Building 124.2s (22/22) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                   0.0s
 => => transferring dockerfile: 37B                                                                                                                    0.0s
 => [internal] load .dockerignore                                                                                                                      0.0s
 => => transferring context: 34B                                                                                                                       0.0s
 => [internal] load metadata for docker.io/library/node:16-slim                                                                                        0.2s
 => [internal] load metadata for docker.io/library/node:16                                                                                             0.2s
 => [internal] load build context                                                                                                                      0.0s
 => => transferring context: 20.92kB                                                                                                                   0.0s
 => [stage-1 1/7] FROM docker.io/library/node:16-slim@sha256:34a3b4b7c2704ce52372c42b9b7945b41fe8eb98d74e8af472add0b599b6e1ff                          0.0s
 => [builder 1/9] FROM docker.io/library/node:16@sha256:1ed1e17ccabb09038cfb8a965337ebcda51ef9e9d32082164c502d44d9731a02                               0.0s
 => CACHED [builder 2/9] RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal                                                            0.0s
 => CACHED [builder 3/9] RUN apt-get update && apt-get install -y build-essential cmake                                                                0.0s
 => CACHED [builder 4/9] WORKDIR /src                                                                                                                  0.0s
 => CACHED [builder 5/9] COPY package.json yarn.lock ./                                                                                                0.0s
 => CACHED [builder 6/9] RUN yarn --ignore-scripts --pure-lockfile                                                                                     0.0s
 => [builder 7/9] COPY . ./                                                                                                                            0.1s
 => [builder 8/9] RUN node node_modules/esbuild/install.js                                                                                             0.3s
 => [builder 9/9] RUN yarn build                                                                                                                     114.8s
 => CACHED [stage-1 2/7] WORKDIR /bin/matrix-hookshot                                                                                                  0.0s
 => CACHED [stage-1 3/7] COPY --from=builder /src/yarn.lock /src/package.json ./                                                                       0.0s
 => CACHED [stage-1 4/7] RUN yarn --ignore-scripts --production --pure-lockfile && yarn cache clean                                                    0.0s
 => [stage-1 5/7] COPY --from=builder /src/node_modules/@turt2live/matrix-sdk-crypto-nodejs /bin/matrix-hookshot/node_modules/@turt2live/matrix-sdk-c  2.4s
 => [stage-1 6/7] COPY --from=builder /src/lib ./                                                                                                      0.0s
 => [stage-1 7/7] COPY --from=builder /src/public ./public                                                                                             0.0s
 => exporting to image                                                                                                                                 3.9s
 => => exporting layers                                                                                                                                3.9s
 => => writing image sha256:ff21d735d4823e80b08bd78aa4fa00b93d2047886f14a2ff1b3128cb7eeeddea                                                           0.0s
 => => naming to docker.io/library/hookshot                                                                                                            0.0s
```
</details>

