### PR TITLE
Fix widget config detection

### DIFF
--- a/changelog.d/657.bugfix
+++ b/changelog.d/657.bugfix
@@ -1,0 +1,1 @@
+`roomSetupWidget` in widget config does now allow an empty value

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -325,7 +325,7 @@ export class SetupConnection extends CommandConnection {
 
     @botCommand("setup-widget", {category: "widget", help: "Open the setup widget in the room"})
     public async onSetupWidget() {
-        if (!this.config.widgets?.roomSetupWidget) {
+        if (this.config.widgets?.roomSetupWidget === undefined) {
             throw new CommandError("Not configured", "The bridge is not configured to support setup widgets");
         }
         if (!await SetupWidget.SetupRoomConfigWidget(this.roomId, this.intent, this.config.widgets, this.serviceTypes)) {


### PR DESCRIPTION
Explicitly check for `undefined` when testing `roomSetupWidget`.

From the docs: „This can be enabled by setting roomSetupWidget to an object. “

If you set this to an object in the config:

```
widgets:
  publicUrl: http://localhost:9000/widgetapi/v1/static
  branding:
    widgetTitle: Hookshot Konfig
  roomSetupWidget:
```

The value of the parsed `roomSetupWidget` will be null → check fails