### PR TITLE
Mark encryption as experimental

### DIFF
--- a/changelog.d/610.misc
+++ b/changelog.d/610.misc
@@ -1,1 +1,1 @@
-Mark encryption feature as experimental (config option is now `experimental_encryption`).
+Mark encryption feature as experimental (config option is now `experimentalEncryption`).

--- a/changelog.d/610.misc
+++ b/changelog.d/610.misc
@@ -1,0 +1,1 @@
+Mark encryption feature as experimental (config option is now `experimental_encryption`).

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -113,11 +113,6 @@ queue:
   monolithic: true
   port: 6379
   host: localhost
-encryption:
-  # (Optional) Configuration for encryption support in the bridge.
-  # If omitted, encryption support will be disabled.
-  #
-  null
 logging:
   # (Optional) Logging settings. You can have a severity debug,info,warn,error
   #

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -117,7 +117,7 @@ encryption:
   # (Optional) Configuration for encryption support in the bridge.
   # If omitted, encryption support will be disabled.
   #
-  storagePath: ./data/encryption
+  null
 logging:
   # (Optional) Logging settings. You can have a severity debug,info,warn,error
   #

--- a/docs/advanced/encryption.md
+++ b/docs/advanced/encryption.md
@@ -11,7 +11,7 @@ Hookshot supports end-to-bridge encryption via [MSC3202](https://github.com/matr
 ## Enabling encryption in Hookshot
 
 In order for hookshot to use encryption, it must be configured as follows:
-- The `experimental_encryption.storagePath` setting must point to a directory that hookshot has permissions to write files into. If running with Docker, this path should be within a volume (for persistency).
+- The `experimentalEncryption.storagePath` setting must point to a directory that hookshot has permissions to write files into. If running with Docker, this path should be within a volume (for persistency).
 - [Redis](./workers.md) must be enabled. Note that worker mode is not yet supported with encryption, so `queue.monolithic` must be set to `true`.
 
 If you ever reset your homeserver's state, ensure you also reset hookshot's encryption state. This includes clearing the `encryption.storagePath` directory and all worker state stored in your redis instance. Otherwise, hookshot may fail on start up with registration errors.

--- a/docs/advanced/encryption.md
+++ b/docs/advanced/encryption.md
@@ -1,12 +1,17 @@
 Encryption
-=======
+==========
+
+<section class="warning">
+Encryption support is <strong>HIGHLY EXPERIMENTAL AND SUBJECT TO CHANGE</strong>. It should not be enabled for production workloads.
+For more details, see <a href="https://github.com/matrix-org/matrix-hookshot/issues/594">issue 594</a>.
+</section>
 
 Hookshot supports end-to-bridge encryption via [MSC3202](https://github.com/matrix-org/matrix-spec-proposals/pull/3202). As such, encryption requires hookshot to be connected to a homeserver that supports that MSC, such as [Synapse](#running-with-synapse).
 
 ## Enabling encryption in Hookshot
 
 In order for hookshot to use encryption, it must be configured as follows:
-- The `encryption.storagePath` setting must point to a directory that hookshot has permissions to write files into. If running with Docker, this path should be within a volume (for persistency).
+- The `experimental_encryption.storagePath` setting must point to a directory that hookshot has permissions to write files into. If running with Docker, this path should be within a volume (for persistency).
 - [Redis](./workers.md) must be enabled. Note that worker mode is not yet supported with encryption, so `queue.monolithic` must be set to `true`.
 
 If you ever reset your homeserver's state, ensure you also reset hookshot's encryption state. This includes clearing the `encryption.storagePath` directory and all worker state stored in your redis instance. Otherwise, hookshot may fail on start up with registration errors.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "repository": "https://github.com/matrix-org/matrix-hookshot",
   "author": "matrix.org",
   "license": "Apache-2.0",
-  "private": false,
   "napi": {
     "name": "matrix-hookshot-rs"
   },

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -426,7 +426,7 @@ export interface BridgeConfigMetrics {
 export interface BridgeConfigRoot {
     bot?: BridgeConfigBot;
     bridge: BridgeConfigBridge;
-    encryption?: BridgeConfigEncryption;
+    experimental_encryption?: BridgeConfigEncryption;
     figma?: BridgeConfigFigma;
     feeds?: BridgeConfigFeedsYAML;
     generic?: BridgeGenericWebhooksConfigYAML;
@@ -515,7 +515,8 @@ export class BridgeConfig {
         this.queue = configData.queue || {
             monolithic: true,
         };
-        this.encryption = configData.encryption;
+        this.encryption = configData.experimental_encryption;
+
 
         this.logging = configData.logging || {
             level: "info",
@@ -527,6 +528,12 @@ export class BridgeConfig {
         this.logging.level = this.logging.level.toLowerCase() as "debug"|"info"|"warn"|"error"|"trace";
         if (!ValidLogLevelStrings.includes(this.logging.level)) {
             throw new ConfigError("logging.level", `Logging level is not valid. Must be one of ${ValidLogLevelStrings.join(', ')}`)
+        }
+        if (this.encryption) {
+            log.warn(`
+You have enabled encryption support in the bridge. This feature is HIGHLY EXPERIMENTAL AND SUBJECT TO CHANGE.
+For more details, see https://github.com/matrix-org/matrix-hookshot/issues/594.
+            `)
         }
 
         this.permissions = configData.permissions || [{

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -426,7 +426,7 @@ export interface BridgeConfigMetrics {
 export interface BridgeConfigRoot {
     bot?: BridgeConfigBot;
     bridge: BridgeConfigBridge;
-    experimental_encryption?: BridgeConfigEncryption;
+    experimentalEncryption?: BridgeConfigEncryption;
     figma?: BridgeConfigFigma;
     feeds?: BridgeConfigFeedsYAML;
     generic?: BridgeGenericWebhooksConfigYAML;
@@ -517,7 +517,7 @@ export class BridgeConfig {
         this.queue = configData.queue || {
             monolithic: true,
         };
-        this.encryption = configData.experimental_encryption;
+        this.encryption = configData.experimentalEncryption;
 
 
         this.logging = configData.logging || {

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -448,7 +448,9 @@ export class BridgeConfig {
     @configKey("Basic homeserver configuration")
     public readonly bridge: BridgeConfigBridge;
     @configKey(`Configuration for encryption support in the bridge.
- If omitted, encryption support will be disabled.`, true)
+ If omitted, encryption support will be disabled.
+ This feature is HIGHLY EXPERIMENTAL AND SUBJECT TO CHANGE.
+ For more details, see https://github.com/matrix-org/matrix-hookshot/issues/594.`, true)
     public readonly encryption?: BridgeConfigEncryption;
     @configKey(`Message queue / cache configuration options for large scale deployments.
  For encryption to work, must be set to monolithic mode and have a host & port specified.`, true)

--- a/src/Config/Defaults.ts
+++ b/src/Config/Defaults.ts
@@ -144,6 +144,10 @@ function renderSection(doc: YAML.Document, obj: Record<string, unknown>, parentN
             return;
         }
 
+        if (value === undefined || value === null) {
+            return;
+        }
+
         let newNode: Node;
         if (typeof value === "object" && !Array.isArray(value)) {
             newNode = YAML.createNode({});

--- a/src/Config/Defaults.ts
+++ b/src/Config/Defaults.ts
@@ -134,10 +134,7 @@ export const DefaultConfig = new BridgeConfig({
             bindAddress: '0.0.0.0',
             resources: ['widgets'],
         }
-    ],
-    encryption: {
-        storagePath: "./data/encryption"
-    }
+    ]
 }, {});
 
 function renderSection(doc: YAML.Document, obj: Record<string, unknown>, parentNode?: YAMLSeq) {


### PR DESCRIPTION
As discussed in #594, the bridge currently isn't stable with encryption enabled. Rather than ripping all the code out, we're going to mark it as experimental while it's still being worked on.