### PR TITLE
Allow multiple Jira connections; stop prefix clash

### DIFF
--- a/changelog.d/540.feature
+++ b/changelog.d/540.feature
@@ -1,0 +1,1 @@
+Allow multiple Jira connections at a time (either in the same room or across multiple rooms).

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -252,8 +252,11 @@ export class ConnectionManager extends EventEmitter {
     public validateCommandPrefix(roomId: string, config: IConnectionState, currentConnection?: IConnection) {
         if (config.commandPrefix === undefined) return;
         for (const c of this.getAllConnectionsForRoom(roomId)) {
-            if (c != currentConnection && c.conflictsWithCommandPrefix(config.commandPrefix)) {
-                throw new ApiError(`Command prefix "${config.commandPrefix}" is already used in this room. Please choose another prefix.`);
+            if (c != currentConnection && c.conflictsWithCommandPrefix?.(config.commandPrefix)) {
+                throw new ApiError(`Command prefix "${config.commandPrefix}" is already used in this room. Please choose another prefix.`, ErrCode.ConflictingConnection, -1, {
+                        existingConnection: c.getProvisionerDetails?.(),
+                    }
+                );
             }
         }
     }

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -7,7 +7,7 @@
 import { Appservice, StateEvent } from "matrix-bot-sdk";
 import { CommentProcessor } from "./CommentProcessor";
 import { BridgeConfig, BridgePermissionLevel, GitLabInstance } from "./Config/Config";
-import { ConnectionDeclarations, GenericHookConnection, GitHubDiscussionConnection, GitHubDiscussionSpace, GitHubIssueConnection, GitHubProjectConnection, GitHubRepoConnection, GitHubUserSpace, GitLabIssueConnection, GitLabRepoConnection, IConnection, JiraProjectConnection } from "./Connections";
+import { ConnectionDeclarations, GenericHookConnection, GitHubDiscussionConnection, GitHubDiscussionSpace, GitHubIssueConnection, GitHubProjectConnection, GitHubRepoConnection, GitHubUserSpace, GitLabIssueConnection, GitLabRepoConnection, IConnection, IConnectionState, JiraProjectConnection } from "./Connections";
 import { GithubInstance } from "./Github/GithubInstance";
 import { GitLabClient } from "./Gitlab/Client";
 import { JiraProject } from "./Jira/Types";
@@ -247,6 +247,15 @@ export class ConnectionManager extends EventEmitter {
 
     public getConnectionById(roomId: string, connectionId: string) {
         return this.connections.find((c) => c.connectionId === connectionId && c.roomId === roomId);
+    }
+
+    public validateCommandPrefix(roomId: string, config: IConnectionState, currentConnection?: IConnection) {
+        if (config.commandPrefix === undefined) return;
+        for (const c of this.getAllConnectionsForRoom(roomId)) {
+            if (c != currentConnection && c.conflictsWithCommandPrefix(config.commandPrefix)) {
+                throw new ApiError(`Command prefix "${config.commandPrefix}" is already used in this room. Please choose another prefix.`);
+            }
+        }
     }
 
     public async purgeConnection(roomId: string, connectionId: string, requireNoRemoveHandler = true) {

--- a/src/Connections/BaseConnection.ts
+++ b/src/Connections/BaseConnection.ts
@@ -18,9 +18,4 @@ export abstract class BaseConnection {
     public get priority(): number {
         return -1;
     }
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public conflictsWithCommandPrefix(commandPrefix: string) {
-        return false;
-    }
 }

--- a/src/Connections/BaseConnection.ts
+++ b/src/Connections/BaseConnection.ts
@@ -18,4 +18,9 @@ export abstract class BaseConnection {
     public get priority(): number {
         return -1;
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    public conflictsWithCommandPrefix(commandPrefix: string) {
+        return false;
+    }
 }

--- a/src/Connections/CommandConnection.ts
+++ b/src/Connections/CommandConnection.ts
@@ -31,6 +31,10 @@ export abstract class CommandConnection<StateType extends IConnectionState = ICo
         return (this.state.commandPrefix || this.defaultCommandPrefix) + " ";
     }
 
+    public conflictsWithCommandPrefix(commandPrefix: string) {
+        return this.commandPrefix == commandPrefix + " ";
+    }
+
     public async onStateUpdate(stateEv: MatrixEvent<unknown>) {
         this.state = this.validateConnectionState(stateEv.content);
     }

--- a/src/Connections/IConnection.ts
+++ b/src/Connections/IConnection.ts
@@ -76,6 +76,8 @@ export interface IConnection {
     onRemove?: () => Promise<void>;
 
     toString(): string;
+
+    conflictsWithCommandPrefix(commandPrefix: string): boolean;
 }
 
 

--- a/src/Connections/IConnection.ts
+++ b/src/Connections/IConnection.ts
@@ -77,7 +77,7 @@ export interface IConnection {
 
     toString(): string;
 
-    conflictsWithCommandPrefix(commandPrefix: string): boolean;
+    conflictsWithCommandPrefix?: (commandPrefix: string) => boolean;
 }
 
 

--- a/src/Connections/JiraProject.ts
+++ b/src/Connections/JiraProject.ts
@@ -91,11 +91,6 @@ export class JiraProjectConnection extends CommandConnection<JiraProjectConnecti
         if (!config.jira) {
             throw new ApiError('JIRA integration is not configured', ErrCode.DisabledFeature);
         }
-        const existingConnections = getAllConnectionsOfType(JiraProjectConnection);
-        if (existingConnections.find(c => c instanceof JiraProjectConnection)) {
-            // TODO: Support this.
-            throw Error("Cannot support multiple connections of the same type yet");
-        }
         const validData = validateJiraConnectionState(data);
         log.info(`Attempting to provisionConnection for ${roomId} ${validData.url} on behalf of ${userId}`);
         const jiraClient = await tokenStore.getJiraForUser(userId, validData.url);

--- a/src/Widgets/BridgeWidgetApi.ts
+++ b/src/Widgets/BridgeWidgetApi.ts
@@ -133,6 +133,7 @@ export class BridgeWidgetApi {
             if (!req.body || typeof req.body !== "object") {
                 throw new ApiError("A JSON body must be provided", ErrCode.BadValue);
             }
+            this.connMan.validateCommandPrefix(req.params.roomId, req.body);
             const connection = await this.connMan.provisionConnection(req.params.roomId as string, req.userId, req.params.type as string, req.body as Record<string, unknown>);
             if (!connection.getProvisionerDetails) {
                 throw new Error('Connection supported provisioning but not getProvisionerDetails');
@@ -156,6 +157,7 @@ export class BridgeWidgetApi {
         if (!connection.provisionerUpdateConfig || !connection.getProvisionerDetails)  {
             throw new ApiError("Connection type does not support updates", ErrCode.UnsupportedOperation);
         }
+        this.connMan.validateCommandPrefix(req.params.roomId, req.body, connection);
         await connection.provisionerUpdateConfig(req.userId, req.body);
         res.send(connection.getProvisionerDetails(true));
     }

--- a/src/provisioning/provisioner.ts
+++ b/src/provisioning/provisioner.ts
@@ -135,6 +135,7 @@ export class Provisioner {
             if (!req.body || typeof req.body !== "object") {
                 throw new ApiError("A JSON body must be provided.", ErrCode.BadValue);
             }
+            this.connMan.validateCommandPrefix(req.params.roomId, req.body);
             const connection = await this.connMan.provisionConnection(req.params.roomId, req.query.userId, req.params.type, req.body);
             if (!connection.getProvisionerDetails) {
                 throw new Error('Connection supported provisioning but not getProvisionerDetails.');
@@ -155,6 +156,7 @@ export class Provisioner {
             if (!connection.provisionerUpdateConfig || !connection.getProvisionerDetails)  {
                 return next(new ApiError("Connection type does not support updates.", ErrCode.UnsupportedOperation));
             }
+            this.connMan.validateCommandPrefix(req.params.roomId, req.body, connection);
             await connection.provisionerUpdateConfig(req.query.userId, req.body);
             res.send(connection.getProvisionerDetails(true));
         } catch (ex) {


### PR DESCRIPTION
Fixes #533
Mitigates #421

----
![image](https://user-images.githubusercontent.com/3271094/196353095-803ddf43-4cd0-4809-b37f-4f74f57578a4.png)

Attempting to add a connection with a command prefix that's already in use for the room will fail:
![Screenshot from 2022-10-18 02-22-00](https://user-images.githubusercontent.com/3271094/196352458-f9d123da-e6a1-4e7e-b429-1e36e839cbfb.png)

