### PR TITLE
Set LRU values to zero to prevent cleanup when using encryption

### DIFF
--- a/src/appservice.ts
+++ b/src/appservice.ts
@@ -38,6 +38,10 @@ export function getAppservice(config: BridgeConfig, registration: IAppserviceReg
         },
         storage: storage,
         intentOptions: {
+            // If encryption support is enabled, we cannot expire Intent objects or we risk
+            // a resource contention on the Sled DB.
+            maxCached: config.encryption && 0,
+            maxAgeMs: config.encryption && 0,
             encryption: !!config.encryption,
         },
         cryptoStorage: cryptoStorage,

--- a/src/appservice.ts
+++ b/src/appservice.ts
@@ -40,8 +40,8 @@ export function getAppservice(config: BridgeConfig, registration: IAppserviceReg
         intentOptions: {
             // If encryption support is enabled, we cannot expire Intent objects or we risk
             // a resource contention on the Sled DB.
-            maxCached: config.encryption && 0,
-            maxAgeMs: config.encryption && 0,
+            maxCached: config.encryption ? 0 : undefined,
+            maxAgeMs: config.encryption ? 0 : undefined,
             encryption: !!config.encryption,
         },
         cryptoStorage: cryptoStorage,


### PR DESCRIPTION
Requires https://github.com/vector-im/matrix-bot-sdk/pull/6

Should fix https://github.com/matrix-org/matrix-hookshot/issues/609, although other process crashing bugs may remain.