### PR TITLE
Useful JSON logger formatting

### DIFF
--- a/changelog.d/463.feature
+++ b/changelog.d/463.feature
@@ -1,0 +1,1 @@
+JSON logging output now includes new keys such as `error` and `args`.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -229,3 +229,34 @@ logging:
   #  Ignored if `json` is enabled. The timestamp format to use in log lines. See https://github.com/taylorhakes/fecha#formatting-tokens for help on formatting tokens.
   timestampFormat: HH:mm:ss:SSS
 ```
+
+
+#### JSON Logging
+
+Enabling the `json` option will configure hookshot to output structured JSON logs. The schema looks like:
+
+```json5
+{
+    // The level of the log.
+    "level": "WARN",
+    // The log message.
+    "message": "Failed to connect to homeserver",
+    // The module which emitted the log line.
+    "module": "Bridge",
+    // The timestamp of the log line.
+    "timestamp": "11:45:02:198",
+    // Optional error field, if the log includes an Error
+    "error": "connect ECONNREFUSED 127.0.0.1:8008",
+    // Additional context, possibly including the error body.
+    "args": [
+        {
+            "address": "127.0.0.1",
+            "code": "ECONNREFUSED",
+            "errno": -111,
+            "port": 8008,
+            "syscall": "connect"
+        },
+        "retrying in 5s"
+    ]
+}
+```

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -124,8 +124,7 @@ export class Webhooks extends EventEmitter {
     private async onGitHubPayload({id, name, payload}: EmitterWebhookEvent) {
         const action = (payload as unknown as {action: string|undefined}).action;
         const eventName =  `github.${name}${action ? `.${action}` : ""}`;
-        log.info(`Got GitHub webhook event ${id} ${eventName}`);
-        log.debug("Payload:", payload);
+        log.info(`Got GitHub webhook event ${id} ${eventName}`, payload);
         try {
             await this.queue.push({
                 eventName,
@@ -186,7 +185,7 @@ export class Webhooks extends EventEmitter {
     }
 
     public async onGitHubGetOauth(req: Request<unknown, unknown, unknown, {error?: string, error_description?: string, code?: string, state?: string}> , res: Response) {
-        log.info(`Got new oauth request for ${req.query.state}`);
+        log.info(`Got new oauth request`, { state: req.query.state });
         try {
             if (!this.config.github || !this.config.github.oauth) {
                 return res.status(500).send(`<p>Bridge is not configured with OAuth support</p>`);


### PR DESCRIPTION
This PR attempts to make the JSON logger output more useful by pulling out metadata from the logs and storing them as keys. However, there was a fair amount of restitching needed to do this.