### PR TITLE
Support filtering workflow run on workflow names

### DIFF
--- a/changelog.d/588.feature
+++ b/changelog.d/588.feature
@@ -1,0 +1,1 @@
+Add new GitHubRepo connection config setting `workflowRun.workflows` to filter run reports by workflow name.

--- a/docs/usage/room_configuration/github_repo.md
+++ b/docs/usage/room_configuration/github_repo.md
@@ -39,7 +39,8 @@ This connection supports a few options which can be defined in the room state:
 |newIssue.labels|Automatically set these labels on issues created via commands|Array of: String matching a label name|*empty*|
 |workflowRun|Configuration options for workflow run results|`{ matchingBranch: string }`|*empty*|
 |workflowRun.matchingBranch|Only report workflow runs if it matches this regex.|Regex string|*empty*|
-|workflowRun.workflows|Only report workflow runs if the workflow name is in this array.|Array of: String matching a workflow name|*empty*|
+|workflowRun.includingWorkflows|Only report workflow runs with a matching workflow name.|Array of: String matching a workflow name|*empty*|
+|workflowRun.excludingWorkflows|Never report workflow runs with a matching workflow name.|Array of: String matching a workflow name|*empty*|
 
 
 [^1]: `ignoreHooks` takes precedence over `enableHooks`.

--- a/docs/usage/room_configuration/github_repo.md
+++ b/docs/usage/room_configuration/github_repo.md
@@ -39,6 +39,7 @@ This connection supports a few options which can be defined in the room state:
 |newIssue.labels|Automatically set these labels on issues created via commands|Array of: String matching a label name|*empty*|
 |workflowRun|Configuration options for workflow run results|`{ matchingBranch: string }`|*empty*|
 |workflowRun.matchingBranch|Only report workflow runs if it matches this regex.|Regex string|*empty*|
+|workflowRun.workflows|Only report workflow runs if the workflow name is in this array.|Array of: String matching a workflow name|*empty*|
 
 
 [^1]: `ignoreHooks` takes precedence over `enableHooks`.

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -57,6 +57,7 @@ export interface GitHubRepoConnectionOptions extends IConnectionState {
     };
     workflowRun?: {
         matchingBranch?: string;
+        workflows?: string[];
     }
 }
 export interface GitHubRepoConnectionState extends GitHubRepoConnectionOptions {
@@ -224,6 +225,11 @@ const ConnectionStateSchema = {
             matchingBranch: {
                 nullable: true,
                 type: "string",
+            },
+            workflows: {
+                nullable: true,
+                type: "array",
+                items: {type: "string"},
             },
         },
     }
@@ -1090,6 +1096,9 @@ ${event.release.body}`;
         }
 
         if (this.state.workflowRun?.matchingBranch && !workflowRun.head_branch.match(this.state.workflowRun?.matchingBranch)) {
+            return;
+        }
+        if (this.state.workflowRun?.workflows && !this.state.workflowRun?.workflows.includes(workflowRun.name)) {
             return;
         }
         log.info(`onWorkflowCompleted ${this.roomId} ${this.org}/${this.repo} '${workflowRun.id}'`);


### PR DESCRIPTION
This allows teams to only report workflow runs that match a given name. Note the name is the `name` field given inside the workflow file, NOT the filename.