### PR TITLE
Ensure unknown keys are retained when connection state is altered via widget

### DIFF
--- a/changelog.d/587.bugfix
+++ b/changelog.d/587.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where unknown keys in a connections state would be clobbered when updated via widget UI.

--- a/src/Connections/GenericHook.ts
+++ b/src/Connections/GenericHook.ts
@@ -433,6 +433,8 @@ export class GenericHookConnection extends BaseConnection implements IConnection
     }
 
     public async provisionerUpdateConfig(userId: string, config: Record<string, unknown>) {
+        // Apply previous state to the current config, as provisioners might not return "unknown" keys.
+        config = { ...this.state, ...config };
         const validatedConfig = GenericHookConnection.validateState(config, this.config.allowJsTransformationFunctions || false);
         await this.as.botClient.sendStateEvent(this.roomId, GenericHookConnection.CanonicalEventType, this.stateKey, 
             {

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -51,7 +51,7 @@ export interface GitHubRepoConnectionOptions extends IConnectionState {
     excludingLabels?: string[];
     hotlinkIssues?: boolean|{
         prefix: string;
-    }|null;
+    };
     newIssue?: {
         labels: string[];
     };
@@ -486,7 +486,7 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
         if (cfg === false) {
             return false;
         }
-        if (cfg === true || cfg === undefined || cfg?.prefix === undefined) {
+        if (cfg === true || cfg === undefined || cfg.prefix === undefined) {
             return {
                 prefix: DEFAULT_HOTLINK_PREFIX,
             }

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -51,7 +51,7 @@ export interface GitHubRepoConnectionOptions extends IConnectionState {
     excludingLabels?: string[];
     hotlinkIssues?: boolean|{
         prefix: string;
-    };
+    }|null;
     newIssue?: {
         labels: string[];
     };
@@ -205,7 +205,7 @@ const ConnectionStateSchema = {
         items: {type: "string"},
     },
     hotlinkIssues: {
-        type: "object",
+        type: ["object","boolean"],
         nullable: true,
         oneOf: [{
             type: "object",
@@ -299,7 +299,7 @@ export interface GitHubTargetFilter {
 export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnectionState> implements IConnection {
 
 	static validateState(state: unknown, isExistingState = false): GitHubRepoConnectionState {
-        const validator = new Ajv().compile(ConnectionStateSchema);
+        const validator = new Ajv({ allowUnionTypes: true }).compile(ConnectionStateSchema);
         if (validator(state)) {
             // Validate ignoreHooks IF this is an incoming update (we can be less strict for existing state)
             if (!isExistingState && state.ignoreHooks && !state.ignoreHooks.every(h => AllowedEvents.includes(h))) {
@@ -486,7 +486,7 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
         if (cfg === false) {
             return false;
         }
-        if (cfg === true || cfg === undefined || cfg.prefix === undefined) {
+        if (cfg === true || cfg === undefined || cfg?.prefix === undefined) {
             return {
                 prefix: DEFAULT_HOTLINK_PREFIX,
             }

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -1247,7 +1247,7 @@ ${event.release.body}`;
 
     public async provisionerUpdateConfig(userId: string, config: Record<string, unknown>) {
         // Apply previous state to the current config, as provisioners might not return "unknown" keys.
-        const newState = { ...this.state, config };
+        const newState = { ...this.state, ...config };
         const validatedConfig = GitHubRepoConnection.validateState(newState);
         await this.as.botClient.sendStateEvent(this.roomId, GitHubRepoConnection.CanonicalEventType, this.stateKey, validatedConfig);
         this.state = validatedConfig;

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -1246,7 +1246,9 @@ ${event.release.body}`;
     }
 
     public async provisionerUpdateConfig(userId: string, config: Record<string, unknown>) {
-        const validatedConfig = GitHubRepoConnection.validateState(config);
+        // Apply previous state to the current config, as provisioners might not return "unknown" keys.
+        const newState = { ...this.state, config };
+        const validatedConfig = GitHubRepoConnection.validateState(newState);
         await this.as.botClient.sendStateEvent(this.roomId, GitHubRepoConnection.CanonicalEventType, this.stateKey, validatedConfig);
         this.state = validatedConfig;
         this.hookFilter.enabledHooks = this.state.enableHooks ?? [];

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -305,6 +305,9 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
             if (!isExistingState && state.ignoreHooks && !state.ignoreHooks.every(h => AllowedEvents.includes(h))) {
                 throw new ApiError('`ignoreHooks` must only contain allowed values', ErrCode.BadValue);
             }
+            if (!isExistingState && state.enableHooks && !state.enableHooks.every(h => AllowedEvents.includes(h))) {
+                throw new ApiError('`ignoreHooks` must only contain allowed values', ErrCode.BadValue);
+            }
             return state;
         }
         throw new ValidatorApiError(validator.errors);

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -306,7 +306,7 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
                 throw new ApiError('`ignoreHooks` must only contain allowed values', ErrCode.BadValue);
             }
             if (!isExistingState && state.enableHooks && !state.enableHooks.every(h => AllowedEvents.includes(h))) {
-                throw new ApiError('`ignoreHooks` must only contain allowed values', ErrCode.BadValue);
+                throw new ApiError('`enableHooks` must only contain allowed values', ErrCode.BadValue);
             }
             return state;
         }

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -775,6 +775,8 @@ ${data.description}`;
     }
 
     public async provisionerUpdateConfig(userId: string, config: Record<string, unknown>) {
+        // Apply previous state to the current config, as provisioners might not return "unknown" keys.
+        config = { ...this.state, ...config };
         const validatedConfig = GitLabRepoConnection.validateState(config);
         await this.as.botClient.sendStateEvent(this.roomId, GitLabRepoConnection.CanonicalEventType, this.stateKey, validatedConfig);
         this.state = validatedConfig;

--- a/src/Connections/JiraProject.ts
+++ b/src/Connections/JiraProject.ts
@@ -507,6 +507,8 @@ export class JiraProjectConnection extends CommandConnection<JiraProjectConnecti
     }
 
     public async provisionerUpdateConfig(userId: string, config: Record<string, unknown>) {
+        // Apply previous state to the current config, as provisioners might not return "unknown" keys.
+        config = { ...config, ...this.state };
         const validatedConfig = validateJiraConnectionState(config);
         if (!validatedConfig.id) {
             await this.updateProjectId(validatedConfig, userId);


### PR DESCRIPTION
Fixes #584 

This also fixes a few validation bugs in GitHubRepo.