### PR TITLE
Add Logger tests

### DIFF
--- a/changelog.d/478.misc
+++ b/changelog.d/478.misc
@@ -1,0 +1,1 @@
+Fix a bug where the bridge can crash when JSON logging is enabled.

--- a/src/App/BridgeApp.ts
+++ b/src/App/BridgeApp.ts
@@ -8,7 +8,7 @@ import { UserNotificationWatcher } from "../Notifications/UserNotificationWatche
 import { ListenerService } from "../ListenerService";
 import { Logging } from "matrix-appservice-bridge";
 
-LogWrapper.configureLogging({level: "info"});
+LogWrapper.root.configureLogging({level: "info"});
 const log = new LogWrapper("App");
 
 async function start() {
@@ -17,7 +17,7 @@ async function start() {
     const config = await BridgeConfig.parseConfig(configFile, process.env);
     const registration = await parseRegistrationFile(registrationFile);
     const listener = new ListenerService(config.listeners);
-    LogWrapper.configureLogging(config.logging);
+    LogWrapper.root.configureLogging(config.logging);
     // Bridge SDK doesn't support trace, use "debug" instead.
     const bridgeSdkLevel = config.logging.level === "trace" ? "debug" : config.logging.level;
     Logging.configure({console: bridgeSdkLevel });
@@ -49,7 +49,7 @@ async function start() {
 }
 
 start().catch((ex) => {
-    if (LogWrapper.configured) {
+    if (LogWrapper.root.configured) {
         log.error("BridgeApp encountered an error and has stopped:", ex);
     } else {
         // eslint-disable-next-line no-console

--- a/src/App/GithubWebhookApp.ts
+++ b/src/App/GithubWebhookApp.ts
@@ -11,7 +11,7 @@ const log = new LogWrapper("App");
 async function start() {
     const configFile = process.argv[2] || "./config.yml";
     const config = await BridgeConfig.parseConfig(configFile, process.env);
-    LogWrapper.configureLogging(config.logging);
+    LogWrapper.root.configureLogging(config.logging);
     const listener = new ListenerService(config.listeners);
     if (config.metrics) {
         if (!config.metrics.port) {

--- a/src/App/MatrixSenderApp.ts
+++ b/src/App/MatrixSenderApp.ts
@@ -12,7 +12,7 @@ async function start() {
     const registrationFile = process.argv[3] || "./registration.yml";
     const config = await BridgeConfig.parseConfig(configFile, process.env);
     const registration = await parseRegistrationFile(registrationFile);
-    LogWrapper.configureLogging(config.logging);
+    LogWrapper.root.configureLogging(config.logging);
     const listener = new ListenerService(config.listeners);
     const sender = new MatrixSender(config, registration);
     if (config.metrics) {

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -661,7 +661,7 @@ export async function parseRegistrationFile(filename: string) {
 
 // Can be called directly
 if (require.main === module) {
-    LogWrapper.configureLogging({level: "info"});
+    LogWrapper.root.configureLogging({level: "info"});
     BridgeConfig.parseConfig(process.argv[2] || "config.yml", process.env).then(() => {
         // eslint-disable-next-line no-console
         console.log('Config successfully validated.');

--- a/src/Connections/CommandConnection.ts
+++ b/src/Connections/CommandConnection.ts
@@ -59,7 +59,7 @@ export abstract class CommandConnection<StateType extends IConnectionState = ICo
                 msgtype: "m.notice",
                 body: humanError ? `Failed to handle command: ${humanError}` : "Failed to handle command.",
             });
-            log.warn(`Failed to handle command:`, error);
+            log.warn(`Failed to handle command:`, error ?? 'Unknown error');
             return true;
         } else {
             const reaction = commandResult.result?.reaction || '✅';

--- a/src/LogWrapper.ts
+++ b/src/LogWrapper.ts
@@ -147,7 +147,7 @@ export class GlobalLogger {
         });
 
         LogService.setLevel(LogLevel.fromString(cfg.level));
-        //LogService.debug("LogWrapper", "Reconfigured logging");
+        LogService.debug("LogWrapper", "Reconfigured logging");
         this.isConfigured = true;
     }
 }

--- a/src/LogWrapper.ts
+++ b/src/LogWrapper.ts
@@ -47,7 +47,7 @@ export default class LogWrapper {
 
     static messageFormatter(info: HookshotLogInfo): string {
         const logPrefix = `${info.level} ${info.timestamp} [${info.module}] `;
-        return logPrefix + this.formatMsgTypeArray(info.data);
+        return logPrefix + this.formatMsgTypeArray(info.data ?? []);
     }
 
     static winstonLog: winston.Logger;
@@ -78,7 +78,7 @@ export default class LogWrapper {
         if (cfg.json) {
             formatters.push((format((info) => {
                 const hsData = {...info as HookshotLogInfo}.data;
-                const firstArg = hsData.shift();
+                const firstArg = hsData?.shift() ?? 'undefined';
                 const result: winston.Logform.TransformableInfo = {
                     level: info.level,
                     module: info.module,
@@ -128,7 +128,7 @@ export default class LogWrapper {
             },
             warn: (module: string, ...messageOrObject: MsgType[]) => {
                 if (isMessageNoise(messageOrObject)) {
-                    log.debug(formatBotSdkMessage(module, ...messageOrObject));
+                    log.log("debug", formatBotSdkMessage(module, ...messageOrObject));
                     return;
                 }
                 log.log("warn", formatBotSdkMessage(module, ...messageOrObject));
@@ -153,38 +153,42 @@ export default class LogWrapper {
         LogWrapper.isConfigured = true;
     }
 
-    constructor(private module: string) { }
+    constructor(private module: string) {
+    }
 
     /**
      * Logs to the DEBUG channel
-     * @param {string} module The module being logged
-     * @param {*[]} messageOrObject The data to log
+     * @param msg The message or data to log.
+     * @param additionalData Additonal context.
      */
-    public debug(...messageOrObject: MsgType[]) {
-        LogWrapper.winstonLog.log("debug", { module: this.module, data: messageOrObject });
+    public debug(msg: MsgType, ...additionalData: MsgType[]) {
+        LogWrapper.winstonLog.log("debug", { module: this.module, data: [msg, ...additionalData] });
     }
 
     /**
      * Logs to the ERROR channel
-     * @param {*[]} messageOrObject The data to log
+     * @param msg The message or data to log.
+     * @param additionalData Additonal context.
      */
-    public error(...messageOrObject: MsgType[]) {
-        LogWrapper.winstonLog.log("error", { module: this.module, data: messageOrObject });
+    public error(msg: MsgType, ...additionalData: MsgType[]) {
+        LogWrapper.winstonLog.log("error", { module: this.module, data: [msg, ...additionalData] });
     }
 
     /**
      * Logs to the INFO channel
-     * @param {*[]} messageOrObject The data to log
+     * @param msg The message or data to log.
+     * @param additionalData Additonal context.
      */
-    public info(...messageOrObject: MsgType[]) {
-        LogWrapper.winstonLog.log("info", { module: this.module, data: messageOrObject });
+    public info(msg: MsgType, ...additionalData: MsgType[]) {
+        LogWrapper.winstonLog.log("info", { module: this.module, data: [msg, ...additionalData] });
     }
 
     /**
      * Logs to the WARN channel
-     * @param {*[]} messageOrObject The data to log
+     * @param msg The message or data to log.
+     * @param additionalData Additonal context.
      */
-    public warn(...messageOrObject: MsgType[]) {
-        LogWrapper.winstonLog.log("warn", { module: this.module, data: messageOrObject });
+    public warn(msg: MsgType, ...additionalData: MsgType[]) {
+        LogWrapper.winstonLog.log("warn", { module: this.module, data: [msg, ...additionalData] });
     }
 }

--- a/src/LogWrapper.ts
+++ b/src/LogWrapper.ts
@@ -27,35 +27,25 @@ function isMessageNoise(messageOrObject: MsgType[]) {
 interface HookshotLogInfo extends winston.Logform.TransformableInfo {
     data: MsgType[];
 }
-export default class LogWrapper {
+export class GlobalLogger {
+    private isConfigured = false;
 
-    private static isConfigured: boolean;
-
-    public static get configured() {
+    public get configured() {
         return this.isConfigured;
     }
 
-    static formatMsgTypeArray(...data: MsgType[]): string {
-        data = data.flat();
-        return data.map(obj => {
-            if (typeof obj === "string") {
-                return obj;
-            }
-            return util.inspect(obj);
-        }).join(" ");
+    private winstonLog?: winston.Logger;
+
+    public get winston() {
+        return this.winstonLog;
     }
 
-    static messageFormatter(info: HookshotLogInfo): string {
-        const logPrefix = `${info.level} ${info.timestamp} [${info.module}] `;
-        return logPrefix + this.formatMsgTypeArray(info.data ?? []);
-    }
-
-    static winstonLog: winston.Logger;
-
-    public static configureLogging(cfg: BridgeConfigLogging) {
+    public configureLogging(cfg: BridgeConfigLogging, debugStream?: NodeJS.WritableStream) {
         if (typeof cfg === "string") {
             cfg = { level: cfg };
         }
+
+        this.winstonLog?.close();
 
         const formatters = [
             winston.format.timestamp({
@@ -77,7 +67,7 @@ export default class LogWrapper {
 
         if (cfg.json) {
             formatters.push((format((info) => {
-                const hsData = {...info as HookshotLogInfo}.data;
+                const hsData = [...(info as HookshotLogInfo).data];
                 const firstArg = hsData?.shift() ?? 'undefined';
                 const result: winston.Logform.TransformableInfo = {
                     level: info.level,
@@ -104,17 +94,25 @@ export default class LogWrapper {
             formatters.push(winston.format.printf(i => LogWrapper.messageFormatter(i as HookshotLogInfo)));
         }
 
+        const formatter: winston.Logform.Format = winston.format.combine(...formatters);
         const log = this.winstonLog = winston.createLogger({
             level: cfg.level,
             transports: [
+                debugStream ? new winston.transports.Stream({
+                    stream: debugStream,
+                    format: formatter,
+                }) :
                 new winston.transports.Console({
-                    format: winston.format.combine(...formatters),
+                    format: formatter,
                 }),
             ],
         });
 
         function formatBotSdkMessage(module: string, ...messageOrObject: MsgType[]) {
-            return { module, data: [LogWrapper.formatMsgTypeArray(messageOrObject)] };
+            return {
+                module,
+                data: [LogWrapper.formatMsgTypeArray(messageOrObject)]
+            };
         }
 
         LogService.setLogger({
@@ -149,11 +147,29 @@ export default class LogWrapper {
         });
 
         LogService.setLevel(LogLevel.fromString(cfg.level));
-        LogService.debug("LogWrapper", "Reconfigured logging");
-        LogWrapper.isConfigured = true;
+        //LogService.debug("LogWrapper", "Reconfigured logging");
+        this.isConfigured = true;
+    }
+}
+export default class LogWrapper {
+    static readonly root = new GlobalLogger();
+
+    static formatMsgTypeArray(...data: MsgType[]): string {
+        data = data.flat();
+        return data.map(obj => {
+            if (typeof obj === "string") {
+                return obj;
+            }
+            return util.inspect(obj);
+        }).join(" ");
     }
 
-    constructor(private module: string) {
+    static messageFormatter(info: HookshotLogInfo): string {
+        const logPrefix = `${info.level} ${info.timestamp} [${info.module}] `;
+        return logPrefix + this.formatMsgTypeArray(info.data ?? []);
+    }
+
+    constructor(private module: string, private readonly logger: GlobalLogger = LogWrapper.root) {
     }
 
     /**
@@ -162,7 +178,7 @@ export default class LogWrapper {
      * @param additionalData Additional context.
      */
     public debug(msg: MsgType, ...additionalData: MsgType[]) {
-        LogWrapper.winstonLog.log("debug", { module: this.module, data: [msg, ...additionalData] });
+        this.logger.winston?.log("debug", { module: this.module, data: [msg, ...additionalData] });
     }
 
     /**
@@ -171,7 +187,7 @@ export default class LogWrapper {
      * @param additionalData Additional context.
      */
     public error(msg: MsgType, ...additionalData: MsgType[]) {
-        LogWrapper.winstonLog.log("error", { module: this.module, data: [msg, ...additionalData] });
+        this.logger.winston?.log("error", { module: this.module, data: [msg, ...additionalData] });
     }
 
     /**
@@ -180,7 +196,7 @@ export default class LogWrapper {
      * @param additionalData Additional context.
      */
     public info(msg: MsgType, ...additionalData: MsgType[]) {
-        LogWrapper.winstonLog.log("info", { module: this.module, data: [msg, ...additionalData] });
+        this.logger.winston?.log("info", { module: this.module, data: [msg, ...additionalData] });
     }
 
     /**
@@ -189,6 +205,6 @@ export default class LogWrapper {
      * @param additionalData Additional context.
      */
     public warn(msg: MsgType, ...additionalData: MsgType[]) {
-        LogWrapper.winstonLog.log("warn", { module: this.module, data: [msg, ...additionalData] });
+        this.logger.winston?.log("warn", { module: this.module, data: [msg, ...additionalData] });
     }
 }

--- a/src/LogWrapper.ts
+++ b/src/LogWrapper.ts
@@ -159,7 +159,7 @@ export default class LogWrapper {
     /**
      * Logs to the DEBUG channel
      * @param msg The message or data to log.
-     * @param additionalData Additonal context.
+     * @param additionalData Additional context.
      */
     public debug(msg: MsgType, ...additionalData: MsgType[]) {
         LogWrapper.winstonLog.log("debug", { module: this.module, data: [msg, ...additionalData] });
@@ -168,7 +168,7 @@ export default class LogWrapper {
     /**
      * Logs to the ERROR channel
      * @param msg The message or data to log.
-     * @param additionalData Additonal context.
+     * @param additionalData Additional context.
      */
     public error(msg: MsgType, ...additionalData: MsgType[]) {
         LogWrapper.winstonLog.log("error", { module: this.module, data: [msg, ...additionalData] });
@@ -177,7 +177,7 @@ export default class LogWrapper {
     /**
      * Logs to the INFO channel
      * @param msg The message or data to log.
-     * @param additionalData Additonal context.
+     * @param additionalData Additional context.
      */
     public info(msg: MsgType, ...additionalData: MsgType[]) {
         LogWrapper.winstonLog.log("info", { module: this.module, data: [msg, ...additionalData] });
@@ -186,7 +186,7 @@ export default class LogWrapper {
     /**
      * Logs to the WARN channel
      * @param msg The message or data to log.
-     * @param additionalData Additonal context.
+     * @param additionalData Additional context.
      */
     public warn(msg: MsgType, ...additionalData: MsgType[]) {
         LogWrapper.winstonLog.log("warn", { module: this.module, data: [msg, ...additionalData] });

--- a/src/LogWrapper.ts
+++ b/src/LogWrapper.ts
@@ -68,7 +68,7 @@ export class GlobalLogger {
         if (cfg.json) {
             formatters.push((format((info) => {
                 const hsData = [...(info as HookshotLogInfo).data];
-                const firstArg = hsData?.shift() ?? 'undefined';
+                const firstArg = hsData.shift() ?? 'undefined';
                 const result: winston.Logform.TransformableInfo = {
                     level: info.level,
                     module: info.module,
@@ -94,7 +94,7 @@ export class GlobalLogger {
             formatters.push(winston.format.printf(i => LogWrapper.messageFormatter(i as HookshotLogInfo)));
         }
 
-        const formatter: winston.Logform.Format = winston.format.combine(...formatters);
+        const formatter = winston.format.combine(...formatters);
         const log = this.winstonLog = winston.createLogger({
             level: cfg.level,
             transports: [

--- a/tests/LogWrapperTest.ts
+++ b/tests/LogWrapperTest.ts
@@ -1,0 +1,87 @@
+import { expect } from "chai";
+import { Writable } from "stream";
+import LogWrapper, { GlobalLogger } from "../src/LogWrapper";
+
+const tortureArgs: [unknown, ...unknown[]][] = [
+    ["test-msg"],
+    [Number.MAX_VALUE],
+    [false],
+    [Buffer.from('foo')],
+    [new Error('Test')],
+    [undefined],
+    [null],
+    [NaN],
+    [[]],
+    [() => { /*dummy*/}],
+    ["Foo", "test-msg"],
+    ["Foo", Number.MAX_VALUE],
+    ["Foo", false],
+    ["Foo", Buffer.from('foo')],
+    ["Foo", new Error('Test')],
+    ["Foo", undefined],
+    ["Foo", null],
+    ["Foo", NaN],
+    ["Foo", []],
+    ["Foo", () => { /*dummy*/}],
+]
+
+const MODULE_NAME = 'LogTesting';
+
+describe('LogWrapper', () => {
+    describe('text logger torture test', () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let data: any;
+        const global = new GlobalLogger();
+        global.configureLogging({
+            json: false,
+            level: 'debug',
+        }, new Writable({
+            write(chunk, _encoding, callback) {
+                data = chunk.toString();
+                callback();
+            },
+        }));
+
+        const log = new LogWrapper(MODULE_NAME, global);
+        for (const args of tortureArgs) {
+            it(`handles logging '${args.map(t => typeof t).join(', ')}'`, () => {
+                for (const level of ['debug', 'info', 'warn', 'error']) {
+                    log[level as 'debug'|'info'|'warn'|'error'](args[0], ...args.slice(1));
+                    expect(data).to.include(level.toUpperCase());
+                    expect(data).to.include(MODULE_NAME);
+                    expect(data).to.not.be.undefined;
+                }
+            })
+        }
+    });
+    describe('JSON logger torture test', () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let data: any;
+        const global = new GlobalLogger();
+        global.configureLogging({
+            json: true,
+            level: 'debug',
+        }, new Writable({
+            write(chunk, _encoding, callback) {
+                data = JSON.parse(chunk.toString());
+                callback();
+            },
+        }));
+
+        const log = new LogWrapper(MODULE_NAME, global);
+        for (const args of tortureArgs) {
+            it(`handles logging '${args.map(t => typeof t).join(', ')}'`, () => {
+                for (const level of ['debug', 'info', 'warn', 'error']) {
+                    log[level as 'debug'|'info'|'warn'|'error'](args[0], ...args.slice(1));
+                    expect(data.level).to.equal(level.toUpperCase());
+                    expect(data.module).to.equal(MODULE_NAME);
+                    expect(data.message).to.not.be.undefined;
+                    expect(data.timestamp).to.not.be.undefined;
+                    if (args.length > 1) {
+                        expect(data.args).to.have.lengthOf(args.length-1);
+                    }
+                }
+            })
+        }
+    });
+});

--- a/tests/init.ts
+++ b/tests/init.ts
@@ -1,2 +1,3 @@
 import LogWrapper from "../src/LogWrapper";
-LogWrapper.configureLogging({level: "info"});
+
+LogWrapper.root.configureLogging({level: "info"});


### PR DESCRIPTION
Fixes #477 

In addition to fixing the issue with JSON causing the bridge to error, this also adds some torture tests for the logger. It was a bit more refactor-y than I'd like but I think this does a good job of ensuring we won't break loggers so easily in the future.