### PR TITLE
Support notifying when a GitLab MR is ready for review

### DIFF
--- a/changelog.d/480.feature
+++ b/changelog.d/480.feature
@@ -1,0 +1,1 @@
+Ready/draft state changes for GitLab merge requests are now reported.

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -361,7 +361,7 @@ export class Bridge {
         this.bindHandlerToQueue<IGitLabWebhookMREvent, GitLabRepoConnection>(
             "gitlab.merge_request.update",
             (data) => connManager.getConnectionsForGitLabRepo(data.project.path_with_namespace), 
-            (c, data) => c.onMergeRequestOpened(data),
+            (c, data) => c.onMergeRequestUpdate(data),
         );
 
         this.bindHandlerToQueue<IGitLabWebhookReleaseEvent, GitLabRepoConnection>(

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -361,7 +361,7 @@ export class Bridge {
         this.bindHandlerToQueue<IGitLabWebhookMREvent, GitLabRepoConnection>(
             "gitlab.merge_request.update",
             (data) => connManager.getConnectionsForGitLabRepo(data.project.path_with_namespace), 
-            (c, data) => c.onMergeRequestReviewed(data),
+            (c, data) => c.onMergeRequestOpened(data),
         );
 
         this.bindHandlerToQueue<IGitLabWebhookReleaseEvent, GitLabRepoConnection>(

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -358,6 +358,12 @@ export class Bridge {
             (c, data) => c.onMergeRequestReviewed(data),
         );
 
+        this.bindHandlerToQueue<IGitLabWebhookMREvent, GitLabRepoConnection>(
+            "gitlab.merge_request.update",
+            (data) => connManager.getConnectionsForGitLabRepo(data.project.path_with_namespace), 
+            (c, data) => c.onMergeRequestReviewed(data),
+        );
+
         this.bindHandlerToQueue<IGitLabWebhookReleaseEvent, GitLabRepoConnection>(
             "gitlab.release.create",
             (data) => connManager.getConnectionsForGitLabRepo(data.project.path_with_namespace), 

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -7,7 +7,7 @@ import { MatrixMessageContent } from "../MatrixEvent";
 import markdown from "markdown-it";
 import LogWrapper from "../LogWrapper";
 import { BridgeConfigGitLab, GitLabInstance } from "../Config/Config";
-import { IGitLabWebhookMREvent, IGitLabWebhookNoteEvent, IGitLabWebhookPushEvent, IGitLabWebhookReleaseEvent, IGitLabWebhookTagPushEvent, IGitLabWebhookWikiPageEvent } from "../Gitlab/WebhookTypes";
+import { IGitlabMergeRequest, IGitLabWebhookMREvent, IGitLabWebhookNoteEvent, IGitLabWebhookPushEvent, IGitLabWebhookReleaseEvent, IGitLabWebhookTagPushEvent, IGitLabWebhookWikiPageEvent } from "../Gitlab/WebhookTypes";
 import { CommandConnection } from "./CommandConnection";
 import { Connection, IConnection, IConnectionState, InstantiateConnectionOpts, ProvisionConnectionOpts } from "./IConnection";
 import { GetConnectionsResponseItem } from "../provisioning/api";
@@ -50,6 +50,7 @@ type AllowedEventsNames =
     "merge_request.close" |
     "merge_request.merge" |
     "merge_request.review" |
+    "merge_request.update" |
     "merge_request.review.comments" |
     `merge_request.${string}` |
     "merge_request" |
@@ -65,6 +66,7 @@ const AllowedEvents: AllowedEventsNames[] = [
     "merge_request.close",
     "merge_request.merge",
     "merge_request.review",
+    "merge_request.update",
     "merge_request.review.comments",
     "merge_request",
     "tag_push",
@@ -440,6 +442,38 @@ export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnection
         });
     }
 
+    public async onMergeRequestUpdate(event: IGitLabWebhookMREvent) {
+        if (this.shouldSkipHook('merge_request', 'merge_request.update')) {
+            return;
+        }
+        log.info(`onMergeRequestUpdate ${this.roomId} ${this.instance}/${this.path} ${event.object_attributes.iid}`);
+        this.validateMREvent(event);
+        // Check if the MR changed to / from a draft
+        if (!event.changes.title) {
+            return;
+        }
+        const orgRepoName = event.project.path_with_namespace;
+        let content: string;
+        const wasDraft = event.changes.title.before.startsWith('Draft: ');
+        const isDraft = event.changes.title.after.startsWith('Draft: ');
+        if (wasDraft && !isDraft) {
+            // Ready for review
+            content = `**${event.user.username}** marked MR [${orgRepoName}#${event.object_attributes.iid}](${event.object_attributes.url}) as ready for review "${event.object_attributes.title}" `;
+        } else if (!wasDraft && isDraft) {
+            // Back to draft.
+            content = `**${event.user.username}** marked MR [${orgRepoName}#${event.object_attributes.iid}](${event.object_attributes.url}) as draft "${event.object_attributes.title}" `;
+        } else {
+            // Nothing changed, drop it.
+            return;
+        }
+        await this.as.botIntent.sendEvent(this.roomId, {
+            msgtype: "m.notice",
+            body: content,
+            formatted_body: md.renderInline(content),
+            format: "org.matrix.custom.html",
+        });
+    }
+
     public async onGitLabTagPush(event: IGitLabWebhookTagPushEvent) {
         log.info(`onGitLabTagPush ${this.roomId} ${this.instance.url}/${this.path} ${event.ref}`);
         if (this.shouldSkipHook('tag_push')) {
@@ -592,9 +626,7 @@ ${data.description}`;
                 timeout: setTimeout(renderFn, MRRCOMMENT_DEBOUNCE_MS),
             })
         }
-
     }
-
 
     public toString() {
         return `GitLabRepo ${this.instance.url}/${this.path}`;

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -50,7 +50,7 @@ type AllowedEventsNames =
     "merge_request.close" |
     "merge_request.merge" |
     "merge_request.review" |
-    "merge_request.update" |
+    "merge_request.ready_for_review" |
     "merge_request.review.comments" |
     `merge_request.${string}` |
     "merge_request" |
@@ -66,7 +66,7 @@ const AllowedEvents: AllowedEventsNames[] = [
     "merge_request.close",
     "merge_request.merge",
     "merge_request.review",
-    "merge_request.update",
+    "merge_request.ready_for_review",
     "merge_request.review.comments",
     "merge_request",
     "tag_push",
@@ -443,7 +443,7 @@ export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnection
     }
 
     public async onMergeRequestUpdate(event: IGitLabWebhookMREvent) {
-        if (this.shouldSkipHook('merge_request', 'merge_request.update')) {
+        if (this.shouldSkipHook('merge_request', 'merge_request.ready_for_review')) {
             return;
         }
         log.info(`onMergeRequestUpdate ${this.roomId} ${this.instance}/${this.path} ${event.object_attributes.iid}`);

--- a/src/Gitlab/WebhookTypes.ts
+++ b/src/Gitlab/WebhookTypes.ts
@@ -63,6 +63,12 @@ export interface IGitLabWebhookMREvent {
     repository: IGitlabRepository;
     object_attributes: IGitLabMergeRequestObjectAttributes;
     labels: IGitLabLabel[];
+    changes: {
+        [key: string]: {
+            before: string;
+            after: string;
+        }
+    }
 }
 
 export interface IGitLabWebhookTagPushEvent {

--- a/web/components/roomConfig/GitlabRepoConfig.tsx
+++ b/web/components/roomConfig/GitlabRepoConfig.tsx
@@ -166,6 +166,8 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ne
                     <EventCheckbox ignoredHooks={ignoredHooks} parentEvent="merge_request" eventName="merge_request.close" onChange={toggleIgnoredHook}>Closed</EventCheckbox>
                     <EventCheckbox ignoredHooks={ignoredHooks} parentEvent="merge_request" eventName="merge_request.merge" onChange={toggleIgnoredHook}>Merged</EventCheckbox>
                     <EventCheckbox ignoredHooks={ignoredHooks} parentEvent="merge_request" eventName="merge_request.review" onChange={toggleIgnoredHook}>Reviewed</EventCheckbox>
+                    {/* update is how we determine ready for review state */}
+                    <EventCheckbox ignoredHooks={ignoredHooks} parentEvent="merge_request" eventName="merge_request.update" onChange={toggleIgnoredHook}>Ready for review</EventCheckbox>
                 </ul>
                 <EventCheckbox ignoredHooks={ignoredHooks} eventName="push" onChange={toggleIgnoredHook}>Pushes</EventCheckbox>
                 <EventCheckbox ignoredHooks={ignoredHooks} eventName="tag_push" onChange={toggleIgnoredHook}>Tag pushes</EventCheckbox>

--- a/web/components/roomConfig/GitlabRepoConfig.tsx
+++ b/web/components/roomConfig/GitlabRepoConfig.tsx
@@ -166,8 +166,7 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ne
                     <EventCheckbox ignoredHooks={ignoredHooks} parentEvent="merge_request" eventName="merge_request.close" onChange={toggleIgnoredHook}>Closed</EventCheckbox>
                     <EventCheckbox ignoredHooks={ignoredHooks} parentEvent="merge_request" eventName="merge_request.merge" onChange={toggleIgnoredHook}>Merged</EventCheckbox>
                     <EventCheckbox ignoredHooks={ignoredHooks} parentEvent="merge_request" eventName="merge_request.review" onChange={toggleIgnoredHook}>Reviewed</EventCheckbox>
-                    {/* update is how we determine ready for review state */}
-                    <EventCheckbox ignoredHooks={ignoredHooks} parentEvent="merge_request" eventName="merge_request.update" onChange={toggleIgnoredHook}>Ready for review</EventCheckbox>
+                    <EventCheckbox ignoredHooks={ignoredHooks} parentEvent="merge_request" eventName="merge_request.ready_for_review" onChange={toggleIgnoredHook}>Ready for review</EventCheckbox>
                 </ul>
                 <EventCheckbox ignoredHooks={ignoredHooks} eventName="push" onChange={toggleIgnoredHook}>Pushes</EventCheckbox>
                 <EventCheckbox ignoredHooks={ignoredHooks} eventName="tag_push" onChange={toggleIgnoredHook}>Tag pushes</EventCheckbox>


### PR DESCRIPTION
Because GitLab webhooks are still quite cryptic, we're having to go based on what the title of the MR contains.