### PR TITLE
Drop `ignoreHooks` configuration.

### DIFF
--- a/changelog.d/592.feature
+++ b/changelog.d/592.feature
@@ -1,0 +1,2 @@
+The GitHub/GitLab connection state configuration has changed. The configuration option `ignoreHooks` is now deprecated, and new connections may not use this options.
+Users should instead explicitly configure all the hooks they want to enable with the `enableHooks` option. Existing connections will continue to work with both options.

--- a/docs/usage/room_configuration/github_repo.md
+++ b/docs/usage/room_configuration/github_repo.md
@@ -27,8 +27,8 @@ This connection supports a few options which can be defined in the room state:
 
 | Option | Description | Allowed values | Default |
 |--------|-------------|----------------|---------|
-|enableHooks [^1]|Enable notifications for some event types|Array of: [Supported event types](#supported-event-types) |*empty*|
-|ignoreHooks [^1]|Choose to exclude notifications for some event types|Array of: [Supported event types](#supported-event-types) |*empty*|
+|enableHooks [^1]|Enable notifications for some event types|Array of: [Supported event types](#supported-event-types) |If not defined, defaults are mentioned below|
+|ignoreHooks [^1]|**deprecated** Choose to exclude notifications for some event types|Array of: [Supported event types](#supported-event-types) |*empty*|
 |commandPrefix|Choose the prefix to use when sending commands to the bot|A string, ideally starts with "!"|`!gh`|
 |showIssueRoomLink|When new issues are created, provide a Matrix alias link to the issue room|`true/false`|`false`|
 |prDiff|Show a diff in the room when a PR is created, subject to limits|`{enabled: boolean, maxLines: number}`|`{enabled: false}`|
@@ -43,7 +43,7 @@ This connection supports a few options which can be defined in the room state:
 |workflowRun.excludingWorkflows|Never report workflow runs with a matching workflow name.|Array of: String matching a workflow name|*empty*|
 
 
-[^1]: `ignoreHooks` takes precedence over `enableHooks`.
+[^1]: `ignoreHooks` is no longer accepted for new state events. Use `enableHooks` to explicitly state all events you want to see.
 
 
 ### Supported event types

--- a/docs/usage/room_configuration/github_repo.md
+++ b/docs/usage/room_configuration/github_repo.md
@@ -46,11 +46,13 @@ This connection supports a few options which can be defined in the room state:
 [^1]: `ignoreHooks` is no longer accepted for new state events. Use `enableHooks` to explicitly state all events you want to see.
 
 
+
 ### Supported event types
 
 This connection supports sending messages when the following actions happen on the repository.
 
-Note: Some of these event types are enabled by default (marked with a `*`)
+Note: Some of these event types are enabled by default (marked with a `*`). When `ignoreHooks` *is* defined,
+the events marked as default below will be enabled. Otherwise, this is ignored.
 
 - issue *
   - issue.created *

--- a/docs/usage/room_configuration/gitlab_project.md
+++ b/docs/usage/room_configuration/gitlab_project.md
@@ -39,7 +39,8 @@ This connection supports a few options which can be defined in the room state:
 
 This connection supports sending messages when the following actions happen on the repository.
 
-Note: Some of these event types are enabled by default (marked with a `*`)
+Note: Some of these event types are enabled by default (marked with a `*`). When `ignoreHooks` *is* defined,
+the events marked as default below will be enabled. Otherwise, this is ignored.
 
 - merge_request *
   - merge_request.close *

--- a/docs/usage/room_configuration/gitlab_project.md
+++ b/docs/usage/room_configuration/gitlab_project.md
@@ -23,26 +23,32 @@ This connection supports a few options which can be defined in the room state:
 
 | Option | Description | Allowed values | Default |
 |--------|-------------|----------------|---------|
-|ignoreHooks|Choose to exclude notifications for some event types|Array of: [Supported event types](#supported-event-types) |*empty*|
 |commandPrefix|Choose the prefix to use when sending commands to the bot|A string, ideally starts with "!"|`!gh`|
-|pushTagsRegex|Only mention pushed tags which match this regex|Regex string|*empty*|
-|includingLabels|Only notify on issues matching these label names|Array of: String matching a label name|*empty*|
+|enableHooks [^1]|Enable notifications for some event types|Array of: [Supported event types](#supported-event-types) |If not defined, defaults are mentioned below|
 |excludingLabels|Never notify on issues matching these label names|Array of: String matching a label name|*empty*|
+|ignoreHooks [^1]|**deprecated** Choose to exclude notifications for some event types|Array of: [Supported event types](#supported-event-types) |*empty*|
 |includeCommentBody|Include the body of a comment when notifying on merge requests|Boolean|false|
+|includingLabels|Only notify on issues matching these label names|Array of: String matching a label name|*empty*|
+|pushTagsRegex|Only mention pushed tags which match this regex|Regex string|*empty*|
+
+
+[^1]: `ignoreHooks` is no longer accepted for new state events. Use `enableHooks` to explicitly state all events you want to see.
 
 
 ### Supported event types
 
 This connection supports sending messages when the following actions happen on the repository.
 
-- merge_request
-  - merge_request.close
-  - merge_request.merge
-  - merge_request.open
-  - merge_request.review.comments
-  - merge_request.review
-- push
-- release
-  - release.created
-- tag_push
-- wiki
+Note: Some of these event types are enabled by default (marked with a `*`)
+
+- merge_request *
+  - merge_request.close *
+  - merge_request.merge *
+  - merge_request.open *
+  - merge_request.review.comments *
+  - merge_request.review *
+- push *
+- release *
+  - release.created *
+- tag_push *
+- wiki *

--- a/src/Connections/CommandConnection.ts
+++ b/src/Connections/CommandConnection.ts
@@ -10,14 +10,14 @@ const log = new Logger("CommandConnection");
  * Connection class that handles commands for a given connection. Should be used
  * by connections expecting to handle user input.
  */
-export abstract class CommandConnection<StateType extends IConnectionState = IConnectionState> extends BaseConnection {
+export abstract class CommandConnection<StateType extends IConnectionState = IConnectionState, ValidatedStateType extends StateType = StateType> extends BaseConnection {
     protected enabledHelpCategories?: string[];
     protected includeTitlesInHelp?: boolean;
     constructor(
         roomId: string,
         stateKey: string,
         canonicalStateType: string,
-        protected state: StateType,
+        protected state: ValidatedStateType,
         private readonly botClient: MatrixClient,
         private readonly botCommands: BotCommands,
         private readonly helpMessage: HelpFunction,
@@ -39,7 +39,7 @@ export abstract class CommandConnection<StateType extends IConnectionState = ICo
         this.state = this.validateConnectionState(stateEv.content);
     }
 
-    protected abstract validateConnectionState(content: unknown): StateType;
+    protected abstract validateConnectionState(content: unknown): ValidatedStateType;
 
     public async onMessageEvent(ev: MatrixEvent<MatrixMessageContent>, checkPermission: PermissionCheckFn) {
         const commandResult = await handleCommand(

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -340,6 +340,7 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
                 }
                 log.warn(`Room has old state key 'ignoreHooks'. Converting to compatible enabledHooks filter`);
                 state.enableHooks = HookFilter.convertIgnoredHooksToEnabledHooks(state.enableHooks, state.ignoreHooks, DefaultHooks);
+                delete state.ignoreHooks;
             }
             return state;
         }

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -346,7 +346,6 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
                 }
                 log.warn(`Room has old state key 'ignoreHooks'. Converting to compatible enabledHooks filter`);
                 state.enableHooks = HookFilter.convertIgnoredHooksToEnabledHooks(state.enableHooks, state.ignoreHooks, DefaultHooks);
-                delete state.ignoreHooks;
             }
             return {
                 ...state,
@@ -507,18 +506,17 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
         private readonly githubInstance: GithubInstance,
         private readonly config: BridgeConfigGitHub,
         ) {
-            super(
-                roomId,
-                stateKey,
-                GitHubRepoConnection.CanonicalEventType,
-                state,
-                as.botClient,
-                GitHubRepoConnection.botCommands,
-                GitHubRepoConnection.helpMessage,
-                "!gh",
-                "github",
-            );
-            // It's possible to have state with no `enableHooks`, so we need 
+        super(
+            roomId,
+            stateKey,
+            GitHubRepoConnection.CanonicalEventType,
+            state,
+            as.botClient,
+            GitHubRepoConnection.botCommands,
+            GitHubRepoConnection.helpMessage,
+            "!gh",
+            "github",
+        );
         this.hookFilter = new HookFilter(
             state.enableHooks,
         )

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -183,6 +183,7 @@ export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnection
                 }
                 log.warn(`Room has old state key 'ignoreHooks'. Converting to compatible enabledHooks filter`);
                 state.enableHooks = HookFilter.convertIgnoredHooksToEnabledHooks(state.enableHooks, state.ignoreHooks, AllowedEvents);
+                delete state.ignoreHooks;
             }
             return state;
         }

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -188,7 +188,6 @@ export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnection
                 }
                 log.warn(`Room has old state key 'ignoreHooks'. Converting to compatible enabledHooks filter`);
                 state.enableHooks = HookFilter.convertIgnoredHooksToEnabledHooks(state.enableHooks, state.ignoreHooks, AllowedEvents);
-                delete state.ignoreHooks;
             }
             return {
                 ...state,
@@ -346,25 +345,26 @@ export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnection
         private readonly as: Appservice,
         state: ConnectionStateValidated,
         private readonly tokenStore: UserTokenStore,
-        private readonly instance: GitLabInstance) {
-            super(
-                roomId,
-                stateKey,
-                GitLabRepoConnection.CanonicalEventType,
-                state,
-                as.botClient,
-                GitLabRepoConnection.botCommands,
-                GitLabRepoConnection.helpMessage,
-                "!gl",
-                "gitlab",
-            )
-            if (!state.path || !state.instance) {
-                throw Error('Invalid state, missing `path` or `instance`');
-            }
-            this.hookFilter = new HookFilter(
-                state.enableHooks ?? DefaultHooks,
-            );
-    }
+        private readonly instance: GitLabInstance
+        ) {
+        super(
+            roomId,
+            stateKey,
+            GitLabRepoConnection.CanonicalEventType,
+            state,
+            as.botClient,
+            GitLabRepoConnection.botCommands,
+            GitLabRepoConnection.helpMessage,
+            "!gl",
+            "gitlab",
+        )
+        if (!state.path || !state.instance) {
+            throw Error('Invalid state, missing `path` or `instance`');
+        }
+        this.hookFilter = new HookFilter(
+            state.enableHooks ?? DefaultHooks,
+        );
+}
 
     public get path() {
         return this.state.path.toLowerCase();

--- a/src/Connections/IConnection.ts
+++ b/src/Connections/IConnection.ts
@@ -81,7 +81,8 @@ export interface ConnectionDeclaration<C extends IConnection = IConnection> {
     EventTypes: string[];
     ServiceCategory: string;
     provisionConnection?: (roomId: string, userId: string, data: Record<string, unknown>, opts: ProvisionConnectionOpts) => Promise<{connection: C, warning?: ConnectionWarning}>;
-    createConnectionForState: (roomId: string, state: StateEvent<Record<string, unknown>>, opts: InstantiateConnectionOpts) => C|Promise<C>
+    checkIfStateRequiresUpgrade?: (data: StateEvent<Record<string, unknown>>) => Record<string, unknown>|false;
+    createConnectionForState: (roomId: string, state: StateEvent<Record<string, unknown>>, opts: InstantiateConnectionOpts) => C|Promise<C>;
 }
 
 export const ConnectionDeclarations: Array<ConnectionDeclaration> = [];

--- a/src/Connections/IConnection.ts
+++ b/src/Connections/IConnection.ts
@@ -81,7 +81,6 @@ export interface ConnectionDeclaration<C extends IConnection = IConnection> {
     EventTypes: string[];
     ServiceCategory: string;
     provisionConnection?: (roomId: string, userId: string, data: Record<string, unknown>, opts: ProvisionConnectionOpts) => Promise<{connection: C, warning?: ConnectionWarning}>;
-    checkIfStateRequiresUpgrade?: (data: StateEvent<Record<string, unknown>>) => Record<string, unknown>|false;
     createConnectionForState: (roomId: string, state: StateEvent<Record<string, unknown>>, opts: InstantiateConnectionOpts) => C|Promise<C>;
 }
 

--- a/src/Connections/JiraProject.ts
+++ b/src/Connections/JiraProject.ts
@@ -106,7 +106,7 @@ export class JiraProjectConnection extends CommandConnection<JiraProjectConnecti
     static botCommands: BotCommands;
     static helpMessage: (cmdPrefix?: string) => MatrixMessageContent;
 
-    static async provisionConnection(roomId: string, userId: string, data: Record<string, unknown>, {getAllConnectionsOfType, as, tokenStore, config}: ProvisionConnectionOpts) {
+    static async provisionConnection(roomId: string, userId: string, data: Record<string, unknown>, {as, tokenStore, config}: ProvisionConnectionOpts) {
         if (!config.jira) {
             throw new ApiError('JIRA integration is not configured', ErrCode.DisabledFeature);
         }

--- a/src/HookFilter.ts
+++ b/src/HookFilter.ts
@@ -1,23 +1,22 @@
 export class HookFilter<T extends string> {
-    static convertIgnoredHooksToEnabledHooks<T extends string>(enabledHooks: T[] = [], ignoredHooks: T[] = [], defaultHooks: T[]): T[] {
-        const hookSet = new Set([
-            ...enabledHooks,
-            // Add all the default hooks
-            ...defaultHooks
+    static convertIgnoredHooksToEnabledHooks<T extends string>(explicitlyEnabledHooks: T[] = [], ignoredHooks: T[], defaultHooks: T[]): T[] {
+        const resultHookSet = new Set([
+            ...explicitlyEnabledHooks,
+            ...defaultHooks,
         ]);
 
-        // For each ignored hook, remove a default
+        // For each ignored hook, remove anything that matches.
         for (const ignoredHook of ignoredHooks) {
-            hookSet.delete(ignoredHook);
+            resultHookSet.delete(ignoredHook);
             // If the hook is a "root" hook name, remove all children.
-            for (const currentHook of hookSet) {
-                if (currentHook.startsWith(`${ignoredHook}.`)) {
-                    hookSet.delete(currentHook);
+            for (const enabledHook of resultHookSet) {
+                if (enabledHook.startsWith(`${ignoredHook}.`)) {
+                    resultHookSet.delete(enabledHook);
                 } 
             }
         }
 
-        return [...hookSet];
+        return [...resultHookSet];
     }
 
     constructor(

--- a/src/HookFilter.ts
+++ b/src/HookFilter.ts
@@ -1,19 +1,32 @@
 export class HookFilter<T extends string> {
+    static convertIgnoredHooksToEnabledHooks<T extends string>(enabledHooks: T[] = [], ignoredHooks: T[] = [], defaultHooks: T[]): T[] {
+        const hookSet = new Set([
+            ...enabledHooks,
+            // Add all the default hooks
+            ...defaultHooks
+        ]);
+
+        // For each ignored hook, remove a default
+        for (const ignoredHook of ignoredHooks) {
+            hookSet.delete(ignoredHook);
+            // If the hook is a "root" hook name, remove all children.
+            for (const currentHook of hookSet) {
+                if (currentHook.startsWith(`${ignoredHook}.`)) {
+                    hookSet.delete(currentHook);
+                } 
+            }
+        }
+
+        return [...hookSet];
+    }
+
     constructor(
-        public readonly defaultHooks: T[],
         public enabledHooks: T[] = [],
-        public ignoredHooks: T[] = []
     ) {
 
     }
 
     public shouldSkip(...hookName: T[]) {
-        if (hookName.some(name => this.ignoredHooks.includes(name))) {
-            return true;
-        }
-        if (hookName.some(name => this.enabledHooks.includes(name))) {
-            return false;
-        }
-        return !hookName.some(h => this.defaultHooks.includes(h));
+        return !hookName.some(name => this.enabledHooks.includes(name));
     }
 }

--- a/src/HookFilter.ts
+++ b/src/HookFilter.ts
@@ -26,6 +26,7 @@ export class HookFilter<T extends string> {
     }
 
     public shouldSkip(...hookName: T[]) {
-        return !hookName.some(name => this.enabledHooks.includes(name));
+        // Should skip if all of the hook names are missing
+        return hookName.every(name => !this.enabledHooks.includes(name));
     }
 }

--- a/tests/HookFilter.ts
+++ b/tests/HookFilter.ts
@@ -25,7 +25,7 @@ describe("HookFilter", () => {
         
         it('should correctly include default and enabled hooks when ignored hooks is set', () => {
             expect(HookFilter.convertIgnoredHooksToEnabledHooks(ENABLED_SET, ['my-ignored-hook'], DEFAULT_SET)).to.have.members([
-                ...ENABLED_SET, ...DEFAULT_SET, 'my-ignored-hook'
+                ...ENABLED_SET, ...DEFAULT_SET
             ]);
         });
         

--- a/tests/HookFilter.ts
+++ b/tests/HookFilter.ts
@@ -20,39 +20,34 @@ describe("HookFilter", () => {
     
     describe('convertIgnoredHooksToEnabledHooks', () => {
         it('should correctly provide a list of default hooks', () => {
-            expect(HookFilter.convertIgnoredHooksToEnabledHooks([], [], DEFAULT_SET)).to.deep.equal(
-                DEFAULT_SET
-            );
+            expect(HookFilter.convertIgnoredHooksToEnabledHooks([], [], DEFAULT_SET)).to.have.members(DEFAULT_SET);
         });
         
         it('should correctly include both default and enabled hooks', () => {
-            expect(HookFilter.convertIgnoredHooksToEnabledHooks(ENABLED_SET, [], DEFAULT_SET)).to.deep.equal([
+            expect(HookFilter.convertIgnoredHooksToEnabledHooks(ENABLED_SET, [], DEFAULT_SET)).to.have.members([
                 ...ENABLED_SET, ...DEFAULT_SET
             ]);
         });
         
         it('should deduplicate', () => {
-            expect(HookFilter.convertIgnoredHooksToEnabledHooks(DEFAULT_SET, [], DEFAULT_SET)).to.deep.equal([
-                ...DEFAULT_SET
-            ]);
+            expect(HookFilter.convertIgnoredHooksToEnabledHooks(DEFAULT_SET, [], DEFAULT_SET)).to.have.members(DEFAULT_SET);
         });
         
         it('should correctly exclude ignored hooks', () => {
-            expect(HookFilter.convertIgnoredHooksToEnabledHooks([], [DEFAULT_SET[0]], DEFAULT_SET)).to.deep.equal([
-                DEFAULT_SET[1]
+            expect(HookFilter.convertIgnoredHooksToEnabledHooks([], [DEFAULT_SET[0]], DEFAULT_SET)).to.not.include([
+                DEFAULT_SET[0]
             ]);
         });
         
         it('should handle ignored root hooks', () => {
             const defaultHooks = ['myhook', 'myhook.foo', 'myhook.foo.bar'];
-            expect(HookFilter.convertIgnoredHooksToEnabledHooks([], [], defaultHooks)).to.deep.equal(defaultHooks);
-            expect(HookFilter.convertIgnoredHooksToEnabledHooks([], [defaultHooks[2]], defaultHooks)).to.deep.equal([
-                defaultHooks[0], defaultHooks[1]
+            expect(HookFilter.convertIgnoredHooksToEnabledHooks([], ['myhook.foo.bar'], defaultHooks)).to.have.members([
+                'myhook', 'myhook.foo'
             ]);
-            expect(HookFilter.convertIgnoredHooksToEnabledHooks([], [defaultHooks[1]], defaultHooks)).to.deep.equal([
-                defaultHooks[0]
+            expect(HookFilter.convertIgnoredHooksToEnabledHooks([], ['myhook.foo'], defaultHooks)).to.have.members([
+                'myhook'
             ]);
-            expect(HookFilter.convertIgnoredHooksToEnabledHooks([], [defaultHooks[0]], defaultHooks)).to.be.empty;
+            expect(HookFilter.convertIgnoredHooksToEnabledHooks([], ['myhook'], defaultHooks)).to.be.empty;
         });
     });
 });

--- a/tests/HookFilter.ts
+++ b/tests/HookFilter.ts
@@ -3,29 +3,56 @@ import { HookFilter } from '../src/HookFilter';
 
 const DEFAULT_SET = ['default-allowed', 'default-allowed-but-ignored'];
 const ENABLED_SET = ['enabled-hook', 'enabled-but-ignored'];
-const IGNORED_SET = ['ignored', 'enabled-but-ignored', 'default-allowed-but-ignored'];
 
 describe("HookFilter", () => {
     let filter: HookFilter<string>;
     beforeEach(() => {
-        filter = new HookFilter(DEFAULT_SET, ENABLED_SET, IGNORED_SET);
+        filter = new HookFilter(ENABLED_SET);
     });
-    it('should skip a hook named in ignoreHooks', () => {
-        expect(filter.shouldSkip('ignored')).to.be.true;
+    describe('shouldSkip', () => {
+        it('should allow a hook named in enabled set', () => {
+            expect(filter.shouldSkip('enabled-hook')).to.be.false;
+        });
+        it('should not allow a hook not named in enabled set', () => {
+            expect(filter.shouldSkip('not-enabled-hook')).to.be.true;
+        });
     });
-    it('should allow a hook named in defaults', () => {
-        expect(filter.shouldSkip('default-allowed')).to.be.false;
-    });
-    it('should allow a hook named in enabled', () => {
-        expect(filter.shouldSkip('enabled-hook')).to.be.false;
-    });
-    it('should skip a hook named in defaults but also in ignored', () => {
-        expect(filter.shouldSkip('default-allowed-but-ignored')).to.be.true;
-    });
-    it('should skip a hook named in enabled but also in ignored', () => {
-        expect(filter.shouldSkip('enabled-but-ignored')).to.be.true;
-    });
-    it('should skip if any hooks are in ignored', () => {
-        expect(filter.shouldSkip('enabled-hook', 'enabled-but-ignored')).to.be.true;
+    
+    describe('convertIgnoredHooksToEnabledHooks', () => {
+        it('should correctly provide a list of default hooks', () => {
+            expect(HookFilter.convertIgnoredHooksToEnabledHooks([], [], DEFAULT_SET)).to.deep.equal(
+                DEFAULT_SET
+            );
+        });
+        
+        it('should correctly include both default and enabled hooks', () => {
+            expect(HookFilter.convertIgnoredHooksToEnabledHooks(ENABLED_SET, [], DEFAULT_SET)).to.deep.equal([
+                ...ENABLED_SET, ...DEFAULT_SET
+            ]);
+        });
+        
+        it('should deduplicate', () => {
+            expect(HookFilter.convertIgnoredHooksToEnabledHooks(DEFAULT_SET, [], DEFAULT_SET)).to.deep.equal([
+                ...DEFAULT_SET
+            ]);
+        });
+        
+        it('should correctly exclude ignored hooks', () => {
+            expect(HookFilter.convertIgnoredHooksToEnabledHooks([], [DEFAULT_SET[0]], DEFAULT_SET)).to.deep.equal([
+                DEFAULT_SET[1]
+            ]);
+        });
+        
+        it('should handle ignored root hooks', () => {
+            const defaultHooks = ['myhook', 'myhook.foo', 'myhook.foo.bar'];
+            expect(HookFilter.convertIgnoredHooksToEnabledHooks([], [], defaultHooks)).to.deep.equal(defaultHooks);
+            expect(HookFilter.convertIgnoredHooksToEnabledHooks([], [defaultHooks[2]], defaultHooks)).to.deep.equal([
+                defaultHooks[0], defaultHooks[1]
+            ]);
+            expect(HookFilter.convertIgnoredHooksToEnabledHooks([], [defaultHooks[1]], defaultHooks)).to.deep.equal([
+                defaultHooks[0]
+            ]);
+            expect(HookFilter.convertIgnoredHooksToEnabledHooks([], [defaultHooks[0]], defaultHooks)).to.be.empty;
+        });
     });
 });

--- a/tests/HookFilter.ts
+++ b/tests/HookFilter.ts
@@ -23,9 +23,9 @@ describe("HookFilter", () => {
             expect(HookFilter.convertIgnoredHooksToEnabledHooks([], [], DEFAULT_SET)).to.have.members(DEFAULT_SET);
         });
         
-        it('should correctly include both default and enabled hooks', () => {
-            expect(HookFilter.convertIgnoredHooksToEnabledHooks(ENABLED_SET, [], DEFAULT_SET)).to.have.members([
-                ...ENABLED_SET, ...DEFAULT_SET
+        it('should correctly include default and enabled hooks when ignored hooks is set', () => {
+            expect(HookFilter.convertIgnoredHooksToEnabledHooks(ENABLED_SET, ['my-ignored-hook'], DEFAULT_SET)).to.have.members([
+                ...ENABLED_SET, ...DEFAULT_SET, 'my-ignored-hook'
             ]);
         });
         

--- a/tests/connections/GithubRepoTest.ts
+++ b/tests/connections/GithubRepoTest.ts
@@ -109,7 +109,7 @@ describe("GitHubRepoConnection", () => {
 				GitHubRepoConnection.validateState({
 					org: "foo",
 					repo: "bar",
-					enabledHooks: ["issue", "pull_request", "release", "not-real"],
+					enabledHooks: ["not-real"],
 				}, false);
 			} catch (ex) {
 				if (ex instanceof ApiError === false || ex.errcode !== ErrCode.BadValue) {
@@ -121,7 +121,7 @@ describe("GitHubRepoConnection", () => {
 			GitHubRepoConnection.validateState({
 				org: "foo",
 				repo: "bar",
-				enabledHooks: ["issue", "pull_request", "release", "not-real"],
+				enabledHooks: ["not-real"],
 			}, true);
 		});
 	});

--- a/tests/connections/GithubRepoTest.ts
+++ b/tests/connections/GithubRepoTest.ts
@@ -5,6 +5,7 @@ import { UserTokenStore } from "../../src/UserTokenStore";
 import { DefaultConfig } from "../../src/Config/Defaults";
 import { AppserviceMock } from "../utils/AppserviceMock";
 import { ApiError, ErrCode, ValidatorApiError } from "../../src/api";
+import { expect } from "chai";
 
 const ROOM_ID = "!foo:bar";
 
@@ -64,7 +65,7 @@ describe("GitHubRepoConnection", () => {
 			GitHubRepoConnection.validateState({
 				org: "foo",
 				repo: "bar",
-				ignoreHooks: ["issue", "pull_request", "release"],
+				enableHooks: ["issue", "pull_request", "release"],
 				commandPrefix: "!foo",
 				showIssueRoomLink: true,
 				prDiff: {
@@ -81,6 +82,16 @@ describe("GitHubRepoConnection", () => {
 				}
 			} as GitHubRepoConnectionState as unknown as Record<string, unknown>);
 		});
+		it("will convert ignoredHooks for existing state", () => {
+			const state = GitHubRepoConnection.validateState({
+				org: "foo",
+				repo: "bar",
+				ignoreHooks: ["issue"],
+				enableHooks: ["issue", "pull_request", "release"],
+				commandPrefix: "!foo",
+			} as GitHubRepoConnectionState as unknown as Record<string, unknown>, true);
+			expect(state.enableHooks).to.not.contain('issue');
+		});
 		it("will disallow invalid state", () => {
 			try {
 				GitHubRepoConnection.validateState({
@@ -93,12 +104,12 @@ describe("GitHubRepoConnection", () => {
 				}
 			}
 		});
-		it("will disallow ignoreHooks to contains invalid enums if this is new state", () => {
+		it("will disallow enabledHooks to contains invalid enums if this is new state", () => {
 			try {
 				GitHubRepoConnection.validateState({
 					org: "foo",
 					repo: "bar",
-					ignoreHooks: ["issue", "pull_request", "release", "not-real"],
+					enabledHooks: ["issue", "pull_request", "release", "not-real"],
 				}, false);
 			} catch (ex) {
 				if (ex instanceof ApiError === false || ex.errcode !== ErrCode.BadValue) {
@@ -106,11 +117,11 @@ describe("GitHubRepoConnection", () => {
 				}
 			}
 		});
-		it("will allow ignoreHooks to contains invalid enums if this is old state", () => {
+		it("will allow enabledHooks to contains invalid enums if this is old state", () => {
 			GitHubRepoConnection.validateState({
 				org: "foo",
 				repo: "bar",
-				ignoreHooks: ["issue", "pull_request", "release", "not-real"],
+				enabledHooks: ["issue", "pull_request", "release", "not-real"],
 			}, true);
 		});
 	});

--- a/tests/connections/GitlabRepoTest.ts
+++ b/tests/connections/GitlabRepoTest.ts
@@ -108,7 +108,7 @@ describe("GitLabRepoConnection", () => {
 				GitLabRepoConnection.validateState({
 					instance: "bar",
 					path: "foo",
-					enabledHooks: ["issue", "pull_request", "release", "not-real"],
+					enabledHooks: ["not-real"],
 				}, false);
 			} catch (ex) {
 				if (ex instanceof ApiError === false || ex.errcode !== ErrCode.BadValue) {
@@ -120,7 +120,7 @@ describe("GitLabRepoConnection", () => {
 			GitLabRepoConnection.validateState({
 				instance: "bar",
 				path: "foo",
-				enabledHooks: ["issues", "merge_request", "foo"],
+				enabledHooks: ["not-real"],
 			}, true);
 		});
 	});

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { h, Component } from 'preact';
+import { Component } from 'preact';
 import WA, { MatrixCapabilities } from 'matrix-widget-api';
 import { BridgeAPI, BridgeAPIError } from './BridgeAPI';
 import { BridgeRoomState } from '../src/Widgets/BridgeWidgetInterface';

--- a/web/components/AdminSettings.tsx
+++ b/web/components/AdminSettings.tsx
@@ -1,4 +1,3 @@
-import { h } from "preact";
 import { useEffect, useState, useCallback } from 'preact/hooks';
 import { BridgeRoomState } from "../../src/Widgets/BridgeWidgetInterface";
 import GeneralConfig from './configs/GeneralConfig';

--- a/web/components/ConnectionCard.tsx
+++ b/web/components/ConnectionCard.tsx
@@ -1,4 +1,3 @@
-import { h } from "preact";
 import style from "./ConnectionCard.module.scss";
 
 interface IProps {

--- a/web/components/GitHubState.tsx
+++ b/web/components/GitHubState.tsx
@@ -1,4 +1,4 @@
-import { h, FunctionComponent } from 'preact';
+import { FunctionComponent } from 'preact';
 import { BridgeRoomStateGitHub } from '../../src/Widgets/BridgeWidgetInterface';
 import "./GitHubState.css";
 

--- a/web/components/ServiceCard.tsx
+++ b/web/components/ServiceCard.tsx
@@ -1,4 +1,4 @@
-import { h, FunctionComponent } from "preact";
+import { FunctionComponent } from "preact";
 import style from "./ServiceCard.module.scss";
 
 

--- a/web/components/configs/GeneralConfig.tsx
+++ b/web/components/configs/GeneralConfig.tsx
@@ -1,4 +1,3 @@
-import { h } from "preact";
 import { Button } from "../elements";
 
 export default function GeneralConfig() {

--- a/web/components/elements/ErrorPane.tsx
+++ b/web/components/elements/ErrorPane.tsx
@@ -1,4 +1,4 @@
-import { h, FunctionComponent } from "preact";
+import { FunctionComponent } from "preact";
 import ErrorBadge from "../../icons/error-badge.svg";
 import style from "./ErrorPane.module.scss";
 

--- a/web/components/elements/EventHookCheckbox.tsx
+++ b/web/components/elements/EventHookCheckbox.tsx
@@ -1,0 +1,28 @@
+import { FunctionComponent } from "preact";
+import { JSXInternal } from "preact/src/jsx";
+
+export const EventHookCheckbox: FunctionComponent<{
+    enabledHooks?: string[],
+    onChange: JSXInternal.GenericEventHandler<HTMLInputElement>,
+    eventName: string,
+    parentEvent?: string,
+}> = ({enabledHooks, onChange, eventName, parentEvent, children}) => {
+    if (!enabledHooks) {
+        throw Error(`Invalid configuration for checkbox ${eventName}`);
+    }
+
+    const disabled = !!(parentEvent && !enabledHooks.includes(parentEvent));
+    const checked = enabledHooks.includes(eventName);
+
+    return <li>
+        <label>
+            <input
+            disabled={disabled}
+            type="checkbox"
+            x-event-name={eventName}
+            checked={checked}
+            onChange={onChange} />
+            { children }
+        </label>
+    </li>;
+};

--- a/web/components/elements/EventHookCheckbox.tsx
+++ b/web/components/elements/EventHookCheckbox.tsx
@@ -11,7 +11,7 @@ export const EventHookCheckbox: FunctionComponent<{
         throw Error(`Invalid configuration for checkbox ${eventName}`);
     }
 
-    const checked = enabledHooks.includes(eventName) || (parentEvent && enabledHooks.includes(parentEvent));
+    const checked = enabledHooks.includes(eventName) || (!!parentEvent && enabledHooks.includes(parentEvent));
 
     return <li>
         <label>

--- a/web/components/elements/EventHookCheckbox.tsx
+++ b/web/components/elements/EventHookCheckbox.tsx
@@ -4,16 +4,16 @@ import { JSXInternal } from "preact/src/jsx";
 export const EventHookCheckbox: FunctionComponent<{
     enabledHooks: string[],
     onChange: JSXInternal.GenericEventHandler<HTMLInputElement>,
-    eventName: string,
+    hookEventName: string,
     parentEvent?: string,
-}> = ({enabledHooks, onChange, eventName, parentEvent, children}) => {
-    const checked = enabledHooks.includes(eventName) || (!!parentEvent && enabledHooks.includes(parentEvent));
+}> = ({enabledHooks, onChange, hookEventName, parentEvent, children}) => {
+    const checked = enabledHooks.includes(hookEventName) || (!!parentEvent && enabledHooks.includes(parentEvent));
 
     return <li>
         <label>
             <input
             type="checkbox"
-            x-event-name={eventName}
+            x-event-name={hookEventName}
             checked={checked}
             onChange={onChange} />
             { children }

--- a/web/components/elements/EventHookCheckbox.tsx
+++ b/web/components/elements/EventHookCheckbox.tsx
@@ -11,13 +11,11 @@ export const EventHookCheckbox: FunctionComponent<{
         throw Error(`Invalid configuration for checkbox ${eventName}`);
     }
 
-    const disabled = !!(parentEvent && !enabledHooks.includes(parentEvent));
-    const checked = enabledHooks.includes(eventName);
+    const checked = enabledHooks.includes(eventName) || (parentEvent && enabledHooks.includes(parentEvent));
 
     return <li>
         <label>
             <input
-            disabled={disabled}
             type="checkbox"
             x-event-name={eventName}
             checked={checked}

--- a/web/components/elements/EventHookCheckbox.tsx
+++ b/web/components/elements/EventHookCheckbox.tsx
@@ -2,15 +2,11 @@ import { FunctionComponent } from "preact";
 import { JSXInternal } from "preact/src/jsx";
 
 export const EventHookCheckbox: FunctionComponent<{
-    enabledHooks?: string[],
+    enabledHooks: string[],
     onChange: JSXInternal.GenericEventHandler<HTMLInputElement>,
     eventName: string,
     parentEvent?: string,
 }> = ({enabledHooks, onChange, eventName, parentEvent, children}) => {
-    if (!enabledHooks) {
-        throw Error(`Invalid configuration for checkbox ${eventName}`);
-    }
-
     const checked = enabledHooks.includes(eventName) || (!!parentEvent && enabledHooks.includes(parentEvent));
 
     return <li>

--- a/web/components/elements/InputField.tsx
+++ b/web/components/elements/InputField.tsx
@@ -1,4 +1,4 @@
-import { h, FunctionComponent } from "preact";
+import { FunctionComponent } from "preact";
 import style from "./InputField.module.scss";
 
 interface Props {

--- a/web/components/elements/ListItem.tsx
+++ b/web/components/elements/ListItem.tsx
@@ -1,4 +1,4 @@
-import { h, FunctionComponent } from "preact"
+import { FunctionComponent } from "preact"
 import { useState } from "preact/hooks"
 import style from "./ListItem.module.scss";
 

--- a/web/components/elements/WarningPane.tsx
+++ b/web/components/elements/WarningPane.tsx
@@ -1,4 +1,4 @@
-import { h, FunctionComponent } from "preact";
+import { FunctionComponent } from "preact";
 import WarningBadge from "../../icons/warning-badge.svg";
 import style from "./WarningPane.module.scss";
 

--- a/web/components/roomConfig/FeedsConfig.tsx
+++ b/web/components/roomConfig/FeedsConfig.tsx
@@ -1,4 +1,4 @@
-import { h, FunctionComponent, createRef } from "preact";
+import { FunctionComponent, createRef } from "preact";
 import { useCallback } from "preact/hooks"
 import { BridgeConfig } from "../../BridgeAPI";
 import { FeedConnectionState, FeedResponseItem } from "../../../src/Connections/FeedConnection";

--- a/web/components/roomConfig/GenericWebhookConfig.tsx
+++ b/web/components/roomConfig/GenericWebhookConfig.tsx
@@ -1,4 +1,4 @@
-import { h, FunctionComponent, createRef } from "preact";
+import { FunctionComponent, createRef } from "preact";
 import { useCallback, useState } from "preact/hooks"
 import CodeMirror from '@uiw/react-codemirror';
 import { javascript } from '@codemirror/lang-javascript';

--- a/web/components/roomConfig/GithubRepoConfig.tsx
+++ b/web/components/roomConfig/GithubRepoConfig.tsx
@@ -159,20 +159,20 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ne
         <InputField visible={!!existingConnection || !!connectionState} label="Events" noPadding={true}>
             <p>Choose which event should send a notification to the room</p>
             <ul>
-                <EventHookCheckbox eventName="issue" onChange={toggleEnabledHook}>Issues</EventHookCheckbox>
+                <EventHookCheckbox enabledHooks={enabledHooks} eventName="issue" onChange={toggleEnabledHook}>Issues</EventHookCheckbox>
                 <ul>
-                    <EventHookCheckbox parentEvent="issue" eventName="issue.created" onChange={toggleEnabledHook}>Created</EventHookCheckbox>
-                    <EventHookCheckbox parentEvent="issue" eventName="issue.changed" onChange={toggleEnabledHook}>Changed</EventHookCheckbox>
-                    <EventHookCheckbox parentEvent="issue" eventName="issue.edited" onChange={toggleEnabledHook}>Edited</EventHookCheckbox>
-                    <EventHookCheckbox parentEvent="issue" eventName="issue.labeled" onChange={toggleEnabledHook}>Labeled</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="issue" eventName="issue.created" onChange={toggleEnabledHook}>Created</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="issue" eventName="issue.changed" onChange={toggleEnabledHook}>Changed</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="issue" eventName="issue.edited" onChange={toggleEnabledHook}>Edited</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="issue" eventName="issue.labeled" onChange={toggleEnabledHook}>Labeled</EventHookCheckbox>
                 </ul>
-                <EventHookCheckbox eventName="pull_request" onChange={toggleEnabledHook}>Pull requests</EventHookCheckbox>
+                <EventHookCheckbox enabledHooks={enabledHooks} eventName="pull_request" onChange={toggleEnabledHook}>Pull requests</EventHookCheckbox>
                 <ul>
-                    <EventHookCheckbox parentEvent="pull_request" eventName="pull_request.opened" onChange={toggleEnabledHook}>Opened</EventHookCheckbox>
-                    <EventHookCheckbox parentEvent="pull_request" eventName="pull_request.closed" onChange={toggleEnabledHook}>Closed</EventHookCheckbox>
-                    <EventHookCheckbox parentEvent="pull_request" eventName="pull_request.merged" onChange={toggleEnabledHook}>Merged</EventHookCheckbox>
-                    <EventHookCheckbox parentEvent="pull_request" eventName="pull_request.ready_for_review" onChange={toggleEnabledHook}>Ready for review</EventHookCheckbox>
-                    <EventHookCheckbox parentEvent="pull_request" eventName="pull_request.reviewed" onChange={toggleEnabledHook}>Reviewed</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="pull_request" eventName="pull_request.opened" onChange={toggleEnabledHook}>Opened</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="pull_request" eventName="pull_request.closed" onChange={toggleEnabledHook}>Closed</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="pull_request" eventName="pull_request.merged" onChange={toggleEnabledHook}>Merged</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="pull_request" eventName="pull_request.ready_for_review" onChange={toggleEnabledHook}>Ready for review</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="pull_request" eventName="pull_request.reviewed" onChange={toggleEnabledHook}>Reviewed</EventHookCheckbox>
                 </ul>
                 <EventHookCheckbox enabledHooks={enabledHooks} eventName="workflow.run" onChange={toggleEnabledHook}>Workflow Runs</EventHookCheckbox>
                 <ul>

--- a/web/components/roomConfig/GithubRepoConfig.tsx
+++ b/web/components/roomConfig/GithubRepoConfig.tsx
@@ -159,35 +159,35 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ne
         <InputField visible={!!existingConnection || !!connectionState} label="Events" noPadding={true}>
             <p>Choose which event should send a notification to the room</p>
             <ul>
-                <EventHookCheckbox enabledHooks={enabledHooks} eventName="issue" onChange={toggleEnabledHook}>Issues</EventHookCheckbox>
+                <EventHookCheckbox enabledHooks={enabledHooks} hookEventName="issue" onChange={toggleEnabledHook}>Issues</EventHookCheckbox>
                 <ul>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="issue" eventName="issue.created" onChange={toggleEnabledHook}>Created</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="issue" eventName="issue.changed" onChange={toggleEnabledHook}>Changed</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="issue" eventName="issue.edited" onChange={toggleEnabledHook}>Edited</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="issue" eventName="issue.labeled" onChange={toggleEnabledHook}>Labeled</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="issue" hookEventName="issue.created" onChange={toggleEnabledHook}>Created</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="issue" hookEventName="issue.changed" onChange={toggleEnabledHook}>Changed</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="issue" hookEventName="issue.edited" onChange={toggleEnabledHook}>Edited</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="issue" hookEventName="issue.labeled" onChange={toggleEnabledHook}>Labeled</EventHookCheckbox>
                 </ul>
-                <EventHookCheckbox enabledHooks={enabledHooks} eventName="pull_request" onChange={toggleEnabledHook}>Pull requests</EventHookCheckbox>
+                <EventHookCheckbox enabledHooks={enabledHooks} hookEventName="pull_request" onChange={toggleEnabledHook}>Pull requests</EventHookCheckbox>
                 <ul>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="pull_request" eventName="pull_request.opened" onChange={toggleEnabledHook}>Opened</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="pull_request" eventName="pull_request.closed" onChange={toggleEnabledHook}>Closed</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="pull_request" eventName="pull_request.merged" onChange={toggleEnabledHook}>Merged</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="pull_request" eventName="pull_request.ready_for_review" onChange={toggleEnabledHook}>Ready for review</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="pull_request" eventName="pull_request.reviewed" onChange={toggleEnabledHook}>Reviewed</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="pull_request" hookEventName="pull_request.opened" onChange={toggleEnabledHook}>Opened</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="pull_request" hookEventName="pull_request.closed" onChange={toggleEnabledHook}>Closed</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="pull_request" hookEventName="pull_request.merged" onChange={toggleEnabledHook}>Merged</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="pull_request" hookEventName="pull_request.ready_for_review" onChange={toggleEnabledHook}>Ready for review</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="pull_request" hookEventName="pull_request.reviewed" onChange={toggleEnabledHook}>Reviewed</EventHookCheckbox>
                 </ul>
-                <EventHookCheckbox enabledHooks={enabledHooks} eventName="workflow.run" onChange={toggleEnabledHook}>Workflow Runs</EventHookCheckbox>
+                <EventHookCheckbox enabledHooks={enabledHooks} hookEventName="workflow.run" onChange={toggleEnabledHook}>Workflow Runs</EventHookCheckbox>
                 <ul>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="workflow.run" eventName="workflow.run.success" onChange={toggleEnabledHook}>Success</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="workflow.run" eventName="workflow.run.failure" onChange={toggleEnabledHook}>Failed</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="workflow.run" eventName="workflow.run.neutral" onChange={toggleEnabledHook}>Neutral</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="workflow.run" eventName="workflow.run.cancelled" onChange={toggleEnabledHook}>Cancelled</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="workflow.run" eventName="workflow.run.timed_out" onChange={toggleEnabledHook}>Timed Out</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="workflow.run" eventName="workflow.run.action_required" onChange={toggleEnabledHook}>Action Required</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="workflow.run" eventName="workflow.run.stale" onChange={toggleEnabledHook}>Stale</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="workflow.run" hookEventName="workflow.run.success" onChange={toggleEnabledHook}>Success</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="workflow.run" hookEventName="workflow.run.failure" onChange={toggleEnabledHook}>Failed</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="workflow.run" hookEventName="workflow.run.neutral" onChange={toggleEnabledHook}>Neutral</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="workflow.run" hookEventName="workflow.run.cancelled" onChange={toggleEnabledHook}>Cancelled</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="workflow.run" hookEventName="workflow.run.timed_out" onChange={toggleEnabledHook}>Timed Out</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="workflow.run" hookEventName="workflow.run.action_required" onChange={toggleEnabledHook}>Action Required</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="workflow.run" hookEventName="workflow.run.stale" onChange={toggleEnabledHook}>Stale</EventHookCheckbox>
                 </ul>
-                <EventHookCheckbox enabledHooks={enabledHooks} eventName="release" onChange={toggleEnabledHook}>Releases</EventHookCheckbox>
+                <EventHookCheckbox enabledHooks={enabledHooks} hookEventName="release" onChange={toggleEnabledHook}>Releases</EventHookCheckbox>
                 <ul>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="release" eventName="release.created" onChange={toggleEnabledHook}>Published</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="release" eventName="release.drafted" onChange={toggleEnabledHook}>Drafted</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="release" hookEventName="release.created" onChange={toggleEnabledHook}>Published</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="release" hookEventName="release.drafted" onChange={toggleEnabledHook}>Drafted</EventHookCheckbox>
                 </ul>
             </ul>
         </InputField>

--- a/web/components/roomConfig/GitlabRepoConfig.tsx
+++ b/web/components/roomConfig/GitlabRepoConfig.tsx
@@ -148,18 +148,18 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ne
         <InputField visible={!!existingConnection || !!newInstanceState} label="Events" noPadding={true}>
             <p>Choose which event should send a notification to the room</p>
             <ul>
-                <EventHookCheckbox enabledHooks={enabledHooks} eventName="merge_request" onChange={toggleEnabledHook}>Merge requests</EventHookCheckbox>
+                <EventHookCheckbox enabledHooks={enabledHooks} hookEventName="merge_request" onChange={toggleEnabledHook}>Merge requests</EventHookCheckbox>
                 <ul>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="merge_request" eventName="merge_request.open" onChange={toggleEnabledHook}>Opened</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="merge_request" eventName="merge_request.close" onChange={toggleEnabledHook}>Closed</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="merge_request" eventName="merge_request.merge" onChange={toggleEnabledHook}>Merged</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="merge_request" eventName="merge_request.review" onChange={toggleEnabledHook}>Reviewed</EventHookCheckbox>
-                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="merge_request" eventName="merge_request.ready_for_review" onChange={toggleEnabledHook}>Ready for review</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="merge_request" hookEventName="merge_request.open" onChange={toggleEnabledHook}>Opened</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="merge_request" hookEventName="merge_request.close" onChange={toggleEnabledHook}>Closed</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="merge_request" hookEventName="merge_request.merge" onChange={toggleEnabledHook}>Merged</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="merge_request" hookEventName="merge_request.review" onChange={toggleEnabledHook}>Reviewed</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="merge_request" hookEventName="merge_request.ready_for_review" onChange={toggleEnabledHook}>Ready for review</EventHookCheckbox>
                 </ul>
-                <EventHookCheckbox enabledHooks={enabledHooks} eventName="push" onChange={toggleEnabledHook}>Pushes</EventHookCheckbox>
-                <EventHookCheckbox enabledHooks={enabledHooks} eventName="tag_push" onChange={toggleEnabledHook}>Tag pushes</EventHookCheckbox>
-                <EventHookCheckbox enabledHooks={enabledHooks} eventName="wiki" onChange={toggleEnabledHook}>Wiki page updates</EventHookCheckbox>
-                <EventHookCheckbox enabledHooks={enabledHooks} eventName="release" onChange={toggleEnabledHook}>Releases</EventHookCheckbox>
+                <EventHookCheckbox enabledHooks={enabledHooks} hookEventName="push" onChange={toggleEnabledHook}>Pushes</EventHookCheckbox>
+                <EventHookCheckbox enabledHooks={enabledHooks} hookEventName="tag_push" onChange={toggleEnabledHook}>Tag pushes</EventHookCheckbox>
+                <EventHookCheckbox enabledHooks={enabledHooks} hookEventName="wiki" onChange={toggleEnabledHook}>Wiki page updates</EventHookCheckbox>
+                <EventHookCheckbox enabledHooks={enabledHooks} hookEventName="release" onChange={toggleEnabledHook}>Releases</EventHookCheckbox>
             </ul>
         </InputField>
         <ButtonSet>

--- a/web/components/roomConfig/GitlabRepoConfig.tsx
+++ b/web/components/roomConfig/GitlabRepoConfig.tsx
@@ -1,10 +1,11 @@
-import { h, FunctionComponent, createRef } from "preact";
-import { useState, useCallback, useEffect, useMemo } from "preact/hooks";
+import GitLabIcon from "../../icons/gitlab.png";
 import { BridgeAPI, BridgeConfig } from "../../BridgeAPI";
 import { ConnectionConfigurationProps, RoomConfig } from "./RoomConfig";
+import { EventHookCheckbox } from '../elements/EventHookCheckbox';
 import { GitLabRepoConnectionState, GitLabRepoResponseItem, GitLabTargetFilter, GitLabRepoConnectionTarget, GitLabRepoConnectionProjectTarget, GitLabRepoConnectionInstanceTarget } from "../../../src/Connections/GitlabRepo";
 import { InputField, ButtonSet, Button, ErrorPane } from "../elements";
-import GitLabIcon from "../../icons/gitlab.png";
+import { h, FunctionComponent, createRef } from "preact";
+import { useState, useCallback, useEffect, useMemo } from "preact/hooks";
 
 const EventType = "uk.half-shot.matrix-hookshot.gitlab.repository";
 
@@ -97,36 +98,18 @@ const ConnectionSearch: FunctionComponent<{api: BridgeAPI, onPicked: (state: Git
     </div>;
 }
 
-const EventCheckbox: FunctionComponent<{
-    ignoredHooks: string[],
-    onChange: (evt: HTMLInputElement) => void,
-    eventName: string,
-    parentEvent?: string,
-}> = ({ignoredHooks, onChange, eventName, parentEvent, children}) => {
-    return <li>
-        <label>
-            <input
-            disabled={parentEvent && ignoredHooks.includes(parentEvent)}
-            type="checkbox"
-            x-event-name={eventName}
-            checked={!ignoredHooks.includes(eventName)}
-            onChange={onChange} />
-            { children }
-        </label>
-    </li>;
-};
-
 const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<never, GitLabRepoResponseItem, GitLabRepoConnectionState>> = ({api, existingConnection, onSave, onRemove }) => {
-    const [ignoredHooks, setIgnoredHooks] = useState<string[]>(existingConnection?.config.ignoreHooks || []);
+    const [enabledHooks, setEnabledHooks] = useState<string[]>(existingConnection?.config.enableHooks || []);
 
-    const toggleIgnoredHook = useCallback(evt => {
+    const toggleEnabledHook = useCallback((evt: any) => {
         const key = (evt.target as HTMLElement).getAttribute('x-event-name');
         if (key) {
-            setIgnoredHooks(ignoredHooks => (
-                ignoredHooks.includes(key) ? ignoredHooks.filter(k => k !== key) : [...ignoredHooks, key]
+            setEnabledHooks(enabledHooks => (
+                enabledHooks.includes(key) ? enabledHooks.filter(k => k !== key) : [...enabledHooks, key]
             ));
         }
     }, []);
+
     const [newInstanceState, setNewInstanceState] = useState<GitLabRepoConnectionState|null>(null);
 
     const canEdit = !existingConnection || (existingConnection?.canEdit ?? false);
@@ -141,12 +124,12 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ne
         if (state) {
             onSave({
                 ...(state),
-                ignoreHooks: ignoredHooks as any[],
+                enableHooks: enabledHooks as any[],
                 includeCommentBody: includeBodyRef.current?.checked,
                 commandPrefix: commandPrefixRef.current?.value || commandPrefixRef.current?.placeholder,
             });
         }
-    }, [canEdit, existingConnection, newInstanceState, ignoredHooks, commandPrefixRef, onSave]);
+    }, [includeBodyRef, canEdit, existingConnection, newInstanceState, enabledHooks, commandPrefixRef, onSave]);
     
     return <form onSubmit={handleSave}>
         {!existingConnection && <ConnectionSearch api={api} onPicked={setNewInstanceState} />}
@@ -165,18 +148,18 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ne
         <InputField visible={!!existingConnection || !!newInstanceState} label="Events" noPadding={true}>
             <p>Choose which event should send a notification to the room</p>
             <ul>
-                <EventCheckbox ignoredHooks={ignoredHooks} eventName="merge_request" onChange={toggleIgnoredHook}>Merge requests</EventCheckbox>
+                <EventHookCheckbox enabledHooks={enabledHooks} eventName="merge_request" onChange={toggleEnabledHook}>Merge requests</EventHookCheckbox>
                 <ul>
-                    <EventCheckbox ignoredHooks={ignoredHooks} parentEvent="merge_request" eventName="merge_request.open" onChange={toggleIgnoredHook}>Opened</EventCheckbox>
-                    <EventCheckbox ignoredHooks={ignoredHooks} parentEvent="merge_request" eventName="merge_request.close" onChange={toggleIgnoredHook}>Closed</EventCheckbox>
-                    <EventCheckbox ignoredHooks={ignoredHooks} parentEvent="merge_request" eventName="merge_request.merge" onChange={toggleIgnoredHook}>Merged</EventCheckbox>
-                    <EventCheckbox ignoredHooks={ignoredHooks} parentEvent="merge_request" eventName="merge_request.review" onChange={toggleIgnoredHook}>Reviewed</EventCheckbox>
-                    <EventCheckbox ignoredHooks={ignoredHooks} parentEvent="merge_request" eventName="merge_request.ready_for_review" onChange={toggleIgnoredHook}>Ready for review</EventCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="merge_request" eventName="merge_request.open" onChange={toggleEnabledHook}>Opened</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="merge_request" eventName="merge_request.close" onChange={toggleEnabledHook}>Closed</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="merge_request" eventName="merge_request.merge" onChange={toggleEnabledHook}>Merged</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="merge_request" eventName="merge_request.review" onChange={toggleEnabledHook}>Reviewed</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="merge_request" eventName="merge_request.ready_for_review" onChange={toggleEnabledHook}>Ready for review</EventHookCheckbox>
                 </ul>
-                <EventCheckbox ignoredHooks={ignoredHooks} eventName="push" onChange={toggleIgnoredHook}>Pushes</EventCheckbox>
-                <EventCheckbox ignoredHooks={ignoredHooks} eventName="tag_push" onChange={toggleIgnoredHook}>Tag pushes</EventCheckbox>
-                <EventCheckbox ignoredHooks={ignoredHooks} eventName="wiki" onChange={toggleIgnoredHook}>Wiki page updates</EventCheckbox>
-                <EventCheckbox ignoredHooks={ignoredHooks} eventName="release" onChange={toggleIgnoredHook}>Releases</EventCheckbox>
+                <EventHookCheckbox enabledHooks={enabledHooks} eventName="push" onChange={toggleEnabledHook}>Pushes</EventHookCheckbox>
+                <EventHookCheckbox enabledHooks={enabledHooks} eventName="tag_push" onChange={toggleEnabledHook}>Tag pushes</EventHookCheckbox>
+                <EventHookCheckbox enabledHooks={enabledHooks} eventName="wiki" onChange={toggleEnabledHook}>Wiki page updates</EventHookCheckbox>
+                <EventHookCheckbox enabledHooks={enabledHooks} eventName="release" onChange={toggleEnabledHook}>Releases</EventHookCheckbox>
             </ul>
         </InputField>
         <ButtonSet>

--- a/web/components/roomConfig/GitlabRepoConfig.tsx
+++ b/web/components/roomConfig/GitlabRepoConfig.tsx
@@ -4,7 +4,7 @@ import { ConnectionConfigurationProps, RoomConfig } from "./RoomConfig";
 import { EventHookCheckbox } from '../elements/EventHookCheckbox';
 import { GitLabRepoConnectionState, GitLabRepoResponseItem, GitLabTargetFilter, GitLabRepoConnectionTarget, GitLabRepoConnectionProjectTarget, GitLabRepoConnectionInstanceTarget } from "../../../src/Connections/GitlabRepo";
 import { InputField, ButtonSet, Button, ErrorPane } from "../elements";
-import { h, FunctionComponent, createRef } from "preact";
+import { FunctionComponent, createRef } from "preact";
 import { useState, useCallback, useEffect, useMemo } from "preact/hooks";
 
 const EventType = "uk.half-shot.matrix-hookshot.gitlab.repository";

--- a/web/components/roomConfig/JiraProjectConfig.tsx
+++ b/web/components/roomConfig/JiraProjectConfig.tsx
@@ -1,4 +1,4 @@
-import { h, FunctionComponent, createRef } from "preact";
+import { FunctionComponent, createRef } from "preact";
 import { useState, useCallback, useEffect, useMemo } from "preact/hooks";
 import { BridgeAPI, BridgeConfig } from "../../BridgeAPI";
 import { ConnectionConfigurationProps, RoomConfig } from "./RoomConfig";
@@ -116,23 +116,6 @@ const ConnectionSearch: FunctionComponent<{api: BridgeAPI, onPicked: (state: Jir
         </InputField>
     </div>;
 }
-
-const EventCheckbox: FunctionComponent<{
-    allowedEvents: string[],
-    onChange: (evt: HTMLInputElement) => void,
-    eventName: string,
-}> = ({allowedEvents, onChange, eventName, children}) => {
-    return <li>
-        <label>
-            <input
-            type="checkbox"
-            x-event-name={eventName}
-            checked={allowedEvents.includes(eventName)}
-            onChange={onChange} />
-            { children }
-        </label>
-    </li>;
-};
 
 const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<never, JiraProjectResponseItem, JiraProjectConnectionState>> = ({api, existingConnection, onSave, onRemove }) => {
     const [allowedEvents, setAllowedEvents] = useState<string[]>(existingConnection?.config.events || ['issue_created']);

--- a/web/components/roomConfig/JiraProjectConfig.tsx
+++ b/web/components/roomConfig/JiraProjectConfig.tsx
@@ -5,6 +5,7 @@ import { ConnectionConfigurationProps, RoomConfig } from "./RoomConfig";
 import { ErrCode } from "../../../src/api";
 import { JiraProjectConnectionState, JiraProjectResponseItem, JiraProjectConnectionProjectTarget, JiraTargetFilter, JiraProjectConnectionInstanceTarget, JiraProjectConnectionTarget } from "../../../src/Connections/JiraProject";
 import { InputField, ButtonSet, Button, ErrorPane } from "../elements";
+import { EventHookCheckbox } from '../elements/EventHookCheckbox';
 import JiraIcon from "../../icons/jira.png";
 
 const EventType = "uk.half-shot.matrix-hookshot.jira.project";
@@ -173,14 +174,14 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ne
             <ul>
                 Issues
                 <ul>
-                    <EventCheckbox allowedEvents={allowedEvents} eventName="issue_created" onChange={toggleEvent}>Created</EventCheckbox>
-                    <EventCheckbox allowedEvents={allowedEvents} eventName="issue_updated" onChange={toggleEvent}>Updated</EventCheckbox>
+                    <EventHookCheckbox enabledHooks={allowedEvents} hookEventName="issue_created" onChange={toggleEvent}>Created</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={allowedEvents} hookEventName="issue_updated" onChange={toggleEvent}>Updated</EventHookCheckbox>
                 </ul>
                 Versions
                 <ul>
-                    <EventCheckbox allowedEvents={allowedEvents} eventName="version_created" onChange={toggleEvent}>Created</EventCheckbox>
-                    <EventCheckbox allowedEvents={allowedEvents} eventName="version_updated" onChange={toggleEvent}>Updated</EventCheckbox>
-                    <EventCheckbox allowedEvents={allowedEvents} eventName="version_released" onChange={toggleEvent}>Released</EventCheckbox>
+                    <EventHookCheckbox enabledHooks={allowedEvents} hookEventName="version_created" onChange={toggleEvent}>Created</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={allowedEvents} hookEventName="version_updated" onChange={toggleEvent}>Updated</EventHookCheckbox>
+                    <EventHookCheckbox enabledHooks={allowedEvents} hookEventName="version_released" onChange={toggleEvent}>Released</EventHookCheckbox>
                 </ul>
             </ul>
         </InputField>

--- a/web/components/roomConfig/RoomConfig.tsx
+++ b/web/components/roomConfig/RoomConfig.tsx
@@ -1,4 +1,4 @@
-import { h, FunctionComponent } from "preact";
+import { FunctionComponent } from "preact";
 import { useCallback, useEffect, useReducer, useState } from "preact/hooks"
 import { BridgeAPI, BridgeAPIError } from "../../BridgeAPI";
 import { ErrorPane, ListItem, WarningPane } from "../elements";

--- a/web/index.tsx
+++ b/web/index.tsx
@@ -1,4 +1,4 @@
-import { h, render } from 'preact';
+import { render } from 'preact';
 import 'preact/devtools';
 import App from './App';
 import "./fonts/fonts.scss"

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,11 +1,12 @@
 {
   "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "module": "commonjs",
-    "target": "es2019",
     "moduleResolution": "node",
-    "jsx": "preserve",
-    "jsxFactory": "h",
-    /* noEmit - Snowpack builds (emits) files, not tsc. */
+    "target": "es2019",
+    "types": ["preact"],
+    /* noEmit - Vite builds (emits) files, not tsc. */
     "noEmit": true,
     /* Additional Options */
     "strict": true,


### PR DESCRIPTION
Fixes #591 

This is a bit of a large refactor, but should massively simplify our event system overall. This:

- Refactors the backend to *only* support *either* `enabledHooks` or defaultHooks.
- Refactors the frontend to support that.
- Refactors a bit of the frontend to split out shared components.
- Cleans up our jsx/preact configuration.

This does NOT autoupgrade state, as that's fairly error prone and we don't want to forcibly do it on startup. This instead adopts an approach of consuming the legacy `ignoreHooks` field from existing state, while overwriting existing state with new keys automatically.
