### PR TITLE
Reorganize the GitHub config widget

### DIFF
--- a/changelog.d/508.feature
+++ b/changelog.d/508.feature
@@ -1,0 +1,1 @@
+Reorganize the GitHub widget to allow searching for repositories by organization.

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -299,8 +299,11 @@ export class ConnectionManager extends EventEmitter {
             return await GitLabRepoConnection.getConnectionTargets(userId, this.tokenStore, configObject, filters);
         }
         case GitHubRepoConnection.CanonicalEventType: {
-            const configObject = this.validateConnectionTarget(userId, this.config.github, "GitHub", "github");
-            return await GitHubRepoConnection.getConnectionTargets(userId, this.tokenStore, configObject);
+            this.validateConnectionTarget(userId, this.config.github, "GitHub", "github");
+            if (!this.github) {
+                throw Error("GitHub instance was never initialized");
+            }
+            return await GitHubRepoConnection.getConnectionTargets(userId, this.tokenStore, this.github, filters);
         }
         case JiraProjectConnection.CanonicalEventType: {
             const configObject = this.validateConnectionTarget(userId, this.config.jira, "JIRA", "jira");

--- a/src/Github/Router.ts
+++ b/src/Github/Router.ts
@@ -4,6 +4,7 @@ import { ApiError, ErrCode } from "../api";
 import { UserTokenStore } from "../UserTokenStore";
 import LogWrapper from "../LogWrapper";
 import { GithubInstance } from "./GithubInstance";
+import { NAMELESS_ORG_PLACEHOLDER } from "./Types";
 
 const log = new LogWrapper("GitHubProvisionerRouter");
 interface GitHubAccountStatus {
@@ -74,7 +75,7 @@ export class GitHubProvisionerRouter {
             for (const install of installs.data.installations) {
                 if (install.account) {
                     organisations.push({
-                        name: install.account.login || "No name", // org or user name
+                        name: install.account.login || NAMELESS_ORG_PLACEHOLDER, // org or user name
                         avatarUrl: install.account.avatar_url,
                     });
                 } else {
@@ -110,7 +111,7 @@ export class GitHubProvisionerRouter {
 
             if (ownSelf.data.login === req.params.orgName) {
                 const userInstallation = await this.githubInstance.appOctokit.apps.getUserInstallation({username: ownSelf.data.login});
-                reposPromise = await octokit.apps.listInstallationReposForAuthenticatedUser({
+                reposPromise = octokit.apps.listInstallationReposForAuthenticatedUser({
                     page,
                     installation_id: userInstallation.data.id,
                     per_page: perPage,
@@ -123,7 +124,7 @@ export class GitHubProvisionerRouter {
 
                 // Github will error if the authed user tries to list repos of a disallowed installation, even
                 // if we got the installation ID from the app's instance.
-                reposPromise = await octokit.apps.listInstallationReposForAuthenticatedUser({
+                reposPromise = octokit.apps.listInstallationReposForAuthenticatedUser({
                     page,
                     installation_id: orgInstallation.data.id,
                     per_page: perPage,

--- a/src/Github/Types.ts
+++ b/src/Github/Types.ts
@@ -17,6 +17,8 @@ export type DiscussionDataType = Endpoints["GET /repos/{owner}/{repo}/pulls/{pul
 export type InstallationDataType = Endpoints["GET /app/installations/{installation_id}"]["response"]["data"];
 export type CreateInstallationAccessTokenDataType = Endpoints["POST /app/installations/{installation_id}/access_tokens"]["response"]["data"];
 
+export const NAMELESS_ORG_PLACEHOLDER = "No name";
+
 /* eslint-disable camelcase */
 export interface GitHubUserNotification {
     id: string;


### PR DESCRIPTION
- Group repos by org
- Paginate repo requests
- Remove redundant label next to chosen repo
- Remove redundant repo field below connected repo
- Include repos that user has doesn't have admin permissions for, to achieve parity with results from provisioning API

---

![image](https://user-images.githubusercontent.com/3271094/193508894-ea23e34d-eeea-4ea3-8e4c-05bea530411c.png)
![image](https://user-images.githubusercontent.com/3271094/193508947-091fc6bb-1a0e-4d9a-a9d6-290ab65e7535.png)

This allows the widget's search UI to match Dimension's:

![image](https://user-images.githubusercontent.com/3271094/193509314-5bebe359-33f9-4f1c-b25f-20c141265944.png)

For what the GH widget looked like before, [see here](https://github.com/matrix-org/matrix-hookshot/pull/420#issuecomment-1192876562).