### PR TITLE
Send bot notice on GitHub OAuth success

### DIFF
--- a/changelog.d/512.feature
+++ b/changelog.d/512.feature
@@ -1,0 +1,1 @@
+Print a notice message after successfully logging in to GitHub when conversing with the bot in a DM.

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -541,7 +541,7 @@ export class Bridge {
                 // Some users won't have an admin room and would have gone through provisioning.
                 const adminRoom = [...this.adminRooms.values()].find(r => r.userId === userId);
                 if (adminRoom) {
-                    await adminRoom.sendNotice(`Logged into Jira`);
+                    await adminRoom.sendNotice("Logged into Jira");
                 }
                 result = JiraOAuthRequestResult.Success;
             } catch (ex) {

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -420,6 +420,12 @@ export class Bridge {
                 refresh_token: msg.data.refresh_token,
                 refresh_token_expires_in: msg.data.refresh_token_expires_in && ((parseInt(msg.data.refresh_token_expires_in) * 1000)  + Date.now()),
             } as GitHubOAuthToken));
+
+            // Some users won't have an admin room and would have gone through provisioning.
+            const adminRoom = [...this.adminRooms.values()].find(r => r.userId === userId);
+            if (adminRoom) {
+                await adminRoom.sendNotice("Logged into GitHub");
+            }
         });
 
         this.bindHandlerToQueue<IGitLabWebhookNoteEvent, GitLabIssueConnection|GitLabRepoConnection>(


### PR DESCRIPTION
i.e. the same as is done for Jira

---

![hookshotGithubLoginNotice](https://user-images.githubusercontent.com/3271094/193624155-492c771e-520d-4cd1-a8c1-2a8dcf0fed59.png)
