### PR TITLE
Add support for cached responses (ETags/LastModified) for RSS feeds

### DIFF
--- a/changelog.d/583.misc
+++ b/changelog.d/583.misc
@@ -1,0 +1,1 @@
+RSS feed polling now uses cache headers sent by servers, which should mean we will be more conservative on resources.

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -91,6 +91,8 @@ export class FeedReader {
     // ts should notice that we do in fact initialize it in constructor, but it doesn't (in this version)
     private observedFeedUrls: Set<string> = new Set();
     private seenEntries: Map<string, string[]> = new Map();
+    // A set of last modified times for each url.
+    private cacheTimes: Map<string, { etag?: string, lastModified?: string}> = new Map();
     static readonly seenEntriesEventType = "uk.half-shot.matrix-hookshot.feed.reader.seenEntries";
 
     constructor(
@@ -175,14 +177,25 @@ export class FeedReader {
 
         for (const url of this.observedFeedUrls.values()) {
             const fetchKey = randomUUID();
+            const { etag, lastModified } = this.cacheTimes.get(url) || {};
             try {
-                const res = await axios.get(url.toString(), {
+                const res = await axios.get(url, {
                     headers: {
                         'User-Agent': UserAgent,
+                        ...(lastModified && { 'If-Modified-Since': lastModified}),
+                        ...(etag && { 'If-None-Match': etag}),
                     },
                     // We don't want to wait forever for the feed.
                     timeout: this.config.pollTimeoutSeconds * 1000,
                 });
+                
+                // Store any entity tags/cache times.
+                if (res.headers.ETag) {
+                    this.cacheTimes.set(url, { etag: res.headers.ETag});
+                } else if (res.headers['Last-Modified']) {
+                    this.cacheTimes.set(url, { lastModified: res.headers['Last-Modified'] });
+                }
+
                 const feed = await (new Parser()).parseString(res.data);
                 let initialSync = false;
                 let seenGuids = this.seenEntries.get(url);


### PR DESCRIPTION
Fixes #570 

This actually fixes the error case in #570 and more, since it also introduces support for local side caching. A few services support this, so we might as well do it.