### PR TITLE
Refactor Jira OAuth to add unit tests

### DIFF
--- a/src/Jira/oauth/CloudOAuth.ts
+++ b/src/Jira/oauth/CloudOAuth.ts
@@ -1,6 +1,5 @@
 import { BridgeConfigJiraCloudOAuth } from "../../Config/Config";
 import { JiraOAuth } from "../OAuth";
-import qs from "querystring";
 import axios from "axios";
 import { JiraOAuthResult } from "../Types";
 
@@ -21,7 +20,7 @@ const JiraOnPremOAuthScopes = [
 export class JiraCloudOAuth implements JiraOAuth {
     constructor(private readonly config: BridgeConfigJiraCloudOAuth) { }
     public async getAuthUrl(state: string) {
-        const options = {
+        const options = new URLSearchParams({
             audience: "api.atlassian.com",
             client_id: this.config.client_id,
             scope: JiraOnPremOAuthScopes.join(" "),
@@ -29,8 +28,8 @@ export class JiraCloudOAuth implements JiraOAuth {
             state: state,
             response_type: "code",
             prompt: "consent",
-        };
-        return `https://auth.atlassian.com/authorize?${qs.stringify(options)}`;
+        });
+        return `https://auth.atlassian.com/authorize?${options}`;
     }
 
     public async exchangeRequestForToken(code: string): Promise<JiraOAuthResult> {

--- a/src/Jira/oauth/OnPremOAuth.ts
+++ b/src/Jira/oauth/OnPremOAuth.ts
@@ -1,6 +1,5 @@
 import { BridgeConfigJiraOnPremOAuth } from "../../Config/Config";
 import Axios, { Method } from "axios"
-import qs from "querystring";
 import { createPrivateKey, createSign, KeyObject } from "crypto";
 import fs from "fs";
 import { Logger } from "matrix-appservice-bridge";
@@ -9,48 +8,120 @@ import { JiraOAuthResult } from "../Types";
 
 const log = new Logger('JiraOnPremOAuth');
 
-const NONCE_CHARS = [
-    'a','b','c','d','e','f','g','h','i','j','k','l','m','n',
-    'o','p','q','r','s','t','u','v','w','x','y','z','A','B',
-    'C','D','E','F','G','H','I','J','K','L','M','N','O','P',
-    'Q','R','S','T','U','V','W','X','Y','Z','0','1','2','3',
-    '4','5','6','7','8','9'
-];
+export const assertOAuthRequestToken = (body: Record<string, string>): { oauth_token: string, oauth_token_secret: string } => {
+    try {
+        if (typeof body.oauth_token !== "string" && body.oauth_token) {
+            throw Error("Unexpected OAuth response from server: missing or invalid oauth_token");
+        }
+        if (typeof body.oauth_token_secret !== "string" && body.oauth_token_secret) {
+            throw Error("Unexpected OAuth response from server: missing or invalid oauth_token_secret");
+        }
+    } catch (error) {
+        log.info(`Unexpected response from JIRA:`, JSON.stringify(body));
+        throw error;
+    }
+    return {
+        oauth_token: body.oauth_token,
+        oauth_token_secret: body.oauth_token_secret,
+    };
+};
+
+export const buildAuthorizationHeaders = (orderedParameters: [string, string][]) => {
+    // Whilst the all the parameters should be included within the signature, only the oauth_ arguments
+    // should appear within the authorization header.
+    const authParams = orderedParameters.filter(([key]) => isParameterNameAnOAuthParameter(key));
+    // Convert to strings: ["oauth_foo", "bar"] becomes oauth_foo="bar"
+    const authStrings = authParams.map(([key, value]) => `${encodeData(key)}="${encodeData(value)}"`);
+    return `OAuth ${authStrings.join(",")}`;
+}
+
+export const createSignatureBase = (method: string, url: string, parameters: string): string => {
+    return `${method.toUpperCase()}&${encodeData(normalizeUrl(url))}&${encodeData(parameters)}`;
+}
+
+export const encodeData = (toEncode: string): string => {
+    return encodeURIComponent(toEncode).replace(/!/g, "%21")
+        .replace(/'/g, "%27")
+        .replace(/\(/g, "%28")
+        .replace(/\)/g, "%29")
+        .replace(/\*/g, "%2A");
+}
+
+/**
+ * Is the parameter considered an OAuth parameter?
+ */
+const isParameterNameAnOAuthParameter = (parameter: string): boolean => {
+    return parameter.startsWith("oauth_");
+}
+
+export const makeArrayOfArgumentsHash = (argumentsHash: Map<string, string | string[]>): [string, string][] => {
+    const argumentPairs: [string, string][] = [];
+    for (const [key, value] of argumentsHash) {
+        if (Array.isArray(value)) {
+            for (const singleValue of value) {
+                argumentPairs.push([key, singleValue]);
+            }
+        } else {
+            argumentPairs.push([key, value]);
+        }
+    }
+    return argumentPairs;
+}
+
+const NONCE_CHARS: string[] = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'.split('');
+export const nonce = (nonceSize = 32) => {
+    return [...Array(nonceSize)].map(() => NONCE_CHARS[Math.floor(Math.random() * NONCE_CHARS.length)]).join('');
+}
+
+export const normalizeRequestParams = (args: Map<string, string>) => {
+    let pairs = makeArrayOfArgumentsHash(args);
+    // First encode them #3.4.1.3.2 .1
+    for (const pair of pairs) {
+        pair[0] = encodeData(pair[0]);
+        pair[1] = encodeData(pair[1]);
+    }
+
+    // Then sort them #3.4.1.3.2 .2
+    pairs = sortRequestParams(pairs);
+
+    // Then concatenate together #3.4.1.3.2 .3 & .4
+    return pairs.map(pair => pair.join("=")).join("&");
+}
+
+/**
+ * 1. Removes unnecessary port declarations
+ * 2. Normalizes an empty path to "/"
+ * 3. Removes search queries
+ */
+export const normalizeUrl = (url: string | URL): string => {
+    url = typeof url === "string" ? new URL(url) : url;
+    const port = usesCustomPort(url) ? `:${url.port}` : "";
+    return url.protocol + "//" + url.hostname + port + (url.pathname || "/");
+}
+
+/**
+ * Sorts key value pairs by name, then value.
+ */
+export const sortRequestParams = function (pairs: [string, string][]): [string, string][] {
+    // Sort by name, then value.
+    return pairs.sort(function (a, b) {
+        if (a[0] === b[0]) {
+            return a[1] < b[1] ? -1 : 1;
+        }
+        return a[0] < b[0] ? -1 : 1;
+    });
+}
+
+/**
+ * Does the URL specify a port that isn't the protocol's default port?
+ */
+export const usesCustomPort = (url: URL): boolean => (
+    !!url.port &&
+    !(url.protocol === "http:" && url.port === "80") &&
+    !(url.protocol === "https:" && url.port === "443")
+);
 
 export class JiraOnPremOAuth implements JiraOAuth {
-
-    private static nonce(nonceSize = 32) {
-        return [...Array(nonceSize)].map(() => NONCE_CHARS[Math.floor(Math.random() * NONCE_CHARS.length)]).join('');
-    }
-
-    private static encodeData(toEncode: string): string {
-        return encodeURIComponent(toEncode).replace(/!/g, "%21")
-                        .replace(/'/g, "%27")
-                        .replace(/\(/g, "%28")
-                        .replace(/\)/g, "%29")
-                        .replace(/\*/g, "%2A");
-    }
-
-    private static normalizeUrl(url: string|URL): string {
-        url = typeof url === "string" ? new URL(url) : url;
-        let port = "";
-        if (url.port) { 
-            if ((url.protocol == "http:" && url.port != "80" ) ||
-                (url.protocol == "https:" && url.port != "443") ) {
-                    port = ":" + url.port;
-                }
-        }
-        if (!url.pathname || url.pathname == "") {
-            url.pathname = "/";
-        }
-        
-        return url.protocol + "//" + url.hostname + port + url.pathname;
-    }
-    
-    private static createSignatureBase (method: string, url: string, parameters: string): string {
-        return `${method.toUpperCase()}&${JiraOnPremOAuth.encodeData(JiraOnPremOAuth.normalizeUrl(url))}&${JiraOnPremOAuth.encodeData(parameters)}`;
-    }
-
     public readonly privateKey: KeyObject;
     private stateToTokenSecret = new Map<string, string>();
 
@@ -59,60 +130,51 @@ export class JiraOnPremOAuth implements JiraOAuth {
         this.privateKey = createPrivateKey(fs.readFileSync(config.privateKey));
     }
 
-
     public async exchangeRequestForToken(codeOrToken: string, verifier: string): Promise<JiraOAuthResult> {
         if (!verifier) {
             throw Error('Missing verifier');
         }
 
-        const result = await this.secureRequest<{oauth_token: string, oauth_token_secret: string}>(codeOrToken, "POST", `${this.instanceUrl}/plugins/servlet/oauth/access-token`, {
-            oauth_verifier: verifier
+        const response = await this.secureRequest(codeOrToken, "POST", `${this.instanceUrl}/plugins/servlet/oauth/access-token`, {
+            oauth_verifier: verifier,
         });
+        const result = assertOAuthRequestToken(response);
         return {
             access_token: encodeJiraToken(result.oauth_token, result.oauth_token_secret),
-            scope: ""
+            scope: "",
         }
     }
 
-    public async getAuthUrl(state: string) {
+    public async getAuthUrl(state: string): Promise<string> {
         // Need to fetch a token first.
         const details = await this.getOAuthRequestToken(state);
-
-        if (!details.oauth_token || !details.oauth_token_secret) {
-            log.info(`Unexpected response from JIRA:`, JSON.stringify(details));
-            throw Error('Unexpected OAuth response from server');
-        }
         this.stateToTokenSecret.set(state, details.oauth_token_secret);
         return `${this.instanceUrl}/plugins/servlet/oauth/authorize?oauth_token=${details.oauth_token}`;
     }
 
-    private async getOAuthRequestToken(state: string) {
+    private async getOAuthRequestToken(state: string): Promise<{oauth_token: string, oauth_token_secret: string}> {
         const callbackUrl = new URL(this.config.redirect_uri);
         callbackUrl.searchParams.set('state', state);
-        const results = this.secureRequest<{oauth_token: string, oauth_token_secret: string}>(null, "POST", `${this.instanceUrl}/plugins/servlet/oauth/request-token`, {
+        const response = await this.secureRequest(null, "POST", `${this.instanceUrl}/plugins/servlet/oauth/request-token`, {
             oauth_callback: callbackUrl.toString(),
         });
-        return results;
+        return assertOAuthRequestToken(response);
     }
 
-    private async secureRequest<T>(
+    private async secureRequest(
         oauthToken: string|null,
         method: Method,
         urlStr: string,
         extraParams: Record<string, string> = {},
         body: unknown = null,
         contentType = "application/x-www-form-urlencoded"
-    ): Promise<T> {
+    ): Promise<Record<string, string>> {
         const orderedParameters = this.prepareParameters(oauthToken, method, urlStr, extraParams);
         const url = new URL(urlStr); 
 
-        const headers: Record<string,string> = {};
-        headers["Authorization"]= JiraOnPremOAuth.buildAuthorizationHeaders(orderedParameters);
-        headers["Host"] = url.host;
-
         // Filter out any passed extra_params that are really to do with OAuth
-        for(const key in extraParams) {
-            if( JiraOnPremOAuth.isParameterNameAnOAuthParameter( key ) ) {
+        for (const key in extraParams) {
+            if (isParameterNameAnOAuthParameter(key) ) {
                 delete extraParams[key];
             }
         }
@@ -120,120 +182,45 @@ export class JiraOnPremOAuth implements JiraOAuth {
         const req = await Axios.request({
             method,
             headers: {
-                Authorization: JiraOnPremOAuth.buildAuthorizationHeaders(orderedParameters),
+                Authorization: buildAuthorizationHeaders(orderedParameters),
                 Host: url.host,
                 'Content-Type': contentType,
             },
-            data: body || qs.stringify(extraParams),
+            data: body || `${new URLSearchParams(extraParams)}`,
             url: url.toString(),
         });
-        return qs.parse(req.data) as unknown as T;
+        // Convert x-www-form-urlencoded string to a Record<string, string>
+        return Object.fromEntries(new URLSearchParams(req.data));
     }
 
     private prepareParameters(oauthToken: string|null, method: Method, urlStr: string, extraParams: Record<string, string> = {}) {
-        const oauthParameters: Record<string, string> = {
-            oauth_timestamp: Math.floor( Date.now() / 1000 ).toString(),
-            oauth_nonce: JiraOnPremOAuth.nonce(),
+        const oauthParameters = new Map<string, string>(Object.entries({
+            oauth_timestamp: Math.floor(Date.now() / 1000).toString(),
+            oauth_nonce: nonce(),
             oauth_version: "1.0",
             oauth_signature_method: "RSA-SHA1",
             oauth_consumer_key: this.config.consumerKey,
-            ...(oauthToken && {oauth_token: oauthToken}),
+            ...(oauthToken && { oauth_token: oauthToken }),
             ...extraParams,
-        };
+        }));
 
         const url = new URL(urlStr);
-      
-        for (const [key, value] of url.searchParams.entries() ) {
-            oauthParameters[key]= value;
+
+        for (const [key, value] of url.searchParams.entries()) {
+            oauthParameters.set(key, value);
         }
       
-        const sig = this.getSignatue(method, urlStr, JiraOnPremOAuth.normaliseRequestParams(oauthParameters));
-        const orderedParameters = JiraOnPremOAuth.sortRequestParams( JiraOnPremOAuth.makeArrayOfArgumentsHash(oauthParameters) );
-        orderedParameters[orderedParameters.length] = ["oauth_signature", sig];
+        const sig = this.getSignatue(method, urlStr, normalizeRequestParams(oauthParameters));
+        const orderedParameters = sortRequestParams(makeArrayOfArgumentsHash(oauthParameters));
+        orderedParameters.push(["oauth_signature", sig]);
         return orderedParameters;
     }
 
-
-    private createSignature (signatureBase: string) {
+    private getSignatue(method: Method, url: string, parameters: string) {
         if (!this.privateKey) {
             throw Error('Cannot sign request, privateKey not ready');
         }
+        const signatureBase = createSignatureBase(method, url, parameters);
         return createSign("RSA-SHA1").update(signatureBase).sign(this.privateKey, 'base64');  
-    }
-
-
-    private getSignatue(method: Method, url: string, parameters: string) {
-        return this.createSignature(JiraOnPremOAuth.createSignatureBase(method, url, parameters));
-    }
-
-
-    private static makeArrayOfArgumentsHash (argumentsHash: Record<string, string|string[]>): [string, string][] {
-        const argumentPairs: [string, string][] = [];
-        for(const key in argumentsHash ) {
-            const value = argumentsHash[key];
-            if (Array.isArray(value) ) {
-                for (let i = 0; i < value.length; i++) {
-                    argumentPairs[argumentPairs.length] = [key, value[i]];
-                }
-            }
-            else {
-                argumentPairs[argumentPairs.length] = [key, value];
-            }
-        }
-        return argumentPairs;  
-    }
-
-
-
-    // Sorts the encoded key value pairs by encoded name, then encoded value
-    private static sortRequestParams= function(pairs: [string, string][]): [string, string][] {
-        // Sort by name, then value.
-        return pairs.sort(function(a,b) {
-            if ( a[0]== b[0] )  {
-            return a[1] < b[1] ? -1 : 1; 
-            }
-            else return a[0] < b[0] ? -1 : 1;  
-        });
-    }
-
-    private static normaliseRequestParams(args: Record<string, string>) {
-        let pairs = JiraOnPremOAuth.makeArrayOfArgumentsHash(args);
-        // First encode them #3.4.1.3.2 .1
-        for(let i=0;i<pairs.length;i++) {
-            pairs[i][0] = JiraOnPremOAuth.encodeData( pairs[i][0] );
-            pairs[i][1] = JiraOnPremOAuth.encodeData( pairs[i][1] );
-        }
-        
-        // Then sort them #3.4.1.3.2 .2
-        pairs = JiraOnPremOAuth.sortRequestParams( pairs );
-        
-        // Then concatenate together #3.4.1.3.2 .3 & .4
-        let result = "";
-        for(let i=0;i<pairs.length;i++) {
-            result += pairs[i][0];
-            result += "=";
-            result += pairs[i][1];
-            if( i < pairs.length-1 ) result+= "&";
-        }     
-        return result;
-    }
-
-    private static buildAuthorizationHeaders(orderedParameters: [string, string][]) {
-        let authHeader = "OAuth ";
-        for( const [key, value] of Object.values(orderedParameters)) {
-           // Whilst the all the parameters should be included within the signature, only the oauth_ arguments
-           // should appear within the authorization header.
-            if (JiraOnPremOAuth.isParameterNameAnOAuthParameter(key) ) {
-                authHeader+= JiraOnPremOAuth.encodeData(key)+"=\""+ JiraOnPremOAuth.encodeData(value)+"\",";
-            }
-        }
-        authHeader= authHeader.substring(0, authHeader.length - 1);
-        return authHeader;
-    }
-
-    // Is the parameter considered an OAuth parameter
-    private static isParameterNameAnOAuthParameter (parameter: string) {
-        const m = parameter.match('^oauth_');
-        return m && m[0] === "oauth_";
     }
 }

--- a/src/UserTokenStore.ts
+++ b/src/UserTokenStore.ts
@@ -1,7 +1,7 @@
 import { GithubInstance } from "./Github/GithubInstance";
 import { GitLabClient } from "./Gitlab/Client";
 import { Intent } from "matrix-bot-sdk";
-import { promises as fs } from "fs";
+import { default as fsSync, promises as fs } from "fs";
 import { publicEncrypt, privateDecrypt } from "crypto";
 import { Logger } from "matrix-appservice-bridge";
 import { isJiraCloudInstance, JiraClient } from "./Jira/Client";
@@ -69,7 +69,9 @@ export class UserTokenStore extends TypedEmitter<Emitter> {
             if ("client_id" in config.jira.oauth) {
                 this.jiraOAuth = new JiraCloudOAuth(config.jira.oauth);
             } else if (config.jira.url) {
-                this.jiraOAuth = new JiraOnPremOAuth(config.jira.oauth, config.jira.url);
+                // TODO: Make this async.
+                const privateKey = fsSync.readFileSync(config.jira.oauth.privateKey);
+                this.jiraOAuth = new JiraOnPremOAuth(config.jira.oauth, config.jira.url, privateKey);
             } else {
                 throw Error('jira oauth misconfigured');
             }

--- a/tests/jira/OnPremOAuth.ts
+++ b/tests/jira/OnPremOAuth.ts
@@ -1,0 +1,166 @@
+import { expect } from "chai";
+import {
+    assertOAuthRequestToken,
+    buildAuthorizationHeaders,
+    makeArrayOfArgumentsHash,
+    nonce,
+    normalizeRequestParams,
+    normalizeUrl,
+    sortRequestParams,
+    usesCustomPort,
+} from "../../src/Jira/oauth/OnPremOAuth";
+
+describe("JiraOnPremOAuth", () => {
+    describe("assertOAuthRequestToken", () => {
+        const DATA = {
+            oauth_token: "abc",
+            oauth_token_secret: "abc",
+        };
+        it("forwards a valid API responses", () => {
+            expect(assertOAuthRequestToken(DATA)).to.deep.equal(DATA);
+        });
+        it("discards additional properties", () => {
+            expect(assertOAuthRequestToken({
+                ...DATA,
+                foo: 'bar',
+            })).to.deep.equal(DATA);
+        });
+        it("throws when oauth_token is invalid", () => {
+            expect(assertOAuthRequestToken({
+                oauth_token: "",
+                oauth_token_secret: "abc",
+            })).to.throw;
+            expect(assertOAuthRequestToken({
+                oauth_token_secret: "abc",
+            })).to.throw;
+        });
+        it("throws when oauth_token_secret is invalid", () => {
+            expect(assertOAuthRequestToken({
+                oauth_token: "abc",
+                oauth_token_secret: "",
+            })).to.throw;
+            expect(assertOAuthRequestToken({
+                oauth_token: "abc",
+            })).to.throw;
+        });
+    });
+    describe("buildAuthorizationHeaders", () => {
+        it("discards additional properties not starting with oauth_", () => {
+            expect(buildAuthorizationHeaders([
+                ["foo", "bar"],
+                ["oauth_token", "abc"],
+                ["oauth_token_secret", "abc"],
+            ])).to.equal(`OAuth oauth_token="abc",oauth_token_secret="abc"`);
+        });
+        it("encodes params", () => {
+            expect(buildAuthorizationHeaders([
+                ["oauth_token", "abc)def"],
+            ])).to.equal(`OAuth oauth_token="abc%29def"`);
+        });
+        it("does not pollute the Object.prototype", () => {
+            const objectPrototype = Object.prototype;
+            buildAuthorizationHeaders([
+                ["__proto__", "test"],
+            ])
+            expect(Object.prototype).to.equal(objectPrototype);
+        });
+    });
+    describe("makeArrayOfArgumentsHash", () => {
+        it("processes strings and arrays of strings", () => {
+            expect(makeArrayOfArgumentsHash(new Map<string, string|string[]>([
+                ["foo", "bar"],
+                ["a", ["b", "c", "d"]],
+            ]))).to.deep.equal([
+                ["foo", "bar"],
+                ["a", "b"],
+                ["a", "c"],
+                ["a", "d"],
+            ]);
+        });
+    });
+    describe("nonce", () => {
+        it("returns 32 characters by default", () => {
+            const actual = nonce();
+            expect(actual).to.be.a.string;
+            expect(actual).to.have.length(32);
+        });
+        it("returns strings of the specified length", () => {
+            expect(nonce(1)).to.have.length(1);
+            expect(nonce(10)).to.have.length(10);
+            expect(nonce(100)).to.have.length(100);
+            expect(nonce(128)).to.have.length(128);
+        });
+    });
+    describe("normalizeUrl", () => {
+        it("removes unnecessary port declarations", () => {
+            expect(normalizeUrl("http://example:80/")).to.equal("http://example/");
+            expect(normalizeUrl("http://example:8080/")).to.equal("http://example:8080/");
+            expect(normalizeUrl("https://example:443/")).to.equal("https://example/");
+            expect(normalizeUrl("https://example:8443/")).to.equal("https://example:8443/");
+        });
+        it("normalizes an empty path to '/'", () => {
+            expect(normalizeUrl("http://example")).to.equal("http://example/");
+            expect(normalizeUrl("https://example")).to.equal("https://example/");
+            expect(normalizeUrl("http://example/")).to.equal("http://example/");
+            expect(normalizeUrl("http://example/foo/bar")).to.equal("http://example/foo/bar");
+        });
+        it("removes the search query", () => {
+            expect(normalizeUrl("https://example/?hello=world")).to.equal("https://example/");
+            expect(normalizeUrl("https://example/foo/bar?hello=world")).to.equal("https://example/foo/bar");
+        });
+    });
+    describe("normalizeRequestParams", () => {
+        const a: [string, string] = ["aachen", "dom"];
+        const b: [string, string] = ["berlin", "fernsehturm"];
+        const c: [string, string] = ["cologne", "maus"];
+        const d: [string, string] = ["dortmund", "Universität"];
+        it("sorts them alphabetically", () => {
+            expect(normalizeRequestParams(new Map([a, b]))).to.equal("aachen=dom&berlin=fernsehturm");
+            expect(normalizeRequestParams(new Map([b, a]))).to.equal("aachen=dom&berlin=fernsehturm");
+            expect(normalizeRequestParams(new Map([a, c]))).to.equal("aachen=dom&cologne=maus");
+            expect(normalizeRequestParams(new Map([c, a]))).to.equal("aachen=dom&cologne=maus");
+        });
+        it("url-encodes values", () => {
+            expect(normalizeRequestParams(new Map([d]))).to.equal("dortmund=Universit%C3%A4t");
+        });
+        it("handles different amounts of pairs", () => {
+            expect(normalizeRequestParams(new Map([a]))).to.equal("aachen=dom");
+            expect(normalizeRequestParams(new Map([a, b]))).to.equal("aachen=dom&berlin=fernsehturm");
+            expect(normalizeRequestParams(
+                new Map([a, b, c]))
+            ).to.equal("aachen=dom&berlin=fernsehturm&cologne=maus");
+            expect(normalizeRequestParams(
+                new Map([a, b, c, d]))
+            ).to.equal("aachen=dom&berlin=fernsehturm&cologne=maus&dortmund=Universit%C3%A4t");
+        });
+    });
+    describe("sortRequestParams", () => {
+        it("correctly sorts request params", () => {
+            const a: [string, string] = ["aachen", "dom"];
+            const b: [string, string] = ["aachen", "rathaus"];
+            const c: [string, string] = ["berlin", "fernsehturm"];
+            const d: [string, string] = ["berlin", "rotes rathaus"];
+            expect(sortRequestParams([a, b, c, d])).to.deep.equal([a, b, c, d]);
+            expect(sortRequestParams([d, c, b, a])).to.deep.equal([a, b, c, d]);
+            expect(sortRequestParams([c, b, a, d])).to.deep.equal([a, b, c, d]);
+            expect(sortRequestParams([a, b, a, d])).to.deep.equal([a, a, b, d]);
+        });
+    });
+    describe("usesCustomPort", () => {
+        it("returns true for a non-default HTTP port", () => {
+            expect(usesCustomPort(new URL('http://example.com:8008'))).to.be.true;
+            expect(usesCustomPort(new URL('http://example.com:8080'))).to.be.true;
+        });
+        it("returns true for a non-default HTTPS port", () => {
+            expect(usesCustomPort(new URL('https://example.com:1234'))).to.be.true;
+            expect(usesCustomPort(new URL('https://example.com:8443'))).to.be.true;
+        });
+        it("returns false when no port is specified", () => {
+            expect(usesCustomPort(new URL('http://example.com'))).to.be.false;
+        });
+        it("returns false for default ports", () => {
+            expect(usesCustomPort(new URL('http://example.com:80'))).to.be.false;
+            expect(usesCustomPort(new URL('https://example.com:443'))).to.be.false;
+        });
+    });
+});


### PR DESCRIPTION
* Add unit tests for many functions.
* Add some tests that mock HTTP server responses from Jira for an access token.
* Refactor `OnPremOAuth.ts` to be simpler, safer and more testable.

Tip for reviewing: Pretend that this is new code – comparing it to the old code has become increasingly difficult. Test it with a Jira instance.
