### PR TITLE
Remove --no-script from yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ WORKDIR /bin/matrix-hookshot
 
 COPY --from=builder /src/yarn.lock /src/package.json ./
 
-# --ignore-scripts so we don't try to build
-RUN yarn --ignore-scripts --production --pure-lockfile && yarn cache clean
+
+RUN yarn --production --pure-lockfile && yarn cache clean
 
 COPY --from=builder /src/lib ./
 COPY --from=builder /src/public ./public

--- a/changelog.d/448.bugfix
+++ b/changelog.d/448.bugfix
@@ -1,0 +1,1 @@
+Fix issue that would cause the bridge not to start when using Docker.


### PR DESCRIPTION
As it turns out, we need to run the script to build the all important crypto modules that we don't use. The --no-script is intended to avoid us trying to build the project, but in practise I think this does more harm than good (we don't seem to build when the production flag is used)