### PR TITLE
Decrease connection creation concurrency when starting up

### DIFF
--- a/changelog.d/614.bugfix
+++ b/changelog.d/614.bugfix
@@ -1,0 +1,1 @@
+Improve startup stability by not loading all room state at once.

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "mime": "^3.0.0",
     "node-emoji": "^1.11.0",
     "nyc": "^15.1.0",
+    "p-queue": "^6.6.2",
     "prom-client": "^14.0.1",
     "reflect-metadata": "^0.1.13",
     "rss-parser": "^3.12.0",

--- a/src/PromiseUtil.ts
+++ b/src/PromiseUtil.ts
@@ -1,8 +1,16 @@
 import { Logger } from "matrix-appservice-bridge";
+import { MatrixError } from "matrix-bot-sdk";
 
 const SLEEP_TIME_MS = 250;
 const DEFAULT_RETRY = () => true;
 const log = new Logger("PromiseUtil");
+
+export function retryMatrixErrorFilter(err: unknown) {
+    if (err instanceof MatrixError && err.statusCode >= 400 && err.statusCode <= 499) {
+        return false;
+    }
+    return true; 
+}
 
 export async function retry<T>(actionFn: () => Promise<T>,
                                maxAttempts: number,


### PR DESCRIPTION
Fixes #608 

This isn't really the best possible fix, but I think actually going through and eliminating all the possible ways we can fail a HTTP request on startup to be a significant effort. To avoid spinning too much time away on that, this change:

- Stops us from trying to fetch all state at once on startup at once concurrently, upsetting the homeserver. Instead, load 2 at a time. In the future we can increase this.
- Avoids `getRoomState` failures (which are probably the biggest explosion point) by retrying them on failure.