### PR TITLE
Check the GitLab instance name when looking for existing connections

### DIFF
--- a/changelog.d/617.bugfix
+++ b/changelog.d/617.bugfix
@@ -1,0 +1,1 @@
+You can now add multiple GitLab connections to the same room with the same project path, if they are under different instances.

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -206,7 +206,7 @@ export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnection
         const stateEventKey = `${validData.instance}/${validData.path}`;
         const connection = new GitLabRepoConnection(roomId, stateEventKey, as, validData, tokenStore, instance);
         const existingConnections = getAllConnectionsOfType(GitLabRepoConnection);
-        const existing = existingConnections.find(c => c.roomId === roomId && c.path === connection.path);
+        const existing = existingConnections.find(c => c.roomId === roomId && c.instance.url === connection.instance.url && c.path === connection.path);
 
         if (existing) {
             throw new ApiError("A GitLab repo connection for this project already exists", ErrCode.ConflictingConnection, -1, {


### PR DESCRIPTION
We're checking to see if there are multiple connections with the same `path` in the room, but they might be on different instances!
