### PR TITLE
Skip GitLab MR reply comments

### DIFF
--- a/changelog.d/536.bugfix
+++ b/changelog.d/536.bugfix
@@ -1,0 +1,1 @@
+Do not send a notice when a user replies to a GitLab comment, or when GitLab comment notices have been disabled.

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -655,7 +655,7 @@ ${data.description}`;
             if (commentNotes) {
                 existing.commentNotes = [...(existing.commentNotes ?? []), ...commentNotes];
             }
-            existing.commentCount = existing.commentCount + opts.commentCount;
+            existing.commentCount += opts.commentCount;
             if (!opts.skip) {
                 existing.skip = false;
             }

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -698,7 +698,7 @@ ${data.description}`;
         // Check to see if this line has had a comment before
         if (event.object_attributes.discussion_id) {
             if (this.mergeRequestSeenDiscussionIds.has(event.object_attributes.discussion_id)) {
-                // If it has, this is probably a reply. Replies are noise, skip em.
+                // If it has, this is probably a reply. Skip repeated replies.
                 return false;
             }
             // Otherwise, record that we have seen the line and continue (it's probably a genuine comment).

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -294,7 +294,7 @@ export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnection
      * so we need to determine if we've seen a comment for a line before, and
      * skip it if we have (because it's probably a reply).
      */
-    private readonly mergeRequestSeenLineCodes = new QuickLRU<string, undefined>({ maxSize: 100 });
+    private readonly mergeRequestSeenDiscussionIds = new QuickLRU<string, undefined>({ maxSize: 100 });
 
     constructor(roomId: string,
         stateKey: string,
@@ -696,13 +696,13 @@ ${data.description}`;
 
     private shouldHandleMRComment(event: IGitLabWebhookNoteEvent) {
         // Check to see if this line has had a comment before
-        if (event.object_attributes.line_code) {
-            if (this.mergeRequestSeenLineCodes.has(event.object_attributes.line_code)) {
+        if (event.object_attributes.discussion_id) {
+            if (this.mergeRequestSeenDiscussionIds.has(event.object_attributes.discussion_id)) {
                 // If it has, this is probably a reply. Replies are noise, skip em.
                 return false;
             }
             // Otherwise, record that we have seen the line and continue (it's probably a genuine comment).
-            this.mergeRequestSeenLineCodes.set(event.object_attributes.line_code, undefined);
+            this.mergeRequestSeenDiscussionIds.set(event.object_attributes.discussion_id, undefined);
         }
         return true;
     }

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -290,7 +290,7 @@ export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnection
     }>();
 
     /**
-     * GitLab provides NO threading information in it's webhook response objects,
+     * GitLab provides NO threading information in its webhook response objects,
      * so we need to determine if we've seen a comment for a line before, and
      * skip it if we have (because it's probably a reply).
      */

--- a/src/Gitlab/WebhookTypes.ts
+++ b/src/Gitlab/WebhookTypes.ts
@@ -183,7 +183,7 @@ export interface IGitLabNote {
     author_id: number;
     noteable_id: number;
     description: string;
-    line_code?: string;
+    discussion_id?: string;
 }
 
 export interface IGitLabWebhookNoteEvent {

--- a/src/Gitlab/WebhookTypes.ts
+++ b/src/Gitlab/WebhookTypes.ts
@@ -183,6 +183,7 @@ export interface IGitLabNote {
     author_id: number;
     noteable_id: number;
     description: string;
+    line_code?: string;
 }
 
 export interface IGitLabWebhookNoteEvent {


### PR DESCRIPTION
GitLab uses `discussion_id` to chain together replies. We can't really tell what position we are *in* the thread, so we just have to assume that if we've not seen the discussion before that we are the first note, and subsequent notes are child notes.

This also changes the code so that we skip sending a notice into the room if the user has disabled comment-only notices.