### PR TITLE
Fix Jira widget request loop for logged-out users

### DIFF
--- a/changelog.d/507.bugfix
+++ b/changelog.d/507.bugfix
@@ -1,0 +1,1 @@
+Add a configuration widget for Jira.

--- a/web/components/roomConfig/JiraProjectConfig.tsx
+++ b/web/components/roomConfig/JiraProjectConfig.tsx
@@ -76,7 +76,7 @@ const ConnectionSearch: FunctionComponent<{api: BridgeAPI, onPicked: (state: Jir
         }
         // Things break if we depend on the thing we are clearing.
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [searchFn, filter, isConnected, instances]);
+    }, [searchFn, filter]);
 
     const onInstancePicked = useCallback((evt: InputEvent) => {
         // Reset the search string.
@@ -97,7 +97,7 @@ const ConnectionSearch: FunctionComponent<{api: BridgeAPI, onPicked: (state: Jir
 
 
     return <div>
-        {instances === null && <p> Loading JIRA connection. </p>}
+        {isConnected === null && <p> Loading JIRA connection. </p>}
         {isConnected === false && <p> You are not logged into JIRA. </p>}
         {isConnected === true && instances?.length === 0 && <p> You are not connected to any JIRA instances. </p>}
         {searchError && <ErrorPane> {searchError} </ErrorPane> }


### PR DESCRIPTION
Without this change, viewing the Jira widget without being logged into Jira causes the widget to repeatedly make network requests.

Note that this intentionally lacks a changelog since it fixes an issue with a yet-to-be-released feature (the Jira widget).