### PR TITLE
Increase maximum size of webhook payload.

### DIFF
--- a/changelog.d/606.misc
+++ b/changelog.d/606.misc
@@ -1,0 +1,1 @@
+Increase maximum size of incoming webhook payload from `100kb` to `10mb`.

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -70,6 +70,7 @@ export class Webhooks extends EventEmitter {
         }
         this.expressRouter.use(express.json({
             verify: this.verifyRequest.bind(this),
+            limit: '10mb', 
         }));
         this.expressRouter.post("/", this.onPayload.bind(this));
     }


### PR DESCRIPTION
<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->

10mb aught to do it, without being to excessive. I didn't feel the need to make this configurable, as really this is better configured in a load balancer.