### PR TITLE
Let GitHub widget support "issue.labeled"

### DIFF
--- a/changelog.d/519.bugfix
+++ b/changelog.d/519.bugfix
@@ -1,0 +1,1 @@
+Fix support for the "Labeled" event in the GitHub widget.

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -90,6 +90,7 @@ const AllowedEvents: AllowedEventsNames[] = [
     "issue.changed" ,
     "issue.created" ,
     "issue.edited" ,
+    "issue.labeled" ,
     "issue" ,
     "pull_request.closed" ,
     "pull_request.merged" ,


### PR DESCRIPTION
The bridge supports it, but schema validation didn't think so