### PR TITLE
Add support for specifying `appservice` as a listener

### DIFF
--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -725,6 +725,7 @@ export class Bridge {
         if (this.config.metrics?.enabled) {
             this.listener.bindResource('metrics', Metrics.expressRouter);
         }
+        this.listener.bindResource('appservice', this.as.expressAppInstance._router);
         await this.as.begin();
         log.info(`Bridge is now ready. Found ${this.connectionManager.size} connections`);
         this.ready = true;

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -372,8 +372,8 @@ interface BridgeConfigBridge {
     domain: string;
     url: string;
     mediaUrl?: string;
-    port: number;
-    bindAddress: string;
+    port?: number;
+    bindAddress?: string;
     pantalaimon?: {
         url: string;
         username: string;
@@ -584,6 +584,15 @@ export class BridgeConfig {
                 port: configData.widgets.port,
             });
             log.warn("The `widgets` configuration still specifies a port/bindAddress. This should be moved to the `listeners` config.");
+        }
+
+        if (this.bridge.port) {
+            this.listeners.push({
+                resources: ['appservice'],
+                port: this.bridge.port,
+                bindAddress: this.bridge.bindAddress,
+            })
+            log.warn("The `bridge` configuration still specifies a port/bindAddress. This should be moved to the `listeners` config.");
         }
 
         const hasWidgetListener = !!this.listeners.find(l => l.resources.includes('widgets'));

--- a/src/ListenerService.ts
+++ b/src/ListenerService.ts
@@ -5,8 +5,8 @@ import { errorMiddleware } from "./api";
 
 // Appserices can't be handled yet because the bot-sdk maintains control of it.
 // See https://github.com/turt2live/matrix-bot-sdk/issues/191
-export type ResourceName = "webhooks"|"widgets"|"metrics"|"provisioning";
-export const ResourceTypeArray: ResourceName[] = ["webhooks","widgets","metrics","provisioning"];
+export type ResourceName = "webhooks"|"widgets"|"metrics"|"provisioning"|"appservice";
+export const ResourceTypeArray: ResourceName[] = ["webhooks","widgets","metrics","provisioning","appservice"];
 
 export interface BridgeConfigListener {
     bindAddress?: string;


### PR DESCRIPTION
This code is slightly janky, but allows us to specify the appservice listener alongside our other listeners. It does this by mocking out the express app slightly so that bot-sdk cannot start it, but reusing the route configuration with the ListenerService logic we use across the rest of hookshot.