### PR TITLE
Fix GitHub/Jira/GitLab login not checking for permissions early enough

### DIFF
--- a/changelog.d/461.bugfix
+++ b/changelog.d/461.bugfix
@@ -1,0 +1,1 @@
+Fix a bug users without "login" permissions could run login commands for GitHub/GitLab/JIRA, but get an error when attempting to store the token. Users now have their permissions checked earlier.

--- a/src/AdminRoom.ts
+++ b/src/AdminRoom.ts
@@ -398,7 +398,7 @@ export class AdminRoom extends AdminRoomCommandHandler {
         return this.emit('open.gitlab-issue', getIssueOpts, issue, instanceName, instance);
     }
 
-    @botCommand("gitlab personaltoken", {help: "Set your personal access token for GitLab", requiredArgs: ['instanceName', 'accessToken'], category: Category.Gitlab})
+    @botCommand("gitlab personaltoken", {help: "Set your personal access token for GitLab", requiredArgs: ['instanceName', 'accessToken'], category: Category.Gitlab, permissionLevel: BridgePermissionLevel.login})
     public async setGitLabPersonalAccessToken(instanceName: string, accessToken: string) {
         let me: GetUserResponse;
         if (!this.config.gitlab) {
@@ -419,7 +419,7 @@ export class AdminRoom extends AdminRoomCommandHandler {
         return this.tokenStore.storeUserToken("gitlab", this.userId, accessToken, instance.url);
     }
 
-    @botCommand("gitlab hastoken", {help: "Check if you have a token stored for GitLab", requiredArgs: ["instanceName"], category: Category.Gitlab})
+    @botCommand("gitlab hastoken", {help: "Check if you have a token stored for GitLab", requiredArgs: ["instanceName"], category: Category.Gitlab, permissionLevel: BridgePermissionLevel.login})
     public async gitlabHasPersonalToken(instanceName: string) {
         if (!this.config.gitlab) {
             return this.sendNotice("The bridge is not configured with GitLab support.");

--- a/src/Github/AdminCommands.ts
+++ b/src/Github/AdminCommands.ts
@@ -5,10 +5,11 @@ import { CommandError, TokenError, TokenErrorCode } from "../errors";
 import { GithubInstance } from "./GithubInstance";
 import { GitHubOAuthToken } from "./Types";
 import LogWrapper from "../LogWrapper";
+import { BridgePermissionLevel } from "../Config/Config";
 
 const log = new LogWrapper('GitHubBotCommands');
 export class GitHubBotCommands extends AdminRoomCommandHandler {
-    @botCommand("github login", {help: "Log in to GitHub", category: Category.Github})
+    @botCommand("github login", {help: "Log in to GitHub", category: Category.Github, permissionLevel: BridgePermissionLevel.login})
     public async loginCommand() {
         if (!this.config.github) {
             throw new CommandError("no-github-support", "The bridge is not configured with GitHub support.");
@@ -29,7 +30,7 @@ export class GitHubBotCommands extends AdminRoomCommandHandler {
         return this.sendNotice(`Open ${url} to link your account to the bridge.`);
     }
 
-    @botCommand("github setpersonaltoken", {help: "Set your personal access token for GitHub", requiredArgs: ['accessToken'], category: Category.Github})
+    @botCommand("github setpersonaltoken", {help: "Set your personal access token for GitHub", requiredArgs: ['accessToken'], category: Category.Github, permissionLevel: BridgePermissionLevel.login})
     public async setGHPersonalAccessToken(accessToken: string) {
         if (!this.config.github) {
             throw new CommandError("no-github-support", "The bridge is not configured with GitHub support.");
@@ -43,11 +44,11 @@ export class GitHubBotCommands extends AdminRoomCommandHandler {
             await this.sendNotice("Could not authenticate with GitHub. Is your token correct?");
             return;
         }
-        await this.sendNotice(`Connected as ${me.data.login}. Token stored.`);
         await this.tokenStore.storeUserToken("github", this.userId, JSON.stringify({access_token: accessToken, token_type: 'pat'} as GitHubOAuthToken));
+        await this.sendNotice(`Connected as ${me.data.login}. Token stored.`);
     }
 
-    @botCommand("github status", {help: "Check the status of your GitHub authentication", category: Category.Github})
+    @botCommand("github status", {help: "Check the status of your GitHub authentication", category: Category.Github, permissionLevel: BridgePermissionLevel.login})
     public async getTokenStatus() {
         if (!this.config.github) {
             throw new CommandError("no-github-support", "The bridge is not configured with GitHub support.");

--- a/src/Jira/AdminCommands.ts
+++ b/src/Jira/AdminCommands.ts
@@ -2,11 +2,12 @@ import { AdminRoomCommandHandler, Category } from "../AdminRoomCommandHandler";
 import { botCommand } from "../BotCommands";
 import { JiraAPIAccessibleResource } from "./Types";
 import LogWrapper from "../LogWrapper";
+import { BridgePermissionLevel } from "../Config/Config";
 
 const log = new LogWrapper('JiraBotCommands');
 
 export class JiraBotCommands extends AdminRoomCommandHandler {
-    @botCommand("jira login", {help: "Log in to JIRA", category: Category.Jira})
+    @botCommand("jira login", {help: "Log in to JIRA", category: Category.Jira, permissionLevel: BridgePermissionLevel.login})
     public async loginCommand() {
         if (!this.config.jira?.oauth || !this.tokenStore.jiraOAuth) {
             this.sendNotice(`Bot is not configured with JIRA OAuth support.`);
@@ -18,7 +19,7 @@ export class JiraBotCommands extends AdminRoomCommandHandler {
     }
 
 
-    @botCommand("jira logout", {help: "Clear any login information", category: Category.Jira})
+    @botCommand("jira logout", {help: "Clear any login information", category: Category.Jira, permissionLevel: BridgePermissionLevel.login})
     public async logout() {
         if (!this.config.jira?.oauth || !this.tokenStore.jiraOAuth) {
             this.sendNotice(`Bot is not configured with JIRA OAuth support.`);
@@ -30,7 +31,7 @@ export class JiraBotCommands extends AdminRoomCommandHandler {
         return this.sendNotice(`No JIRA account was linked to your Matrix user.`);
     }
 
-    @botCommand("jira whoami", {help: "Determine JIRA identity", category: Category.Jira})
+    @botCommand("jira whoami", {help: "Determine JIRA identity", category: Category.Jira, permissionLevel: BridgePermissionLevel.login})
     public async whoami() {
         if (!this.config.jira) {
             await this.sendNotice(`Bot is not configured with JIRA OAuth support.`);


### PR DESCRIPTION
We lock logging into the bridge behind a permission level, "login". When attempting to login, the commands will always check permissions at the point of token storage but they were not checking at the point of executing the command, which meant users got confusing messages like:

> Token stored!
> Nevermind, you never had permission to do this!

This addresses the problem by simply being explicit about the permission level in the command metadata.