### PR TITLE
A11y: Add alt tags to all images

### DIFF
--- a/changelog.d/602.feature
+++ b/changelog.d/602.feature
@@ -1,0 +1,1 @@
+A11y: Add alt tags to all images.

--- a/web/components/ConnectionCard.tsx
+++ b/web/components/ConnectionCard.tsx
@@ -11,7 +11,7 @@ interface IProps {
 
 export function ConnectionCard(props: IProps) {
     return <div className={style.card} onClick={props.onClick}>
-        <img src={props.imageSrc} />
+        <img alt="" src={props.imageSrc} />
         <div>
             <span>{props.serviceName}</span>
             <p>{props.description}</p>

--- a/web/components/GitHubState.tsx
+++ b/web/components/GitHubState.tsx
@@ -6,7 +6,7 @@ const GitHubState: FunctionComponent<{config: BridgeRoomStateGitHub}> = ({ confi
     return <div class="container login-card">
         <div class="row">
             <div class="col-sm-2">
-                <img src={config.identity.avatarUrl} title="GitHub avatar" />
+                <img alt="GitHub avatar" src={config.identity.avatarUrl} />
             </div>
             <div class="col-sm-9">
                 Logged in as <span>{config.identity.name}</span>

--- a/web/components/elements/ErrorPane.tsx
+++ b/web/components/elements/ErrorPane.tsx
@@ -4,6 +4,6 @@ import style from "./ErrorPane.module.scss";
 
 export const ErrorPane: FunctionComponent<{header?: string}> = ({ children, header }) => {
     return <div class={`card error ${style.errorPane}`}>
-        <p><strong><img src={ErrorBadge} /> { header || "Error occurred during widget load" }</strong>: {children}</p>
+        <p><strong><img alt="error" src={ErrorBadge} /> { header || "Error occurred during widget load" }</strong>: {children}</p>
     </div>;
 };

--- a/web/components/elements/WarningPane.tsx
+++ b/web/components/elements/WarningPane.tsx
@@ -4,6 +4,6 @@ import style from "./WarningPane.module.scss";
 
 export const WarningPane: FunctionComponent<{header?: string}> = ({ children, header }) => {
     return <div class={`card error ${style.warningPane}`}>
-        <p><strong><img src={WarningBadge} /> { header || "Problem occurred during widget load" }</strong>: {children}</p>
+        <p><strong><img alt="warning" src={WarningBadge} /> { header || "Problem occurred during widget load" }</strong>: {children}</p>
     </div>;
 };

--- a/web/components/roomConfig/RoomConfig.tsx
+++ b/web/components/roomConfig/RoomConfig.tsx
@@ -100,7 +100,7 @@ export const RoomConfig = function<SConfig, ConnectionType extends GetConnection
                 )
         }
         <header className={style.header}>
-            <img src={headerImg} />
+            <img alt="" src={headerImg} />
             <h1>{text.header}</h1> 
         </header>
         { canEditRoom && <section>


### PR DESCRIPTION
* `alt=""` indicates that there's no additional information in the image. It can be used for avatars and icons where the label is next to the image.