### PR TITLE
Make GitLab path uniqueness case-insensitive

### DIFF
--- a/changelog.d/557.feature
+++ b/changelog.d/557.feature
@@ -1,0 +1,1 @@
+Forbid creating multiple GitLab connections on the same path with different letter casing.

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -206,7 +206,7 @@ export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnection
         const stateEventKey = `${validData.instance}/${validData.path}`;
         const connection = new GitLabRepoConnection(roomId, stateEventKey, as, validData, tokenStore, instance);
         const existingConnections = getAllConnectionsOfType(GitLabRepoConnection);
-        const existing = existingConnections.find(c => c.roomId === roomId && c.stateKey === connection.stateKey);
+        const existing = existingConnections.find(c => c.roomId === roomId && c.path === connection.path);
 
         if (existing) {
             throw new ApiError("A GitLab repo connection for this project already exists", ErrCode.ConflictingConnection, -1, {


### PR DESCRIPTION
NOTE: If a room already contains multiple GitLab connections with case-insensensitive identical paths, they will _not_ be removed.