### PR TITLE
Don't provision command-created connections twice

### DIFF
--- a/changelog.d/558.misc
+++ b/changelog.d/558.misc
@@ -1,0 +1,1 @@
+Don't provision a connection twice when using a bot command to create a connection.

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -881,6 +881,7 @@ export class Bridge {
                                 getAllConnectionsOfType: this.connectionManager.getAllConnectionsOfType.bind(this.connectionManager),
                             },
                             this.getOrCreateAdminRoom.bind(this),
+                            this.connectionManager.push.bind(this.connectionManager),
                         )
                     ).onMessageEvent(event, checkPermission);
                 } catch (ex) {

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -46,7 +46,7 @@ export class ConnectionManager extends EventEmitter {
     /**
      * Push a new connection to the manager, if this connection already
      * exists then this will no-op.
-     * @param connection The connection instance to push.
+     * @param connections The connection instances to push.
      */
     public push(...connections: IConnection[]) {
         for (const connection of connections) {


### PR DESCRIPTION
Without this change, adding a connection with a bot command creates the connection, but doesn't store it in memory (by pushing it into the connection manager's list of known connections).  Thus, what would actually store the connection in memory was the bot responding to its own room state event, which made it provision the connection again from scratch.