### PR TITLE
Add `getMediaUrl` function for generic webhooks

### DIFF
--- a/docs/setup/webhooks.md
+++ b/docs/setup/webhooks.md
@@ -177,3 +177,28 @@ if (data.counter > data.maxValue) {
     result = `*Everything is fine*, the counter is under by ${data.maxValue - data.counter}`
 }
 ```
+
+
+### Functions
+
+The scripting environment exposes some convienence functions for doing advanced transformations
+of your data. 
+
+#### `getMediaUrl(url: string)`
+
+This function will take an input URL and return a deferred MXC URL, which can then be inserted
+into your response to display an image. If the input URL fails to be resolved, the deferred
+URL will be left in place.
+
+There is a maximum timeout for the fetch request of 5 seconds.
+
+#### Example
+
+```js
+const mxc = getMediaUrl(data.myimage);
+return {
+  "version": "v2" // The version of the schema being returned from the function. This is always "v2".
+  "plain": `![My image](${mxc})`, // The plaintext value to be used for the Matrix message.
+  "html": `<img src="${mxc}" alt="My image"></img>`, // The HTML value to be used for the Matrix message. If not provided, plain will be interpreted as markdown.
+};
+```

--- a/src/Connections/GenericHook.ts
+++ b/src/Connections/GenericHook.ts
@@ -10,6 +10,7 @@ import { ApiError, ErrCode } from "../api";
 import { BaseConnection } from "./BaseConnection";
 import { GetConnectionsResponseItem } from "../provisioning/api";
 import { BridgeConfigGenericWebhooks } from "../Config/Config";
+import { randomUUID } from "crypto";
 
 export interface GenericHookConnectionState extends IConnectionState {
     /**
@@ -293,7 +294,7 @@ export class GenericHookConnection extends BaseConnection implements IConnection
         return msg;
     }
 
-    public executeTransformationFunction(data: unknown): {plain: string, html?: string, msgtype?: string}|null {
+    public async executeTransformationFunction(data: unknown): Promise<{plain: string, html?: string, msgtype?: string}|null> {
         if (!this.transformationFunction) {
             throw Error('Transformation function not defined');
         }
@@ -306,6 +307,15 @@ export class GenericHookConnection extends BaseConnection implements IConnection
         });
         vm.setGlobal('HookshotApiVersion', 'v2');
         vm.setGlobal('data', data);
+
+        // Handle media
+        const mediaUrls = new Map<string,string>();
+        vm.setGlobal('getMediaUrl', (url: string) => {
+            const uuid = `mxc-deferred:${randomUUID()}`;
+            mediaUrls.set(uuid, url);
+            return uuid;
+        });
+
         vm.run(this.transformationFunction);
         const result = vm.getGlobal('result');
 
@@ -324,7 +334,7 @@ export class GenericHookConnection extends BaseConnection implements IConnection
             return null; // No-op
         }
 
-        const plain = transformationResult.plain;
+        let plain = transformationResult.plain;
         if (typeof plain !== "string") {
             throw Error("Result returned from transformation didn't provide a string value for plain");
         }
@@ -333,6 +343,25 @@ export class GenericHookConnection extends BaseConnection implements IConnection
         }
         if (transformationResult.msgtype && typeof transformationResult.msgtype !== "string") {
             throw Error("Result returned from transformation didn't provide a string value for msgtype");
+        }
+
+        // Transform media
+        for (const [uuid, mediaurl] of mediaUrls) {
+            // Ensure the media exists
+            if (!plain.includes(uuid) && !transformationResult.html?.includes(uuid)) {
+                log.debug(`Media ${uuid} requested but not used`);
+                continue;
+            }
+            try {
+                const mxcUri = await this.as.botClient.uploadContentFromUrl(mediaurl);
+                plain = plain.replace(uuid, mxcUri);
+                if (transformationResult.html) {
+                    transformationResult.html = transformationResult.html.replace(transformationResult.html, mxcUri);
+                }
+            } catch (ex) {
+                log.warn(`Failed to fetch media for transformation ${mediaurl}`, ex.message);
+                log.debug(ex);
+            }
         }
 
         return {
@@ -355,7 +384,7 @@ export class GenericHookConnection extends BaseConnection implements IConnection
             content = this.transformHookData(data);
         } else {
             try {
-                const potentialContent = this.executeTransformationFunction(data);
+                const potentialContent = await this.executeTransformationFunction(data);
                 if (potentialContent === null) {
                     // Explitly no action
                     return true;


### PR DESCRIPTION
Fixes #470 

This function will return a deferred URI, and then attempt to perform a download+upload to a media repo after the script has finished processing.