### PR TITLE
Don't lower-case GitLab URLs with bot command 

### DIFF
--- a/changelog.d/553.bugfix
+++ b/changelog.d/553.bugfix
@@ -1,0 +1,1 @@
+Don't ignore events from GitLab projects that have capital letters in their project path, and had their room connection set up by the configuration widget or provisioning API.

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -205,7 +205,7 @@ export class ConnectionManager extends EventEmitter {
 
     public getConnectionsForGitLabRepo(pathWithNamespace: string): GitLabRepoConnection[] {
         pathWithNamespace = pathWithNamespace.toLowerCase();
-        return this.connections.filter((c) => (c instanceof GitLabRepoConnection && c.path === pathWithNamespace)) as GitLabRepoConnection[];
+        return this.connections.filter((c) => (c instanceof GitLabRepoConnection && c.path.toLowerCase() === pathWithNamespace)) as GitLabRepoConnection[];
     }
 
     public getConnectionsForJiraProject(project: JiraProject): JiraProjectConnection[] {

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -90,7 +90,6 @@ export class SetupConnection extends CommandConnection {
         if (!this.config.gitlab) {
             throw new CommandError("not-configured", "The bridge is not configured to support GitLab.");
         }
-        url = url.toLowerCase();
 
         await this.checkUserPermissions(userId, "gitlab", GitLabRepoConnection.CanonicalEventType);
 


### PR DESCRIPTION
This is a simpler fix than #511 because, although GitLab project paths seem to be case-sensitive, several scenarios effectively ignore their casing anyways [1], [2], so it's reasonable for Hookshot do to the same.

[1] https://gitlab.com/gitlab-org/gitlab/-/issues/14533
[2] https://gitlab.com/gitlab-org/gitlab-foss/-/issues/30997