### PR TITLE
Check GitLab Repo access level via a better API

### DIFF
--- a/changelog.d/539.bugfix
+++ b/changelog.d/539.bugfix
@@ -1,0 +1,1 @@
+Parent projects are now taken into account when calculating a user's access level to a GitLab project.

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -193,10 +193,7 @@ export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnection
         let permissionLevel;
         let project;
         try {
-            project = await client.projects.get(validData.path);
-            // Get the actual casing of the project path
-            validData.path = project.path_with_namespace;
-            permissionLevel = Math.max(project.permissions.group_access?.access_level || 0, project.permissions.project_access?.access_level || 0) as AccessLevel;
+            permissionLevel = await client.projects.getMyAccessLevel(validData.path);
         } catch (ex) {
             throw new ApiError("Could not determine if the user has access to this project, does the project exist?", ErrCode.ForbiddenUser);
         }

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -191,7 +191,6 @@ export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnection
             throw new ApiError("User is not authenticated with GitLab", ErrCode.ForbiddenUser);
         }
         let permissionLevel;
-        let project;
         try {
             permissionLevel = await client.projects.getMyAccessLevel(validData.path);
         } catch (ex) {
@@ -201,6 +200,8 @@ export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnection
         if (permissionLevel < AccessLevel.Developer) {
             throw new ApiError("You must at least have developer access to bridge this project", ErrCode.ForbiddenUser);
         }
+        
+        const project = await client.projects.get(validData.path);
 
         const stateEventKey = `${validData.instance}/${validData.path}`;
         const connection = new GitLabRepoConnection(roomId, stateEventKey, as, validData, tokenStore, instance);

--- a/src/Gitlab/Client.ts
+++ b/src/Gitlab/Client.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError } from "axios";
+import axios from "axios";
 import { GitLabInstance } from "../Config/Config";
 import { GetIssueResponse, GetUserResponse, CreateIssueOpts, CreateIssueResponse, GetIssueOpts, EditIssueOpts, GetTodosResponse, EventsOpts, CreateIssueNoteOpts, CreateIssueNoteResponse, GetProjectResponse, ProjectHook, ProjectHookOpts, AccessLevel, SimpleProject } from "./Types";
 import { Logger } from "matrix-appservice-bridge";

--- a/src/Gitlab/Client.ts
+++ b/src/Gitlab/Client.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import { GitLabInstance } from "../Config/Config";
 import { GetIssueResponse, GetUserResponse, CreateIssueOpts, CreateIssueResponse, GetIssueOpts, EditIssueOpts, GetTodosResponse, EventsOpts, CreateIssueNoteOpts, CreateIssueNoteResponse, GetProjectResponse, ProjectHook, ProjectHookOpts, AccessLevel, SimpleProject } from "./Types";
 import { Logger } from "matrix-appservice-bridge";
@@ -134,6 +134,17 @@ export class GitLabClient {
         }
     }
 
+    public async getProjectAccessLevel(id: ProjectId): Promise<AccessLevel> {
+        try {
+            const me = await this.user();
+            const { data } = await axios.get(`api/v4/projects/${encodeURIComponent(id)}/members/${me.id}`, this.defaultConfig);
+            return data.access_level as AccessLevel;
+        } catch (ex) {
+            log.warn(`Failed to get project access level:`, ex);
+            throw ex;
+        }
+    }
+
     get issues() {
         return {
             create: this.createIssue.bind(this),
@@ -145,6 +156,7 @@ export class GitLabClient {
         return {
             get: this.getProject.bind(this),
             list: this.listProjects.bind(this),
+            getMyAccessLevel: this.getProjectAccessLevel.bind(this),
             hooks: {
                 list: this.getProjectHooks.bind(this),
                 add: this.addProjectHook.bind(this),

--- a/src/Gitlab/Client.ts
+++ b/src/Gitlab/Client.ts
@@ -145,6 +145,9 @@ export class GitLabClient {
             const me = await this.user();
             // https://docs.gitlab.com/ee/api/members.html#get-a-member-of-a-group-or-project-including-inherited-and-invited-members
             const { data } = await axios.get(`api/v4/projects/${encodeURIComponent(id)}/members/all/${me.id}`, this.defaultConfig);
+            if (typeof data?.access_level !== "number") {
+                throw Error(`Unexpected value for data.access_level. '${data?.access_level}'`);
+            } 
             return data.access_level as AccessLevel;
         } catch (ex) {
             if (axios.isAxiosError(ex)) {


### PR DESCRIPTION
Fixes #538 

Use a better API for checking access levels, that accounts for parent group permissions rather than just project permissions.