### PR TITLE
Add query parameter to scope room config widget to a particular service

### DIFF
--- a/changelog.d/ 441.feature
+++ b/changelog.d/ 441.feature
@@ -1,0 +1,1 @@
+Add query parameter to scope room config widget to a particular service.

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -17,7 +17,8 @@ interface ICompleteState extends IMinimalState {
     roomState: BridgeRoomState,
     supportedServices: {
         [sectionName: string]: boolean;
-    }
+    },
+    serviceScope?: string,
     kind: "invite"|"admin"|"roomConfig",
 }
 
@@ -53,6 +54,7 @@ export default class App extends Component<void, IState> {
         const widgetId = assertParam(qs, 'widgetId');
         const roomId = assertParam(qs, 'roomId');
         const widgetKind = qs.get('kind') as "invite"|"admin"|"roomConfig";
+        const serviceScope = qs.get('serviceScope');
         // Fetch via config.
         this.widgetApi = new WA.WidgetApi(widgetId);
         this.widgetApi.requestCapability(MatrixCapabilities.RequiresClient);
@@ -81,6 +83,7 @@ export default class App extends Component<void, IState> {
             roomState,
             roomId,
             supportedServices,
+            serviceScope: serviceScope || undefined,
             kind: widgetKind,
             busy: false,
         });
@@ -109,7 +112,7 @@ export default class App extends Component<void, IState> {
         } else if (this.state.busy) {
             content = <div class="spinner" />;
         }
-        
+
         if ("kind" in this.state) {
             if (this.state.roomState && this.state.kind === "admin") {
                 content = <AdminSettings bridgeApi={this.bridgeApi} roomState={this.state.roomState} />;
@@ -119,10 +122,11 @@ export default class App extends Component<void, IState> {
                 content = <RoomConfigView
                     roomId={this.state.roomId}
                     supportedServices={this.state.supportedServices}
+                    serviceScope={this.state.serviceScope}
                     bridgeApi={this.bridgeApi}
                     widgetApi={this.widgetApi}
                  />;
-            } 
+            }
         }
 
         if (!content) {

--- a/web/components/RoomConfigView.tsx
+++ b/web/components/RoomConfigView.tsx
@@ -18,6 +18,7 @@ interface IProps {
     widgetApi: WidgetApi,
     bridgeApi: BridgeAPI,
     supportedServices: {[service: string]: boolean},
+    serviceScope?: string,
     roomId: string,
 }
 
@@ -63,7 +64,8 @@ const connections: Record<ConnectionType, IConnectionProps> = {
 };
 
 export default function RoomConfigView(props: IProps) {
-    const [ activeConnectionType, setActiveConnectionType ] = useState<ConnectionType|null>(null);
+    const serviceScope = props.serviceScope && props.supportedServices[props.serviceScope] ? props.serviceScope as ConnectionType : null;
+    const [ activeConnectionType, setActiveConnectionType ] = useState<ConnectionType|null>(serviceScope);
 
     let content;
 
@@ -90,7 +92,11 @@ export default function RoomConfigView(props: IProps) {
 
     return <div className={style.root}>
         <header>
-            {activeConnectionType && <span className={style.backButton} onClick={() => setActiveConnectionType(null)}><span className="chevron" /> Browse integrations</span>}
+            {!serviceScope && activeConnectionType &&
+                <span className={style.backButton} onClick={() => setActiveConnectionType(null)}>
+                    <span className="chevron" /> Browse integrations
+                </span>
+            }
         </header>
         {content}
     </div>;


### PR DESCRIPTION
Adds support for a `serviceScope` query parameter in the config widget URL, which makes it go directly to a particular service (and removes navigation back to the list of services).

For example with `serviceScope=feeds`:

![Screen Shot 2022-08-11 at 2 04 22 PM](https://user-images.githubusercontent.com/20007954/184208730-5aba8aed-0052-4309-8269-973c4e71d3ef.png)

If the value provided for `serviceScope` does not correspond to a supported service, behavior will be as if it wasn't provided.

Fixes #437