### PR TITLE
Split out GitHub release events into created and drafted

### DIFF
--- a/changelog.d/582.bugfix
+++ b/changelog.d/582.bugfix
@@ -1,0 +1,1 @@
+Ensure bridge treats published and drafted GitHub releases as different events.

--- a/docs/usage/room_configuration/github_repo.md
+++ b/docs/usage/room_configuration/github_repo.md
@@ -63,6 +63,7 @@ Note: Some of these event types are enabled by default (marked with a `*`)
   - pull_request.reviewed *
 - release *
   - release.created *
+  - release.drafted
 - workflow.run
   - workflow.run.success
   - workflow.run.failure

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -331,13 +331,13 @@ export class Bridge {
         this.bindHandlerToQueue<GitHubWebhookTypes.ReleasePublishedEvent, GitHubRepoConnection>(
             "github.release.published",
             (data) => connManager.getConnectionsForGithubRepo(data.repository.owner.login, data.repository.name), 
-            (c, data) => c.onReleasePublished(data),
+            (c, data) => c.onReleaseCreated(data),
         );
 
         this.bindHandlerToQueue<GitHubWebhookTypes.ReleaseCreatedEvent, GitHubRepoConnection>(
             "github.release.created",
             (data) => connManager.getConnectionsForGithubRepo(data.repository.owner.login, data.repository.name), 
-            (c, data) => c.onReleaseCreated(data),
+            (c, data) => c.onReleaseDrafted(data),
         );
 
         this.bindHandlerToQueue<IGitLabWebhookMREvent, GitLabRepoConnection>(

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -328,6 +328,12 @@ export class Bridge {
             (c, data) => c.onWorkflowCompleted(data),
         );
 
+        this.bindHandlerToQueue<GitHubWebhookTypes.ReleasePublishedEvent, GitHubRepoConnection>(
+            "github.release.published",
+            (data) => connManager.getConnectionsForGithubRepo(data.repository.owner.login, data.repository.name), 
+            (c, data) => c.onReleasePublished(data),
+        );
+
         this.bindHandlerToQueue<GitHubWebhookTypes.ReleaseCreatedEvent, GitHubRepoConnection>(
             "github.release.created",
             (data) => connManager.getConnectionsForGithubRepo(data.repository.owner.login, data.repository.name), 

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -1059,7 +1059,7 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
         });
     }
 
-    public async onReleasePublished(event: ReleasePublishedEvent) {
+    public async onReleaseCreated(event: ReleasePublishedEvent) {
         // This checks `release.created` despite the function being called onReleasePublished
         // because historically release.created used to refer to all releases (rather than just published ones).
         // This is now considered an *unsafe* default, so hookshot now treats release.created
@@ -1067,7 +1067,7 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
         if (this.hookFilter.shouldSkip('release', 'release.created')) {
             return;
         }
-        log.info(`onReleasePublished ${this.roomId} ${this.org}/${this.repo} #${event.release.tag_name}`);
+        log.info(`onReleaseCreated ${this.roomId} ${this.org}/${this.repo} #${event.release.tag_name}`);
         if (!event.release) {
             throw Error('No release content!');
         }
@@ -1087,13 +1087,13 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
         });
     }
 
-    public async onReleaseCreated(event: ReleaseCreatedEvent) {
+    public async onReleaseDrafted(event: ReleaseCreatedEvent) {
         // This function handles release.created events but published releases are handled by the above function,
         // therefore this only handles drafted releases.
         if (this.hookFilter.shouldSkip('release', 'release.drafted') || !event.release.draft) {
             return;
         }
-        log.info(`onReleaseCreated ${this.roomId} ${this.org}/${this.repo} #${event.release.tag_name}`);
+        log.info(`onReleaseDrafted ${this.roomId} ${this.org}/${this.repo} #${event.release.tag_name}`);
         if (!event.release) {
             throw Error('No release content!');
         }

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -1060,8 +1060,10 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
     }
 
     public async onReleasePublished(event: ReleasePublishedEvent) {
-        // NOTE: Previously release.created used to reference created releases, but this would
-        // include drafted releases.
+        // This checks `release.created` despite the function being called onReleasePublished
+        // because historically release.created used to refer to all releases (rather than just published ones).
+        // This is now considered an *unsafe* default, so hookshot now treats release.created
+        // as published.
         if (this.hookFilter.shouldSkip('release', 'release.created')) {
             return;
         }
@@ -1086,8 +1088,8 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
     }
 
     public async onReleaseCreated(event: ReleaseCreatedEvent) {
-        // NOTE: Previously release.created used to reference created releases, but this would
-        // include drafted releases.
+        // This function handles release.created events but published releases are handled by the above function,
+        // therefore this only handles drafted releases.
         if (this.hookFilter.shouldSkip('release', 'release.drafted') || !event.release.draft) {
             return;
         }

--- a/web/components/roomConfig/GithubRepoConfig.tsx
+++ b/web/components/roomConfig/GithubRepoConfig.tsx
@@ -245,7 +245,11 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ne
                     <EventCheckbox enabledHooks={enabledHooks} ignoredHooks={ignoredHooks} parentEvent="workflow.run" eventName="workflow.run.action_required" onChange={toggleEnabledHook}>Action Required</EventCheckbox>
                     <EventCheckbox enabledHooks={enabledHooks} ignoredHooks={ignoredHooks} parentEvent="workflow.run" eventName="workflow.run.stale" onChange={toggleEnabledHook}>Stale</EventCheckbox>
                 </ul>
-                <EventCheckbox ignoredHooks={ignoredHooks} eventName="release" onChange={toggleIgnoredHook}>Releases</EventCheckbox>
+                <EventCheckbox enabledHooks={enabledHooks} ignoredHooks={ignoredHooks} eventName="release" onChange={toggleIgnoredHook}>Releases</EventCheckbox>
+                <ul>
+                    <EventCheckbox enabledHooks={enabledHooks} ignoredHooks={ignoredHooks} parentEvent="release" eventName="release.created" onChange={toggleIgnoredHook}>Published</EventCheckbox>
+                    <EventCheckbox enabledHooks={enabledHooks} ignoredHooks={ignoredHooks} parentEvent="release" eventName="release.drafted" onChange={toggleEnabledHook}>Drafted</EventCheckbox>
+                </ul>
             </ul>
         </InputField>
         <ButtonSet>


### PR DESCRIPTION
Fixes #581 

This fixes a bug where drafted GitHub releases are no longer emitted by default, but under a different event type.