### PR TITLE
Add `encryptNotices` option

### DIFF
--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -407,7 +407,9 @@ interface BridgeConfigBot {
     displayname?: string;
     avatar?: string;
 }
-interface BridgeConfigEncryption {
+
+export interface BridgeConfigEncryption {
+    encryptNotices: boolean;
     storagePath: string;
 }
 


### PR DESCRIPTION
:exclamation: Draft PR to further discuss this.

This shows how an option might look like to disable encryption for notices.
It can be used as a workaround until „notices trigger notification“ will be properly fixed.

closes https://github.com/matrix-org/matrix-hookshot/issues/646