### PR TITLE
Don't send empty query string in widget API reqs

### DIFF
--- a/changelog.d/518.misc
+++ b/changelog.d/518.misc
@@ -1,0 +1,1 @@
+Don't send empty query string in some widget API requests.

--- a/web/BridgeAPI.ts
+++ b/web/BridgeAPI.ts
@@ -130,7 +130,7 @@ export class BridgeAPI {
     }
 
     getConnectionTargets<R>(type: string, filters?: Record<never, never>|Record<string, string>): Promise<R[]> {
-        const searchParams = filters && new URLSearchParams(filters);
+        const searchParams = filters && !!Object.keys(filters).length && new URLSearchParams(filters);
         return this.request('GET', `/widgetapi/v1/targets/${encodeURIComponent(type)}${searchParams ? `?${searchParams}` : ''}`);
     }
 }


### PR DESCRIPTION
Nitpick change to avoid a trailing `?` in `/widgetapi/v1/targets/<type>` query URLs when not using any filters.