### PR TITLE
Logging fixes

### DIFF
--- a/changelog.d/467.bugfix
+++ b/changelog.d/467.bugfix
@@ -1,0 +1,1 @@
+Fixed issue where log lines would only be outputted when the `logging.level` is `debug`.

--- a/src/App/BridgeApp.ts
+++ b/src/App/BridgeApp.ts
@@ -49,6 +49,11 @@ async function start() {
 }
 
 start().catch((ex) => {
-    log.error("BridgeApp encountered an error and has stopped:", ex);
+    if (LogWrapper.configured) {
+        log.error("BridgeApp encountered an error and has stopped:", ex);
+    } else {
+        // eslint-disable-next-line no-console
+        console.error("BridgeApp encountered an error and has stopped", ex);
+    }
     process.exit(1);
 });

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -88,6 +88,7 @@ export class Bridge {
 
     public async start() {
         log.info('Starting up');
+        await this.tokenStore.load();
         await this.storage.connect?.();
         await this.queue.connect?.();
 
@@ -140,7 +141,6 @@ export class Bridge {
         }
 
 
-        await this.tokenStore.load();
         const connManager = this.connectionManager = new ConnectionManager(this.as,
             this.config, this.tokenStore, this.commentProcessor, this.messageClient, this.storage, this.github);
 

--- a/src/LogWrapper.ts
+++ b/src/LogWrapper.ts
@@ -161,7 +161,7 @@ export default class LogWrapper {
      * @param {*[]} messageOrObject The data to log
      */
     public debug(...messageOrObject: MsgType[]) {
-        LogWrapper.winstonLog.debug("debug", { module: this.module, data: messageOrObject });
+        LogWrapper.winstonLog.log("debug", { module: this.module, data: messageOrObject });
     }
 
     /**
@@ -169,7 +169,7 @@ export default class LogWrapper {
      * @param {*[]} messageOrObject The data to log
      */
     public error(...messageOrObject: MsgType[]) {
-        LogWrapper.winstonLog.error("error", { module: this.module, data: messageOrObject });
+        LogWrapper.winstonLog.log("error", { module: this.module, data: messageOrObject });
     }
 
     /**
@@ -177,7 +177,7 @@ export default class LogWrapper {
      * @param {*[]} messageOrObject The data to log
      */
     public info(...messageOrObject: MsgType[]) {
-        LogWrapper.winstonLog.info("info", { module: this.module, data: messageOrObject });
+        LogWrapper.winstonLog.log("info", { module: this.module, data: messageOrObject });
     }
 
     /**
@@ -185,6 +185,6 @@ export default class LogWrapper {
      * @param {*[]} messageOrObject The data to log
      */
     public warn(...messageOrObject: MsgType[]) {
-        LogWrapper.winstonLog.warn("warn", { module: this.module, data: messageOrObject });
+        LogWrapper.winstonLog.log("warn", { module: this.module, data: messageOrObject });
     }
 }

--- a/src/LogWrapper.ts
+++ b/src/LogWrapper.ts
@@ -29,6 +29,12 @@ interface HookshotLogInfo extends winston.Logform.TransformableInfo {
 }
 export default class LogWrapper {
 
+    static isConfigured: boolean;
+
+    public static get configured() {
+        return this.isConfigured;
+    }
+
     static formatMsgTypeArray(...data: MsgType[]): string {
         data = data.flat();
         return data.map(obj => {
@@ -144,6 +150,7 @@ export default class LogWrapper {
 
         LogService.setLevel(LogLevel.fromString(cfg.level));
         LogService.debug("LogWrapper", "Reconfigured logging");
+        LogWrapper.isConfigured = true;
     }
 
     constructor(private module: string) { }

--- a/src/LogWrapper.ts
+++ b/src/LogWrapper.ts
@@ -29,7 +29,7 @@ interface HookshotLogInfo extends winston.Logform.TransformableInfo {
 }
 export default class LogWrapper {
 
-    static isConfigured: boolean;
+    private static isConfigured: boolean;
 
     public static get configured() {
         return this.isConfigured;

--- a/src/LogWrapper.ts
+++ b/src/LogWrapper.ts
@@ -169,7 +169,7 @@ export default class LogWrapper {
      * @param {*[]} messageOrObject The data to log
      */
     public error(...messageOrObject: MsgType[]) {
-        LogWrapper.winstonLog.debug("error", { module: this.module, data: messageOrObject });
+        LogWrapper.winstonLog.error("error", { module: this.module, data: messageOrObject });
     }
 
     /**
@@ -177,7 +177,7 @@ export default class LogWrapper {
      * @param {*[]} messageOrObject The data to log
      */
     public info(...messageOrObject: MsgType[]) {
-        LogWrapper.winstonLog.debug("info", { module: this.module, data: messageOrObject });
+        LogWrapper.winstonLog.info("info", { module: this.module, data: messageOrObject });
     }
 
     /**
@@ -185,6 +185,6 @@ export default class LogWrapper {
      * @param {*[]} messageOrObject The data to log
      */
     public warn(...messageOrObject: MsgType[]) {
-        LogWrapper.winstonLog.debug("warn", { module: this.module, data: messageOrObject });
+        LogWrapper.winstonLog.warn("warn", { module: this.module, data: messageOrObject });
     }
 }


### PR DESCRIPTION
#463 broke logging so that everything now logs at debug, which is less than helpful.

This also fixes the case where we don't log out errors before logging is configured.