### PR TITLE
Add support for GitHub workflow run completion events

### DIFF
--- a/changelog.d/520.feature
+++ b/changelog.d/520.feature
@@ -1,0 +1,1 @@
+Add support for notifying when a GitHub workflow completes.

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -322,6 +322,12 @@ export class Bridge {
             (c, data) => c.onPRReviewed(data),
         );
 
+        this.bindHandlerToQueue<GitHubWebhookTypes.WorkflowRunCompletedEvent, GitHubRepoConnection>(
+            "github.workflow_run.completed",
+            (data) => connManager.getConnectionsForGithubRepo(data.repository.owner.login, data.repository.name), 
+            (c, data) => c.onWorkflowCompleted(data),
+        );
+
         this.bindHandlerToQueue<GitHubWebhookTypes.ReleaseCreatedEvent, GitHubRepoConnection>(
             "github.release.created",
             (data) => connManager.getConnectionsForGithubRepo(data.repository.owner.login, data.repository.name), 


### PR DESCRIPTION
So we can spot failures, looks a bit like:

![image](https://user-images.githubusercontent.com/2072976/194298679-c067974a-7fe5-4d18-b4c6-38fa6c86e5c9.png)
