### PR TITLE
Register namespace for sample serviceBot in registration.sample.yml

### DIFF
--- a/changelog.d/643.doc
+++ b/changelog.d/643.doc
@@ -1,0 +1,1 @@
+Update docs and sample config for serviceBots. Thanks to @HarHarLinks.

--- a/docs/advanced/service_bots.md
+++ b/docs/advanced/service_bots.md
@@ -26,3 +26,11 @@ serviceBots:
 ```
 
 There will be a bot user `@feeds:example.com` which responds to commands prefixed with `!feeds`, and only handles feeds connections.
+
+For the homeserver to allow hookshot control over users, they need to be added to the list of user namespaces in the `registration.yml` file provided to the homeserver.
+
+In the example above, you would need to add these lines:
+```yaml
+    - regex: "@feeds:example.com" # Where example.com is your homeserver's domain
+      exclusive: true
+```

--- a/registration.sample.yml
+++ b/registration.sample.yml
@@ -12,6 +12,8 @@ namespaces:
       exclusive: true
     - regex: "@_webhooks_.*:foobar" # Where _webhooks_ is set by userIdPrefix in config.yml
       exclusive: true
+    - regex: "@feeds:foobar" # Matches the localpart of all serviceBots in config.yml
+      exclusive: true
   aliases:
     - regex: "#github_.+:foobar" # Where foobar is your homeserver's domain
       exclusive: true


### PR DESCRIPTION
Signed-off-by: Kim Brose <2803622+HarHarLinks@users.noreply.github.com>

Context: https://matrix.to/#/!TlZdPIYrhwNvXlBiEk:half-shot.uk/$AdcR43mfQlQq2p97UOgmIZTfUlmBVNbI7CtTQZ6_-74?via=half-shot.uk&via=matrix.org&via=element.io

Sample config
- disables feeds
- enables feeds serviceBot
- does not register feeds serviceBot namespace

This change fixes the latter, thus providing an example for anybody using servicebots.

[The spec](https://spec.matrix.org/unstable/application-service-api/#registration) isn't totally clear that this is needed, but it appears to be this way with synapse. Should the spec be updated to state this requirement more clearly?

Related: https://github.com/matrix-org/matrix-hookshot/issues/641