### PR TITLE
Harden against unauthorized changes to room state

### DIFF
--- a/changelog.d/565.bugfix
+++ b/changelog.d/565.bugfix
@@ -1,0 +1,1 @@
+Harden against unauthorized changes to room state for connection settings.

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -9,7 +9,7 @@ import { GetIssueResponse, GetIssueOpts } from "./Gitlab/Types"
 import { GithubInstance } from "./Github/GithubInstance";
 import { IBridgeStorageProvider } from "./Stores/StorageProvider";
 import { IConnection, GitHubDiscussionSpace, GitHubDiscussionConnection, GitHubUserSpace, JiraProjectConnection, GitLabRepoConnection,
-    GitHubIssueConnection, GitHubProjectConnection, GitHubRepoConnection, GitLabIssueConnection, FigmaFileConnection, FeedConnection, GenericHookConnection, ConnectionDeclaration } from "./Connections";
+    GitHubIssueConnection, GitHubProjectConnection, GitHubRepoConnection, GitLabIssueConnection, FigmaFileConnection, FeedConnection, GenericHookConnection } from "./Connections";
 import { IGitLabWebhookIssueStateEvent, IGitLabWebhookMREvent, IGitLabWebhookNoteEvent, IGitLabWebhookPushEvent, IGitLabWebhookReleaseEvent, IGitLabWebhookTagPushEvent, IGitLabWebhookWikiPageEvent } from "./Gitlab/WebhookTypes";
 import { JiraIssueEvent, JiraIssueUpdatedEvent, JiraVersionEvent } from "./Jira/WebhookTypes";
 import { JiraOAuthResult } from "./Jira/Types";
@@ -961,8 +961,7 @@ export class Bridge {
             const existingConnections = this.connectionManager.getInterestedForRoomState(roomId, event.type, event.state_key);
             const state = new StateEvent(event);
             for (const connection of existingConnections) {
-                const cd: ConnectionDeclaration = Object.getPrototypeOf(connection).constructor;
-                if (!this.connectionManager.verifyStateEvent(roomId, state, cd.ServiceCategory)) {
+                if (!this.connectionManager.verifyStateEventForConnection(connection, state)) {
                     continue;
                 }
                 try {

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -675,7 +675,7 @@ export class Bridge {
         await Promise.all(joinedRooms.map(async (roomId) => {
             log.debug("Fetching state for " + roomId);
             try {
-                await connManager.createConnectionsForRoomId(roomId);
+                await connManager.createConnectionsForRoomId(roomId, false);
             } catch (ex) {
                 log.error(`Unable to create connection for ${roomId}`, ex);
                 return;
@@ -939,7 +939,7 @@ export class Bridge {
 
         // Only fetch rooms we have no connections in yet.
         if (!this.connectionManager.isRoomConnected(roomId)) {
-            await this.connectionManager.createConnectionsForRoomId(roomId);
+            await this.connectionManager.createConnectionsForRoomId(roomId, true);
         }
     }
 
@@ -961,7 +961,7 @@ export class Bridge {
             const existingConnections = this.connectionManager.getInterestedForRoomState(roomId, event.type, event.state_key);
             const state = new StateEvent(event);
             for (const connection of existingConnections) {
-                if (!this.connectionManager.verifyStateEventForConnection(connection, state)) {
+                if (!this.connectionManager.verifyStateEventForConnection(connection, state, true)) {
                     continue;
                 }
                 try {
@@ -977,7 +977,7 @@ export class Bridge {
             }
             if (!existingConnections.length) {
                 // Is anyone interested in this state?
-                const connection = await this.connectionManager.createConnectionForState(roomId, new StateEvent(event));
+                const connection = await this.connectionManager.createConnectionForState(roomId, new StateEvent(event), true);
                 if (connection) {
                     log.info(`New connected added to ${roomId}: ${connection.toString()}`);
                     this.connectionManager.push(connection);

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -962,7 +962,7 @@ export class Bridge {
             const state = new StateEvent(event);
             for (const connection of existingConnections) {
                 const cd: ConnectionDeclaration = Object.getPrototypeOf(connection).constructor;
-                if (!this.connectionManager.assertStateAllowed(roomId, state, cd.ServiceCategory)) {
+                if (!this.connectionManager.verifyStateEvent(roomId, state, cd.ServiceCategory)) {
                     continue;
                 }
                 try {

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -91,7 +91,7 @@ export class ConnectionManager extends EventEmitter {
         throw new ApiError(`Connection type not known`);
     }
 
-    public assertStateAllowed(roomId: string, state: StateEvent<any>, serviceType: string) {
+    public assertStateAllowed(roomId: string, state: StateEvent, serviceType: string) {
         if (!this.isStateAllowed(roomId, state, serviceType)) {
             this.tryRestoreState(roomId, state, serviceType);
             log.error(`User ${state.sender} is disallowed to manage state for ${serviceType} in ${roomId}`);
@@ -101,12 +101,12 @@ export class ConnectionManager extends EventEmitter {
         }
     }
 
-    private isStateAllowed(roomId: string, state: StateEvent<any>, serviceType: string) {
+    private isStateAllowed(roomId: string, state: StateEvent, serviceType: string) {
         return state.sender === this.as.botUserId
             || this.config.checkPermission(state.sender, serviceType, BridgePermissionLevel.manageConnections);
     }
 
-    private async tryRestoreState(roomId: string, originalState: StateEvent<any>, serviceType: string) {
+    private async tryRestoreState(roomId: string, originalState: StateEvent, serviceType: string) {
         let state = originalState;
         try {
             do {

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -114,7 +114,8 @@ export class ConnectionManager extends EventEmitter {
                 if (state.unsigned.replaces_state) {
                     state = new StateEvent(await this.as.botClient.getEvent(roomId, state.unsigned.replaces_state));
                 } else {
-                    await this.as.botClient.redactEvent(roomId, originalState.eventId);
+                    await this.as.botClient.redactEvent(roomId, originalState.eventId,
+                        `User ${originalState.sender} is disallowed to manage state for ${serviceType} in ${roomId}`);
                     return;
                 }
             } while (--attemptsRemaining > 0 && !this.isStateAllowed(roomId, state, serviceType));

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -108,6 +108,7 @@ export class ConnectionManager extends EventEmitter {
 
     private async tryRestoreState(roomId: string, originalState: StateEvent, serviceType: string) {
         let state = originalState;
+        let attemptsRemaining = 5;
         try {
             do {
                 if (state.unsigned.replaces_state) {
@@ -116,7 +117,7 @@ export class ConnectionManager extends EventEmitter {
                     await this.as.botClient.redactEvent(roomId, originalState.eventId);
                     return;
                 }
-            } while (!this.isStateAllowed(roomId, state, serviceType));
+            } while (--attemptsRemaining > 0 && !this.isStateAllowed(roomId, state, serviceType));
             await this.as.botClient.sendStateEvent(roomId, state.type, state.stateKey, state.content);
         } catch (ex) {
             log.warn(`Unable to undo state event from ${state.sender} for disallowed ${serviceType} connection management in ${roomId}`);

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -7,7 +7,7 @@
 import { Appservice, StateEvent } from "matrix-bot-sdk";
 import { CommentProcessor } from "./CommentProcessor";
 import { BridgeConfig, BridgePermissionLevel, GitLabInstance } from "./Config/Config";
-import { ConnectionDeclarations, GenericHookConnection, GitHubDiscussionConnection, GitHubDiscussionSpace, GitHubIssueConnection, GitHubProjectConnection, GitHubRepoConnection, GitHubUserSpace, GitLabIssueConnection, GitLabRepoConnection, IConnection, IConnectionState, JiraProjectConnection } from "./Connections";
+import { ConnectionDeclaration, ConnectionDeclarations, GenericHookConnection, GitHubDiscussionConnection, GitHubDiscussionSpace, GitHubIssueConnection, GitHubProjectConnection, GitHubRepoConnection, GitHubUserSpace, GitLabIssueConnection, GitLabRepoConnection, IConnection, IConnectionState, JiraProjectConnection } from "./Connections";
 import { GithubInstance } from "./Github/GithubInstance";
 import { GitLabClient } from "./Gitlab/Client";
 import { JiraProject, JiraVersion } from "./Jira/Types";
@@ -107,6 +107,17 @@ export class ConnectionManager extends EventEmitter {
         } else {
             return true;
         }
+    }
+
+    /**
+     * The same as {@link verifyStateEvent}, but verifies the state event against the room & service type of the given connection.
+     * @param connection The connection to verify the state event against.
+     * @param state The state event for altering a connection in the room targeted by {@link connection}.
+     * @returns Whether the state event was allowed to be set. If not, the state will be reverted asynchronously.
+     */
+    public verifyStateEventForConnection(connection: IConnection, state: StateEvent) {
+        const cd: ConnectionDeclaration = Object.getPrototypeOf(connection).constructor;
+        return !this.verifyStateEvent(connection.roomId, state, cd.ServiceCategory);
     }
 
     private isStateAllowed(roomId: string, state: StateEvent, serviceType: string) {

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -93,7 +93,7 @@ export class ConnectionManager extends EventEmitter {
 
     public assertStateAllowed(roomId: string, state: StateEvent, serviceType: string) {
         if (!this.isStateAllowed(roomId, state, serviceType)) {
-            this.tryRestoreState(roomId, state, serviceType);
+            void this.tryRestoreState(roomId, state, serviceType);
             log.error(`User ${state.sender} is disallowed to manage state for ${serviceType} in ${roomId}`);
             return false;
         } else {


### PR DESCRIPTION
If an unauthorized change to connection-related room state is detected, deny the new connection settings & attempt to revert the state change.

Also catch an otherwise-uncaught error on authentication failure.