### PR TITLE
Fix figma not working on startup

### DIFF
--- a/changelog.d/481.bugfix
+++ b/changelog.d/481.bugfix
@@ -1,0 +1,1 @@
+Fix Figma service not being able to create new webhooks on startup, causing a crash.

--- a/src/figma/index.ts
+++ b/src/figma/index.ts
@@ -74,7 +74,7 @@ export async function ensureFigmaWebhooks(figmaConfig: BridgeConfigFigma, matrix
         } else {
             log.info(`No webhook defined for instance ${instanceName}, creating`);
             try {
-                const res = await client.client.post(`v2/webhooks`, {
+                const res = await client.client.post(`webhooks`, {
                     passcode,
                     endpoint: publicUrl,
                     description: 'matrix-hookshot',

--- a/src/figma/index.ts
+++ b/src/figma/index.ts
@@ -52,7 +52,7 @@ export async function ensureFigmaWebhooks(figmaConfig: BridgeConfigFigma, matrix
                     }
                     throw Error(`Failed to verify Figma webhooks for ${instanceName}: ${ex.message}`);
                 }
-                log.warn(`Webhook ID stored but API returned not found, creating new one.`);
+                log.warn(`Previous webhook ID ${webhookId} stored but API returned not found, creating new one.`);
             }
         }
         if (webhookDefinition) {

--- a/src/figma/index.ts
+++ b/src/figma/index.ts
@@ -79,7 +79,7 @@ export async function ensureFigmaWebhooks(figmaConfig: BridgeConfigFigma, matrix
                     endpoint: publicUrl,
                     description: 'matrix-hookshot',
                     event_type: 'FILE_COMMENT',
-                    team_id: teamId,
+                    team_id: teamId.toString(),
                 }, axiosConfig);
                 webhookDefinition = res.data as FigmaWebhookDefinition;
                 await matrixClient.setAccountData(accountDataKey, {webhookId: webhookDefinition.id});


### PR DESCRIPTION
Because we decided to stick `v2/` in front of our client calls, all the requests would fail with a 404.