### PR TITLE
Preserve case-sensitivity of GitHub URLs

### DIFF
--- a/changelog.d/511.bugfix
+++ b/changelog.d/511.bugfix
@@ -1,0 +1,1 @@
+Preserve case-sensitivity of GitHub repository URLs.

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -139,31 +139,23 @@ export class ConnectionManager extends EventEmitter {
     }
 
     public getConnectionsForGithubIssue(org: string, repo: string, issueNumber: number): (GitHubIssueConnection|GitHubRepoConnection)[] {
-        org = org.toLowerCase();
-        repo = repo.toLowerCase();
         return this.connections.filter((c) => (c instanceof GitHubIssueConnection && c.org === org && c.repo === repo && c.issueNumber === issueNumber) ||
             (c instanceof GitHubRepoConnection && c.org === org && c.repo === repo)) as (GitHubIssueConnection|GitHubRepoConnection)[];
     }
 
     public getConnectionsForGithubRepo(org: string, repo: string): GitHubRepoConnection[] {
-        org = org.toLowerCase();
-        repo = repo.toLowerCase();
         return this.connections.filter((c) => (c instanceof GitHubRepoConnection && c.org === org && c.repo === repo)) as GitHubRepoConnection[];
     }
 
     public getConnectionsForGithubRepoDiscussion(owner: string, repo: string): GitHubDiscussionSpace[] {
-        owner = owner.toLowerCase();
-        repo = repo.toLowerCase();
         return this.connections.filter((c) => (c instanceof GitHubDiscussionSpace && c.owner === owner && c.repo === repo)) as GitHubDiscussionSpace[];
     }
 
     public getConnectionForGithubUser(user: string): GitHubUserSpace {
-        return this.connections.find(c => c instanceof GitHubUserSpace && c.owner === user.toLowerCase()) as GitHubUserSpace;
+        return this.connections.find(c => c instanceof GitHubUserSpace && c.owner === user) as GitHubUserSpace;
     }
 
     public getConnectionsForGithubDiscussion(owner: string, repo: string, discussionNumber: number) {
-        owner = owner.toLowerCase();
-        repo = repo.toLowerCase();
         return this.connections.filter(
             c => (
                 c instanceof GitHubDiscussionConnection &&

--- a/src/Connections/GithubDiscussion.ts
+++ b/src/Connections/GithubDiscussion.ts
@@ -80,7 +80,7 @@ export class GitHubDiscussionConnection extends BaseConnection implements IConne
             preset: 'public_chat',
             name: `${discussion.title} (${owner}/${repo})`,
             topic: emoji.emojify(`Under ${discussion.category.emoji} ${discussion.category.name}`),
-            room_alias_name: `github_disc_${owner.toLowerCase()}_${repo.toLowerCase()}_${discussion.number}`,
+            room_alias_name: `github_disc_${owner}_${repo}_${discussion.number}`,
             initial_state: [{
                 content: state,
                 state_key: '',
@@ -131,11 +131,11 @@ export class GitHubDiscussionConnection extends BaseConnection implements IConne
     }
 
     public get repo() {
-        return this.state.repo.toLowerCase();
+        return this.state.repo;
     }
 
     public get owner() {
-        return this.state.owner.toLowerCase();
+        return this.state.owner;
     }
 
     public toString() {

--- a/src/Connections/GithubDiscussionSpace.ts
+++ b/src/Connections/GithubDiscussionSpace.ts
@@ -68,8 +68,8 @@ export class GitHubDiscussionSpace extends BaseConnection implements IConnection
             throw Error("Could not find repo");
         }
         const state: GitHubDiscussionSpaceConnectionState = {
-            owner: repoRes.owner.login.toLowerCase(),
-            repo: repoRes.name.toLowerCase(),
+            owner: repoRes.owner.login,
+            repo: repoRes.name,
         };
 
         // URL hack so we don't need to fetch the repo itself.
@@ -106,7 +106,7 @@ export class GitHubDiscussionSpace extends BaseConnection implements IConnection
             name: `${state.owner}/${state.repo} Discussions`,
             topic: `GitHub discussion index for ${state.owner}/${state.repo}`,
             preset: 'public_chat',
-            room_alias_name: `github_disc_${owner.toLowerCase()}_${repo.toLowerCase()}`,
+            room_alias_name: `github_disc_${owner}_${repo}`,
             initial_state: [
                 
                 {
@@ -152,11 +152,11 @@ export class GitHubDiscussionSpace extends BaseConnection implements IConnection
     }
 
     public get repo() {
-        return this.state.repo.toLowerCase();
+        return this.state.repo;
     }
 
     public get owner() {
-        return this.state.owner.toLowerCase();
+        return this.state.owner;
     }
 
     public toString() {

--- a/src/Connections/GithubIssue.ts
+++ b/src/Connections/GithubIssue.ts
@@ -175,11 +175,11 @@ export class GitHubIssueConnection extends BaseConnection implements IConnection
     }
 
     public get org() {
-        return this.state.org.toLowerCase();
+        return this.state.org;
     }
 
     public get repo() {
-        return this.state.repo.toLowerCase();
+        return this.state.repo;
     }
 
     public async onIssueCommentCreated(event: IssueCommentCreatedEvent) {

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -421,7 +421,7 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
     }
 
     public get org() {
-        return this.state.org.toLowerCase();
+        return this.state.org;
     }
 
     private get showIssueRoomLink() {
@@ -429,7 +429,7 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
     }
 
     public get repo() {
-        return this.state.repo.toLowerCase();
+        return this.state.repo;
     }
 
     public get priority(): number {

--- a/src/Connections/GithubUserSpace.ts
+++ b/src/Connections/GithubUserSpace.ts
@@ -99,16 +99,16 @@ export class GitHubUserSpace extends BaseConnection implements IConnection {
 
         return {
             visibility: "public",
-            name: `GitHub - ${name} (${state.username.toLowerCase()})`,
-            topic: `GitHub page of ${state.username.toLowerCase()}`,
+            name: `GitHub - ${name} (${state.username})`,
+            topic: `GitHub page of ${state.username}`,
             preset: 'public_chat',
-            room_alias_name: `github_${state.username.toLowerCase()}`,
+            room_alias_name: `github_${state.username}`,
             initial_state: [
                 
                 {
                     type: this.CanonicalEventType,
                     content: state,
-                    state_key: state.username.toLowerCase(),
+                    state_key: state.username,
                 },
                 avatarState,
                 {
@@ -148,7 +148,7 @@ export class GitHubUserSpace extends BaseConnection implements IConnection {
     }
 
     public get owner() {
-        return this.state.username.toLowerCase();
+        return this.state.username;
     }
 
     public toString() {

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -77,7 +77,7 @@ export class SetupConnection extends CommandConnection {
         if (!octokit) {
             throw new CommandError("User not logged in", "You are not logged into GitHub. Start a DM with this bot and use the command `github login`.");
         }
-        const urlParts = /^https:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(url.trim().toLowerCase());
+        const urlParts = /^https:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(url.trim());
         if (!urlParts) {
             throw new CommandError("Invalid GitHub url", "The GitHub url you entered was not valid.");
         }

--- a/src/Github/GithubInstance.ts
+++ b/src/Github/GithubInstance.ts
@@ -82,7 +82,7 @@ export class GithubInstance {
     }
 
     public getSafeOctokitForRepo(orgName: string, repoName?: string) {
-        const targetName = (repoName ? `${orgName}/${repoName}` : orgName).toLowerCase();
+        const targetName = (repoName ? `${orgName}/${repoName}` : orgName);
         for (const install of this.installationsCache.values()) {
             if (install.matchesRepository.includes(targetName) || install.matchesRepository.includes(`${targetName.split('/')[0]}/*`)) {
                 return this.createOctokitForInstallation(install.id);
@@ -146,13 +146,13 @@ export class GithubInstance {
     private async addInstallation(install: InstallationDataType, repos?: {full_name: string}[]) {
         let matchesRepository: string[] = [];
         if (install.repository_selection === "all") {
-            matchesRepository = [`${install.account?.login}/*`.toLowerCase()];
+            matchesRepository = [`${install.account?.login}/*`];
         } else if (repos) {
-            matchesRepository = repos.map(r => r.full_name.toLowerCase());
+            matchesRepository = repos.map(r => r.full_name);
         } else {
             const installOctokit = this.createOctokitForInstallation(install.id);
             const repos = await installOctokit.apps.listReposAccessibleToInstallation({ per_page: 100 });
-            matchesRepository.push(...repos.data.repositories.map(r => r.full_name.toLowerCase()));
+            matchesRepository.push(...repos.data.repositories.map(r => r.full_name));
         }
         this.installationsCache.set(install.id, {
             account: install.account,


### PR DESCRIPTION
Don't lower-case GitHub repos, orgs, usernames, etc when using them as room state event keys, room aliases, etc.
