### PR TITLE
Disable GitHub workflow events by default

### DIFF
--- a/changelog.d/528.feature
+++ b/changelog.d/528.feature
@@ -1,0 +1,1 @@
+Disable GitHub workflow events by default.

--- a/docs/usage/room_configuration/github_repo.md
+++ b/docs/usage/room_configuration/github_repo.md
@@ -27,7 +27,8 @@ This connection supports a few options which can be defined in the room state:
 
 | Option | Description | Allowed values | Default |
 |--------|-------------|----------------|---------|
-|ignoreHooks|Choose to exclude notifications for some event types|Array of: [Supported event types](#supported-event-types) |*empty*|
+|enableHooks [^1]|Enable notifications for some event types|Array of: [Supported event types](#supported-event-types) |*empty*|
+|ignoreHooks [^1]|Choose to exclude notifications for some event types|Array of: [Supported event types](#supported-event-types) |*empty*|
 |commandPrefix|Choose the prefix to use when sending commands to the bot|A string, ideally starts with "!"|`!gh`|
 |showIssueRoomLink|When new issues are created, provide a Matrix alias link to the issue room|`true/false`|`false`|
 |prDiff|Show a diff in the room when a PR is created, subject to limits|`{enabled: boolean, maxLines: number}`|`{enabled: false}`|
@@ -40,21 +41,28 @@ This connection supports a few options which can be defined in the room state:
 |workflowRun.matchingBranch|Only report workflow runs if it matches this regex.|Regex string|*empty*|
 
 
+[^1]: `ignoreHooks` takes precedence over `enableHooks`.
+
+
 ### Supported event types
 
 This connection supports sending messages when the following actions happen on the repository.
 
-- issue
-  - issue.created
-  - issue.changed
-  - issue.edited
-  - issue.labeled
-- pull_request
-  - pull_request.closed
-  - pull_request.merged
-  - pull_request.opened
-  - pull_request.ready_for_review
-  - pull_request.reviewed
+Note: Some of these event types are enabled by default (marked with a `*`)
+
+- issue *
+  - issue.created *
+  - issue.changed *
+  - issue.edited *
+  - issue.labeled *
+- pull_request *
+  - pull_request.closed *
+  - pull_request.merged *
+  - pull_request.opened *
+  - pull_request.ready_for_review *
+  - pull_request.reviewed *
+- release *
+  - release.created *
 - workflow.run
   - workflow.run.success
   - workflow.run.failure
@@ -63,5 +71,3 @@ This connection supports sending messages when the following actions happen on t
   - workflow.run.timed_out
   - workflow.run.stale
   - workflow.run.action_required
-- release
-  - release.created

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -46,16 +46,15 @@ export class ConnectionManager extends EventEmitter {
     /**
      * Push a new connection to the manager, if this connection already
      * exists then this will no-op.
-     * NOTE: The comparison only checks that the same object instance isn't present,
-     * but not if two instances exist with the same type/state.
      * @param connection The connection instance to push.
      */
     public push(...connections: IConnection[]) {
         for (const connection of connections) {
-            if (!this.connections.find(c => c.connectionId === connection.connectionId)) {
-                this.connections.push(connection);
-                this.emit('new-connection', connection);
+            if (this.connections.some(c => c.connectionId === connection.connectionId)) {
+                return;
             }
+            this.connections.push(connection);
+            this.emit('new-connection', connection);
         }
         Metrics.connections.set(this.connections.length);
         // Already exists, noop.

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -311,7 +311,8 @@ export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnection
                 throw Error('Invalid state, missing `path` or `instance`');
             }
             this.hookFilter = new HookFilter(
-                [],
+                // GitLab allows all events by default
+                AllowedEvents,
                 [],
                 state.ignoreHooks,
             );

--- a/src/HookFilter.ts
+++ b/src/HookFilter.ts
@@ -1,0 +1,19 @@
+export class HookFilter<T extends string> {
+    constructor(
+        public readonly defaultHooks: T[],
+        public enabledHooks: T[] = [],
+        public ignoredHooks: T[] = []
+    ) {
+
+    }
+
+    public shouldSkip(...hookName: T[]) {
+        if (hookName.some(name => this.ignoredHooks.includes(name))) {
+            return true;
+        }
+        if (hookName.some(name => this.enabledHooks.includes(name))) {
+            return false;
+        }
+        return !hookName.some(h => this.defaultHooks.includes(h));
+    }
+}

--- a/tests/HookFilter.ts
+++ b/tests/HookFilter.ts
@@ -1,0 +1,31 @@
+import { expect } from "chai";
+import { HookFilter } from '../src/HookFilter';
+
+const DEFAULT_SET = ['default-allowed', 'default-allowed-but-ignored'];
+const ENABLED_SET = ['enabled-hook', 'enabled-but-ignored'];
+const IGNORED_SET = ['ignored', 'enabled-but-ignored', 'default-allowed-but-ignored'];
+
+describe("HookFilter", () => {
+    let filter: HookFilter<string>;
+    beforeEach(() => {
+        filter = new HookFilter(DEFAULT_SET, ENABLED_SET, IGNORED_SET);
+    });
+    it('should skip a hook named in ignoreHooks', () => {
+        expect(filter.shouldSkip('ignored')).to.be.true;
+    });
+    it('should allow a hook named in defaults', () => {
+        expect(filter.shouldSkip('default-allowed')).to.be.false;
+    });
+    it('should allow a hook named in enabled', () => {
+        expect(filter.shouldSkip('enabled-hook')).to.be.false;
+    });
+    it('should skip a hook named in defaults but also in ignored', () => {
+        expect(filter.shouldSkip('default-allowed-but-ignored')).to.be.true;
+    });
+    it('should skip a hook named in enabled but also in ignored', () => {
+        expect(filter.shouldSkip('enabled-but-ignored')).to.be.true;
+    });
+    it('should skip if any hooks are in ignored', () => {
+        expect(filter.shouldSkip('enabled-hook', 'enabled-but-ignored')).to.be.true;
+    });
+});

--- a/web/components/elements/InputField.tsx
+++ b/web/components/elements/InputField.tsx
@@ -2,7 +2,7 @@ import { h, FunctionComponent } from "preact";
 import style from "./InputField.module.scss";
 
 interface Props {
-    className: string;
+    className?: string;
     visible?: boolean;
     label?: string;
     noPadding: boolean;

--- a/web/components/roomConfig/GithubRepoConfig.tsx
+++ b/web/components/roomConfig/GithubRepoConfig.tsx
@@ -6,6 +6,7 @@ import { ErrCode } from "../../../src/api";
 import { GitHubRepoConnectionState, GitHubRepoResponseItem, GitHubRepoConnectionRepoTarget, GitHubTargetFilter, GitHubRepoConnectionOrgTarget } from "../../../src/Connections/GithubRepo";
 import { InputField, ButtonSet, Button, ErrorPane } from "../elements";
 import GitHubIcon from "../../icons/github.png";
+import e from "express";
 
 const EventType = "uk.half-shot.matrix-hookshot.github.repository";
 const NUM_REPOS_PER_PAGE = 10;
@@ -136,9 +137,14 @@ const EventCheckbox: FunctionComponent<{
     if (enabledHooks) {
         disabled = !!(parentEvent && !enabledHooks.includes(parentEvent));
         checked = enabledHooks.includes(eventName);
-    }
-
-    if (ignoredHooks) {
+        if (ignoredHooks?.includes(eventName)) {
+            // If both are set, this was previously a on-by-default event
+            // that is now off-by-default, and so we need to check both fields.
+            disabled = !!(parentEvent && ignoredHooks.includes(parentEvent)); 
+            checked = true
+        }
+    } else if (ignoredHooks) {
+        // If enabled hooks is not set, this is on-by-default hook.
         disabled = !!(parentEvent && ignoredHooks.includes(parentEvent)); 
         checked = !ignoredHooks.includes(eventName);
     }

--- a/web/components/roomConfig/GithubRepoConfig.tsx
+++ b/web/components/roomConfig/GithubRepoConfig.tsx
@@ -6,7 +6,6 @@ import { ErrCode } from "../../../src/api";
 import { GitHubRepoConnectionState, GitHubRepoResponseItem, GitHubRepoConnectionRepoTarget, GitHubTargetFilter, GitHubRepoConnectionOrgTarget } from "../../../src/Connections/GithubRepo";
 import { InputField, ButtonSet, Button, ErrorPane } from "../elements";
 import GitHubIcon from "../../icons/github.png";
-import e from "express";
 
 const EventType = "uk.half-shot.matrix-hookshot.github.repository";
 const NUM_REPOS_PER_PAGE = 10;


### PR DESCRIPTION
Fixes #527 

This is my attempt to change our model so we can support events being disabled by default. The problem with the current state model is that `ignoreHooks` doesn't allow you to be explicit about what events you would like enabled, therefore there is now a second field called `enabledHooks`.

In the future, I am minded to refactor and drop ignoreHooks (except for backwards compat) and just make our default hooks explicit in the state event itself upon creation.

However, for now we can juggle two events. To make this easier, I've added a helper class and some tests.