### PR TITLE
Add commands to remove/list Jira connections

### DIFF
--- a/changelog.d/503.feature
+++ b/changelog.d/503.feature
@@ -1,0 +1,1 @@
+Add bot commands to list and remove Jira connections.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -15,6 +15,7 @@
   - [Room Configuration](./usage/room_configuration.md)
     - [GitHub Repo](./usage/room_configuration/github_repo.md)
     - [GitLab Project](./usage/room_configuration/gitlab_project.md)
+    - [JIRA Project](./usage/room_configuration/jira_project.md)
 - [📊 Metrics](./metrics.md)
 
 # 🧑‍💻 Development

--- a/docs/setup/jira.md
+++ b/docs/setup/jira.md
@@ -1,21 +1,22 @@
 # JIRA
 
-## Adding a webhook to a JIRA Organisation
+## Adding a webhook to a JIRA Instance
 
-This should be done for all JIRA organisations you wish to bridge. The setup steps are the same for both On-Prem and Cloud.
+This should be done for the JIRA instance you wish to bridge. The setup steps are the same for both On-Prem and Cloud.
 
 You need to go to the `WebHooks` configuration page under Settings > System.
+Note that this may require administrative access to the JIRA instance.
 
 Next, add a webhook that points to `/` on the public webhooks address for hookshot. You should also include a
 secret value by appending `?secret=your-webhook-secret`. The secret value can be anything, but should
 be reasonably secure and should also be stored in the `config.yml` file.
 
-Ensure that you enable all the events that you wish to be bridge.
+Ensure that you enable all the events that you wish to be bridged.
 
 
 ## Configuration
 
-You can now set some configuration in the bridge `config.yml`
+You can now set some configuration in the bridge `config.yml`:
 
 ```yaml
 jira:

--- a/docs/usage/room_configuration/jira_project.md
+++ b/docs/usage/room_configuration/jira_project.md
@@ -1,0 +1,38 @@
+JIRA Project
+=================
+
+This connection type connects a JIRA project to a room.
+
+You can run commands to create and assign issues, and receive notifications when issues are created.
+
+## Setting up
+
+To set up a connection to a JIRA project in a new room:
+
+(NB you must have permission to bridge JIRA projects before you can use this command, see [auth](../auth.html#jira).)
+
+1. Create a new, unencrypted room. It can be public or private.
+1. Invite the bridge bot (e.g. `@hookshot:example.com`).
+1. Give the bridge bot moderator permissions or higher (power level 50) (or otherwise configure the room so the bot can edit room state).
+1. Send the command `!hookshot jira project https://jira-instance/.../projects/PROJECTKEY/...`.
+1. If you have permission to bridge this repo, the bridge will respond with a confirmation message.
+
+## Managing connections
+
+Send the command `!hookshot jira list project` to list all of a room's connections to JIRA projects.
+
+Send the command `!hookshot jira remove project <url>` to remove a room's connection to a JIRA project at a given URL.
+
+## Configuration
+
+This connection supports a few options which can be defined in the room state:
+
+| Option | Description | Allowed values | Default |
+|--------|-------------|----------------|---------|
+|events|Choose to include notifications for some event types|Array of: [Supported event types](#supported-event-types) |*empty*|
+|commandPrefix|Choose the prefix to use when sending commands to the bot|A string, ideally starts with "!"|`!jira`|
+
+
+### Supported event types
+
+This connection currently supports sending messages only when a `issue.created` action happens on the project.


### PR DESCRIPTION
This adds bot-command equivalents of the list & remove features that are available in the provisioning API, and soon, the configuration widget (note that this PR is not required by / dependent on the widget PR).

Note that this stops lower-casing the "safe URL" because that URL gets used as a state event key, which is case-sensitive, and wasn't lower-cased by the provisioning API (and isn't by the config widget either) -- meaning a connection added via a bot command couldn't be removed by the provisioning API (or widget), and vice-versa!

I'm pointing this out since the name of "safe URL" suggests that the lower-casing was done for a good reason, but AFAICT it only makes things worse.  (The rest of the "safety" in pulling apart irrelevant parts of the URL works great, though.)