### PR TITLE
Validate figma access token + cleaner errors

### DIFF
--- a/changelog.d/440.misc
+++ b/changelog.d/440.misc
@@ -1,1 +1,1 @@
-Better error logging when validating Figma webhooksd on startup.
+Better error logging when validating Figma webhooks on startup.

--- a/changelog.d/440.misc
+++ b/changelog.d/440.misc
@@ -1,0 +1,1 @@
+Better error logging when validating Figma webhooksd on startup.

--- a/src/figma/index.ts
+++ b/src/figma/index.ts
@@ -1,7 +1,7 @@
 import { BridgeConfigFigma } from "../Config/Config";
 import * as Figma from 'figma-js';
 import { MatrixClient } from "matrix-bot-sdk";
-import { AxiosError, isAxiosError } from "axios";
+import { AxiosError } from "axios";
 import LogWrapper from "../LogWrapper";
 
 export * from "./router";

--- a/src/figma/index.ts
+++ b/src/figma/index.ts
@@ -1,10 +1,11 @@
 import { BridgeConfigFigma } from "../Config/Config";
 import * as Figma from 'figma-js';
 import { MatrixClient } from "matrix-bot-sdk";
-export * from "./router";
-export * from "./types";
+import { AxiosError, isAxiosError } from "axios";
 import LogWrapper from "../LogWrapper";
 
+export * from "./router";
+export * from "./types";
 
 interface FigmaWebhookDefinition {
     id: string;
@@ -15,47 +16,77 @@ interface FigmaWebhookDefinition {
 }
 
 const log = new LogWrapper('FigmaWebhooks');
- 
+
 export async function ensureFigmaWebhooks(figmaConfig: BridgeConfigFigma, matrixClient: MatrixClient) {
     const publicUrl = figmaConfig.publicUrl;
     const axiosConfig = { baseURL: 'https://api.figma.com/v2'};
     
     for (const [instanceName, {accessToken, teamId, passcode}] of Object.entries(figmaConfig.instances)) {
+        const accountDataKey = `figma.${teamId}.webhook_id`;
         const client = Figma.Client({
             personalAccessToken: accessToken
         });
-        const accountDataKey = `figma.${teamId}.webhook_id`;
+
+        try {
+            await client.me();
+        } catch (ex) {
+            const axiosErr = ex as AxiosError;
+            if (axiosErr.isAxiosError) {
+                log.error(`Failed to check figma access token: ${axiosErr.code} ${axiosErr.response?.data?.message ?? ""}`)
+            }
+            throw Error(`Could not validate access token for figma team ${instanceName} (${teamId})`);
+        }
+
         const { webhookId } = await matrixClient.getSafeAccountData<{webhookId: string|null}>(accountDataKey, {webhookId: null});
         let webhookDefinition: FigmaWebhookDefinition|undefined;
         if (webhookId) {
             try {
-                webhookDefinition = (await client.client.get(`webhooks/${webhookId}`, axiosConfig)).data;
+                webhookDefinition = (await client.client.get(`v2/webhooks/${webhookId}`, axiosConfig)).data;
                 log.info(`Found existing hook for Figma instance ${instanceName} ${webhookId}`);
             } catch (ex) {
+                const axiosErr = ex as AxiosError;
+                if (axiosErr.isAxiosError) {
+                    log.error(`Failed to update webhook: ${axiosErr.code} ${axiosErr.response?.data?.message ?? ""}`)
+                }
                 throw Error(`Failed to verify Figma webhooks for ${instanceName}: ${ex.message}`);
             }
         }
         if (webhookDefinition) {
             if (webhookDefinition.endpoint !== publicUrl || webhookDefinition.passcode !== passcode) {
                 log.info(`Existing hook ${webhookId} for ${instanceName} has stale endpoint or passcode, updating`);
-                await client.client.put(`webhooks/${webhookId}`, {
-                    passcode,
-                    endpoint: publicUrl,
-                }, axiosConfig);
+                try {
+                    await client.client.put(`v2/webhooks/${webhookId}`, {
+                        passcode,
+                        endpoint: publicUrl,
+                    }, axiosConfig);
+                } catch (ex) {
+                    const axiosErr = ex as AxiosError;
+                    if (axiosErr.isAxiosError) {
+                        log.error(`Failed to update webhook: ${axiosErr.code} ${axiosErr.response?.data?.message ?? ""}`)
+                    }
+                    throw Error(`Could not update an Figma webhook for instance ${instanceName}`);
+                }
             }
         } else {
             log.info(`No webhook defined for instance ${instanceName}, creating`);
-            const res = await client.client.post(`webhooks`, {
-                passcode,
-                endpoint: publicUrl,
-                description: 'matrix-hookshot',
-                event_type: 'FILE_COMMENT',
-                team_id: teamId
-            }, axiosConfig);
-            webhookDefinition = res.data as FigmaWebhookDefinition;
-            await matrixClient.setAccountData(accountDataKey, {webhookId: webhookDefinition.id});
+            try {
+                const res = await client.client.post(`v2/webhooks`, {
+                    passcode,
+                    endpoint: publicUrl,
+                    description: 'matrix-hookshot',
+                    event_type: 'FILE_COMMENT',
+                    team_id: teamId,
+                }, axiosConfig);
+                webhookDefinition = res.data as FigmaWebhookDefinition;
+                await matrixClient.setAccountData(accountDataKey, {webhookId: webhookDefinition.id});
+            } catch (ex) {
+                const axiosErr = ex as AxiosError;
+                if (axiosErr.isAxiosError) {
+                    log.error(`Failed to create webhook: ${axiosErr.code} ${axiosErr.response?.data?.message ?? ""}`)
+                }
+                throw Error(`Could not create a Figma webhook for instance ${instanceName}`);
+            }
         }
-        // Webhook is ready and set up
     }
 
 }

--- a/src/figma/index.ts
+++ b/src/figma/index.ts
@@ -64,7 +64,7 @@ export async function ensureFigmaWebhooks(figmaConfig: BridgeConfigFigma, matrix
                     if (axiosErr.isAxiosError) {
                         log.error(`Failed to update webhook: ${axiosErr.code} ${axiosErr.response?.data?.message ?? ""}`)
                     }
-                    throw Error(`Could not update an Figma webhook for instance ${instanceName}`);
+                    throw Error(`Could not update an Figma webhook for instance ${instanceName}: ${ex}`);
                 }
             }
         } else {
@@ -84,7 +84,7 @@ export async function ensureFigmaWebhooks(figmaConfig: BridgeConfigFigma, matrix
                 if (axiosErr.isAxiosError) {
                     log.error(`Failed to create webhook: ${axiosErr.code} ${axiosErr.response?.data?.message ?? ""}`)
                 }
-                throw Error(`Could not create a Figma webhook for instance ${instanceName}`);
+                throw Error(`Could not create a Figma webhook for instance ${instanceName}: ${ex}`);
             }
         }
     }


### PR DESCRIPTION
After seeing vague errors in production, it felt wise to make our errors cleaner, and also check that the access token is valid.