### PR TITLE
Add ability to view request results / logs for generic webhooks

### DIFF
--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -564,12 +564,12 @@ export class Bridge {
                 try {
                     // TODO: Support webhook responses to more than one room
                     if (index !== 0) {
-                        await c.onGenericHook(data.hookData);
+                        await c.onGenericHook(data);
                         return;
                     }
                     let successful: boolean|null = null;
                     if (this.config.generic?.waitForComplete) {
-                        successful = await c.onGenericHook(data.hookData);
+                        successful = await c.onGenericHook(data);
                     }
                     await this.queue.push<GenericWebhookEventResult>({
                         data: {successful},
@@ -579,7 +579,7 @@ export class Bridge {
                     });
                     didPush = true;
                     if (!this.config.generic?.waitForComplete) {
-                        await c.onGenericHook(data.hookData);
+                        await c.onGenericHook(data);
                     }
                 }
                 catch (ex) {

--- a/src/generic/Router.ts
+++ b/src/generic/Router.ts
@@ -33,6 +33,8 @@ export class GenericWebhooksRouter {
             data: {
                 hookData: body,
                 hookId: req.params.hookId,
+                userAgent: req.headers["user-agent"],
+                contentType: req.headers["content-type"],
             },
         }, WEBHOOK_RESPONSE_TIMEOUT).then((response) => {
             if (response.notFound) {

--- a/src/generic/types.ts
+++ b/src/generic/types.ts
@@ -1,6 +1,8 @@
 export interface GenericWebhookEvent {
     hookData: unknown;
     hookId: string;
+    userAgent?: string;
+    contentType?: string;
 }
 
 export interface GenericWebhookEventResult {

--- a/web/components/roomConfig/FeedConnection.module.scss
+++ b/web/components/roomConfig/FeedConnection.module.scss
@@ -2,3 +2,8 @@
     list-style: none;
     padding-bottom: 1rem;
 }
+
+.logContainer {
+    overflow: auto;
+    max-height: 10rem;
+}


### PR DESCRIPTION
Fixes #479 

This works much like the RSS feed result system, except for hooks. This additionally stores logs, errors and a couple of headers to help script writers diagnose any issues with their scripts.

TODO: Make this actually pleasant to use and look at.

![image](https://user-images.githubusercontent.com/2072976/190114489-10cbc122-9670-4ada-b0d3-cbf8a3b28a16.png)
