### PR TITLE
Increase feed.pollTimeoutSeconds from 10s to 30s

### DIFF
--- a/changelog.d/483.misc
+++ b/changelog.d/483.misc
@@ -1,0 +1,1 @@
+Increase default `feeds.pollTimeoutSeconds` from 10 seconds to 30.

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -87,7 +87,7 @@ feeds:
   #
   enabled: false
   pollIntervalSeconds: 600
-  pollTimeoutSeconds: 10
+  pollTimeoutSeconds: 30
 provisioning:
   # (Optional) Provisioning API for integration managers
   #

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -244,7 +244,7 @@ export class BridgeConfigFeeds {
         this.enabled = yaml.enabled;
         this.pollIntervalSeconds = yaml.pollIntervalSeconds;
         assert.strictEqual(typeof this.pollIntervalSeconds, "number");
-        this.pollTimeoutSeconds = yaml.pollTimeoutSeconds ?? 10;
+        this.pollTimeoutSeconds = yaml.pollTimeoutSeconds ?? 30;
         assert.strictEqual(typeof this.pollTimeoutSeconds, "number");
     }
 

--- a/src/Config/Defaults.ts
+++ b/src/Config/Defaults.ts
@@ -111,7 +111,7 @@ export const DefaultConfig = new BridgeConfig({
     feeds: {
         enabled: false,
         pollIntervalSeconds: 600,
-        pollTimeoutSeconds: 10,
+        pollTimeoutSeconds: 30,
     },
     provisioning: {
         secret: "!secretToken"

--- a/src/Config/Defaults.ts
+++ b/src/Config/Defaults.ts
@@ -111,7 +111,6 @@ export const DefaultConfig = new BridgeConfig({
     feeds: {
         enabled: false,
         pollIntervalSeconds: 600,
-        pollTimeoutSeconds: 30,
     },
     provisioning: {
         secret: "!secretToken"


### PR DESCRIPTION
10s seems too low in practice for things like GitHub, and it does seem to be doing more harm than good.