### PR TITLE
Add webhook name and room to admin info

### DIFF
--- a/changelog.d/620.feature
+++ b/changelog.d/620.feature
@@ -1,0 +1,1 @@
+The message in the admin room when creating a webhook now also shows the name and links to the room.

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -216,10 +216,11 @@ export class SetupConnection extends CommandConnection {
         this.pushConnections(c.connection);
         const url = new URL(c.connection.hookId, this.config.generic.parsedUrlPrefix);
         const adminRoom = await this.getOrCreateAdminRoom(userId);
+        const safeRoomId = encodeURIComponent(this.roomId);
         await adminRoom.sendNotice(
-            `You have bridged the webhook "${name}" in https://matrix.to/#/${this.roomId} .\n` +
-                // Line break before and no full stop after URL is intentional.
-                // This makes copying and pasting the URL much easier.
+            `You have bridged the webhook "${name}" in https://matrix.to/#/${safeRoomId} .\n` +
+            // Line break before and no full stop after URL is intentional.
+            // This makes copying and pasting the URL much easier.
             `Please configure your webhook source to use\n${url}`
         );
         return this.as.botClient.sendNotice(this.roomId, `Room configured to bridge webhooks. See admin room for secret url.`);

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -22,7 +22,7 @@ const log = new Logger("SetupConnection");
  * no state, and is only invoked when messages from other clients fall through.
  */
 export class SetupConnection extends CommandConnection {
-    
+
     static botCommands: BotCommands;
     static helpMessage: HelpFunction;
 
@@ -216,7 +216,12 @@ export class SetupConnection extends CommandConnection {
         this.pushConnections(c.connection);
         const url = new URL(c.connection.hookId, this.config.generic.parsedUrlPrefix);
         const adminRoom = await this.getOrCreateAdminRoom(userId);
-        await adminRoom.sendNotice(`You have bridged a webhook. Please configure your webhook source to use ${url}.`);
+        await adminRoom.sendNotice(
+            `You have bridged the webhook "${name}" in https://matrix.to/#/${this.roomId} .\n` +
+                // Line break before and no full stop after URL is intentional.
+                // This makes copying and pasting the URL much easier.
+            `Please configure your webhook source to use\n${url}`
+        );
         return this.as.botClient.sendNotice(this.roomId, `Room configured to bridge webhooks. See admin room for secret url.`);
     }
 


### PR DESCRIPTION
Now in admin webhook info:
- Name of the hook
- Link to room (used a matrix.to link, because that seems to be working)
- URL on own line for better copying

![image](https://user-images.githubusercontent.com/6216686/211897784-2c20204d-ae07-45d7-af63-96687bfc75f6.png)

closes #619