### PR TITLE
Fix feed.success crashing the process due to a typing issue

### DIFF
--- a/changelog.d/469.bugfix
+++ b/changelog.d/469.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where reading RSS feeds could crash the process.

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -615,9 +615,9 @@ export class Bridge {
             (data) => connManager.getConnectionsForFeedUrl(data.feed.url),
             (c, data) => c.handleFeedEntry(data),
         );
-        this.bindHandlerToQueue<FeedEntry, FeedConnection>(
+        this.bindHandlerToQueue<{url: string}, FeedConnection>(
             "feed.success",
-            (data) => connManager.getConnectionsForFeedUrl(data.feed.url),
+            (data) => connManager.getConnectionsForFeedUrl(data.url),
             c => c.handleFeedSuccess(),
         );
         this.bindHandlerToQueue<FeedError, FeedConnection>(

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -40,7 +40,7 @@ import { getAppservice } from "./appservice";
 import { JiraOAuthRequestCloud, JiraOAuthRequestOnPrem, JiraOAuthRequestResult } from "./Jira/OAuth";
 import { GenericWebhookEvent, GenericWebhookEventResult } from "./generic/types";
 import { SetupWidget } from "./Widgets/SetupWidget";
-import { FeedEntry, FeedError, FeedReader } from "./feeds/FeedReader";
+import { FeedEntry, FeedError, FeedReader, FeedSuccess } from "./feeds/FeedReader";
 const log = new LogWrapper("Bridge");
 
 export class Bridge {

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -615,7 +615,7 @@ export class Bridge {
             (data) => connManager.getConnectionsForFeedUrl(data.feed.url),
             (c, data) => c.handleFeedEntry(data),
         );
-        this.bindHandlerToQueue<{url: string}, FeedConnection>(
+        this.bindHandlerToQueue<FeedSuccess, FeedConnection>(
             "feed.success",
             (data) => connManager.getConnectionsForFeedUrl(data.url),
             c => c.handleFeedSuccess(),

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -210,7 +210,7 @@ export class FeedReader {
                     const entry = {
                         feed: {
                             title: feed.title ? stripHtml(feed.title) : null,
-                            url: url.toString()
+                            url: url,
                         },
                         title: item.title ? stripHtml(item.title) : null,
                         link: item.link || null,
@@ -233,7 +233,7 @@ export class FeedReader {
                     const newSeenItems = Array.from(new Set([ ...newGuids, ...seenGuids ]).values()).slice(0, maxGuids);
                     this.seenEntries.set(url, newSeenItems);
                 }
-                this.queue.push<undefined>({ eventName: 'feed.success', sender: 'FeedReader', data: undefined});
+                this.queue.push<{url: string}>({ eventName: 'feed.success', sender: 'FeedReader', data: { url: url } });
             } catch (err: unknown) {
                 const error = err instanceof Error ? err : new Error(`Unknown error ${err}`);
                 const feedError = new FeedError(url.toString(), error, fetchKey);

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -56,7 +56,7 @@ export interface FeedEntry {
 }
 
 export interface FeedSuccess {
-    url: string;
+    url: string,
 }
 
 interface AccountData {

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -55,6 +55,10 @@ export interface FeedEntry {
     fetchKey: string,
 }
 
+export interface FeedSuccess {
+    url: string;
+}
+
 interface AccountData {
     [url: string]: string[],
 }
@@ -233,7 +237,7 @@ export class FeedReader {
                     const newSeenItems = Array.from(new Set([ ...newGuids, ...seenGuids ]).values()).slice(0, maxGuids);
                     this.seenEntries.set(url, newSeenItems);
                 }
-                this.queue.push<{url: string}>({ eventName: 'feed.success', sender: 'FeedReader', data: { url: url } });
+                this.queue.push<FeedSuccess>({ eventName: 'feed.success', sender: 'FeedReader', data: { url: url } });
             } catch (err: unknown) {
                 const error = err instanceof Error ? err : new Error(`Unknown error ${err}`);
                 const feedError = new FeedError(url.toString(), error, fetchKey);


### PR DESCRIPTION
This caused:

```
/bin/matrix-hookshot/Bridge.js:402
        this.bindHandlerToQueue("feed.success", (data) => connManager.getConnectionsForFeedUrl(data.feed.url), c => c.handleFeedSuccess());
                                                                                                    ^

TypeError: Cannot read properties of undefined (reading 'feed')
    at Bridge.<anonymous> (/bin/matrix-hookshot/Bridge.js:402:101)
    at LocalMQ.<anonymous> (/bin/matrix-hookshot/Bridge.js:494:61)
    at LocalMQ.emit (node:events:513:28)
    at LocalMQ.push (/bin/matrix-hookshot/MessageQueue/LocalMQ.js:31:14)
    at FeedReader.pollFeeds (/bin/matrix-hookshot/feeds/FeedReader.js:199:28)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)

```