### PR TITLE
Save bot-created admin rooms in profile data

### DIFF
--- a/changelog.d/578.bugfix
+++ b/changelog.d/578.bugfix
@@ -1,1 +1,1 @@
-Track bot-created admin rooms in the bot's room profile data, not just user-created admin rooms.
+Fixed a case where a bridge-created admin room would stop working on restart.

--- a/changelog.d/578.bugfix
+++ b/changelog.d/578.bugfix
@@ -1,0 +1,1 @@
+Track bot-created admin rooms in the bot's room profile data, not just user-created admin rooms.

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -1185,7 +1185,11 @@ export class Bridge {
             is_direct: true,
             preset: "trusted_private_chat",
         });
-        return this.setUpAdminRoom(roomId, {admin_user: userId}, NotifFilter.getDefaultContent());
+        const room = await this.setUpAdminRoom(roomId, {admin_user: userId}, NotifFilter.getDefaultContent());
+        await this.as.botClient.setRoomAccountData(
+            BRIDGE_ROOM_TYPE, roomId, room.accountData,
+        );
+        return room;
     }
 
     private async setUpAdminRoom(roomId: string, accountData: AdminAccountData, notifContent: NotificationFilterStateContent) {


### PR DESCRIPTION
This prevents a process restart from causing bot-created admin rooms to be forgotten.

<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->
