### PR TITLE
Add label to GitLab widget's comment body toggle

### DIFF
--- a/changelog.d/517.feature
+++ b/changelog.d/517.feature
@@ -1,0 +1,1 @@
+Add new GitLab connection flag `includeCommentBody`, to enable including the body of comments on MR notifications.

--- a/web/components/elements/InputField.tsx
+++ b/web/components/elements/InputField.tsx
@@ -5,11 +5,12 @@ interface Props {
     visible?: boolean;
     label?: string;
     noPadding: boolean;
+    innerChild?: boolean;
 }
 
-export const InputField: FunctionComponent<Props> = ({ children, visible = true, label, noPadding }) => {
-    return visible && <div className={style.inputField}>
-        {label && <label className={noPadding ? style.nopad : ""}>{label}</label>}
-        {children}
-    </div>;
+export const InputField: FunctionComponent<Props> = ({ children, visible = true, label, noPadding, innerChild = false }) => {
+    return visible ? <div className={style.inputField}>
+        {label && <label className={noPadding ? style.nopad : ""}>{innerChild && children}{label}</label>}
+        {(!label || !innerChild) && children}
+    </div> : <></>
 };

--- a/web/components/roomConfig/GitlabRepoConfig.tsx
+++ b/web/components/roomConfig/GitlabRepoConfig.tsx
@@ -159,7 +159,7 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ne
         <InputField visible={!!existingConnection || !!newInstanceState} label="Command Prefix" noPadding={true}>
             <input ref={commandPrefixRef} type="text" value={existingConnection?.config.commandPrefix} placeholder="!gl" />
         </InputField>
-        <InputField visible={!!existingConnection || !!newInstanceState} label="" noPadding={true}>
+        <InputField visible={!!existingConnection || !!newInstanceState} label="Include comment bodies" noPadding={true} innerChild={true}>
             <input ref={includeBodyRef} disabled={!canEdit} type="checkbox" checked={!!existingConnection?.config.includeCommentBody} />
         </InputField>
         <InputField visible={!!existingConnection || !!newInstanceState} label="Events" noPadding={true}>


### PR DESCRIPTION
Fixes #513 
![image](https://user-images.githubusercontent.com/3271094/193741195-9b8652e9-c5f9-4460-b5ab-dff69c374f3d.png)
