### PR TITLE
Fix & refactor Jira issue event handling

### DIFF
--- a/changelog.d/543.bugfix
+++ b/changelog.d/543.bugfix
@@ -1,0 +1,1 @@
+Fix the Jira config widget to properly add listeners for issue creation events & expose support for issue update events.

--- a/docs/usage/room_configuration/jira_project.md
+++ b/docs/usage/room_configuration/jira_project.md
@@ -29,10 +29,14 @@ This connection supports a few options which can be defined in the room state:
 
 | Option | Description | Allowed values | Default |
 |--------|-------------|----------------|---------|
-|events|Choose to include notifications for some event types|Array of: [Supported event types](#supported-event-types) |*empty*|
+|events|Choose to include notifications for some event types|Array of: [Supported event types](#supported-event-types) |`issue_created`|
 |commandPrefix|Choose the prefix to use when sending commands to the bot|A string, ideally starts with "!"|`!jira`|
 
 
 ### Supported event types
 
-This connection currently supports sending messages only when a `issue.created` action happens on the project.
+This connection supports sending messages when the following actions happen on the project.
+
+- issue
+  - issue_created
+  - issue_updated

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -506,16 +506,16 @@ export class Bridge {
     
         this.bindHandlerToQueue<JiraIssueEvent, JiraProjectConnection>(
             "jira.issue_created",
-            (data) => connManager.getConnectionsForJiraProject(data.issue.fields.project, "jira.issue_created"), 
+            (data) => connManager.getConnectionsForJiraProject(data.issue.fields.project),
             (c, data) => c.onJiraIssueCreated(data),
         );
 
         this.bindHandlerToQueue<JiraIssueUpdatedEvent, JiraProjectConnection>(
             "jira.issue_updated",
-            (data) => connManager.getConnectionsForJiraProject(data.issue.fields.project, "jira.issue_updated"), 
+            (data) => connManager.getConnectionsForJiraProject(data.issue.fields.project),
             (c, data) => c.onJiraIssueUpdated(data),
         );
-    
+
         this.queue.on<JiraOAuthRequestCloud|JiraOAuthRequestOnPrem>("jira.oauth.response", async (msg) => {
             if (!this.config.jira || !this.tokenStore.jiraOAuth) {
                 throw Error('Cannot handle, JIRA oauth support not enabled');

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -209,11 +209,8 @@ export class ConnectionManager extends EventEmitter {
         return this.connections.filter((c) => (c instanceof GitLabRepoConnection && c.path === pathWithNamespace)) as GitLabRepoConnection[];
     }
 
-    public getConnectionsForJiraProject(project: JiraProject, eventName: string): JiraProjectConnection[] {
-        return this.connections.filter((c) => 
-            (c instanceof JiraProjectConnection &&
-                c.interestedInProject(project) &&
-                c.isInterestedInHookEvent(eventName))) as JiraProjectConnection[];
+    public getConnectionsForJiraProject(project: JiraProject): JiraProjectConnection[] {
+        return this.connections.filter((c) => (c instanceof JiraProjectConnection && c.interestedInProject(project))) as JiraProjectConnection[];
     }
 
     public getConnectionsForGenericWebhook(hookId: string): GenericHookConnection[] {

--- a/src/Connections/IConnection.ts
+++ b/src/Connections/IConnection.ts
@@ -53,11 +53,6 @@ export interface IConnection {
     isInterestedInStateEvent: (eventType: string, stateKey: string) => boolean;
 
     /**
-     * Is the connection interested in the event that is being sent from the remote side?
-     */
-    isInterestedInHookEvent?: (eventType: string) => boolean;
-
-    /**
      * The details to be sent to the provisioner when requested about this connection.
      */
     getProvisionerDetails?: (showSecrets?: boolean) => GetConnectionsResponseItem;

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -116,9 +116,9 @@ export class Webhooks extends EventEmitter {
     }
 
     private onJiraPayload(body: IJiraWebhookEvent) {
-        const webhookEvent = body.webhookEvent.replace("jira:", "");
-        log.debug(`onJiraPayload ${webhookEvent}:`, body);
-        return `jira.${webhookEvent}`;
+        body.webhookEvent = body.webhookEvent.replace("jira:", "");
+        log.debug(`onJiraPayload ${body.webhookEvent}:`, body);
+        return `jira.${body.webhookEvent}`;
     }
 
     private async onGitHubPayload({id, name, payload}: EmitterWebhookEvent) {

--- a/web/components/roomConfig/JiraProjectConfig.tsx
+++ b/web/components/roomConfig/JiraProjectConfig.tsx
@@ -134,7 +134,7 @@ const EventCheckbox: FunctionComponent<{
 };
 
 const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<never, JiraProjectResponseItem, JiraProjectConnectionState>> = ({api, existingConnection, onSave, onRemove }) => {
-    const [allowedEvents, setAllowedEvents] = useState<string[]>(existingConnection?.config.events || []);
+    const [allowedEvents, setAllowedEvents] = useState<string[]>(existingConnection?.config.events || ['issue_created']);
 
     const toggleEvent = useCallback((evt: Event) => {
         const key = (evt.target as HTMLElement).getAttribute('x-event-name');
@@ -171,7 +171,11 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ne
         <InputField visible={!!existingConnection || !!newConnectionState} label="Events" noPadding={true}>
             <p>Choose which event should send a notification to the room</p>
             <ul>
-                <EventCheckbox allowedEvents={allowedEvents} eventName="issue.created" onChange={toggleEvent}>Issue created</EventCheckbox>
+                Issues
+                <ul>
+                    <EventCheckbox allowedEvents={allowedEvents} eventName="issue_created" onChange={toggleEvent}>Created</EventCheckbox>
+                    <EventCheckbox allowedEvents={allowedEvents} eventName="issue_updated" onChange={toggleEvent}>Updated</EventCheckbox>
+                </ul>
             </ul>
         </InputField>
         <ButtonSet>


### PR DESCRIPTION
- Refactor Jira event handling to be more like GitHub & GitLab
- Fix silently-ignored Jira events due to expecting wrong type strings
- Update UI for Jira events

---

This is the portion of #534 unrelated to version events, split into its own PR for better visibility.