### PR TITLE
Fix service bots not rejecting invites on incoming DMs

### DIFF
--- a/changelog.d/659.bugfix
+++ b/changelog.d/659.bugfix
@@ -1,0 +1,1 @@
+Fix service bots not being able to reject invites with a reason.

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -789,18 +789,24 @@ export class Bridge {
             // We got an invite but it's not a configured bot user, must be for a ghost user
             log.debug(`Rejecting invite to room ${roomId} for ghost user ${invitedUserId}`);
             const client = this.as.getIntentForUserId(invitedUserId).underlyingClient;
-            return client.kickUser(invitedUserId, roomId, "Bridge does not support DMing ghosts");
+            return client.doRequest("POST", "/_matrix/client/v3/rooms/" + encodeURIComponent(roomId) + "/leave", null, {
+                reason: "Bridge does not support DMing ghosts"
+            });
         }
 
         // Don't accept invites from people who can't do anything
         if (!this.config.checkPermissionAny(event.sender, BridgePermissionLevel.login)) {
-            return botUser.intent.underlyingClient.kickUser(botUser.userId, roomId, "You do not have permission to invite this bot.");
+            return botUser.intent.underlyingClient.doRequest("POST", "/_matrix/client/v3/rooms/" + encodeURIComponent(roomId) + "/leave", null, {
+                reason: "You do not have permission to invite this bot."
+            });
         }
 
         if (event.content.is_direct && botUser.userId !== this.as.botUserId) {
             // Service bots do not support direct messages (admin rooms)
             log.debug(`Rejecting direct message (admin room) invite to room ${roomId} for service bot ${botUser.userId}`);
-            return botUser.intent.underlyingClient.kickUser(botUser.userId, roomId, "This bot does not support admin rooms.");
+            return botUser.intent.underlyingClient.doRequest("POST", "/_matrix/client/v3/rooms/" + encodeURIComponent(roomId) + "/leave", null, {
+                reason: "This bot does not support admin rooms."
+            });
         }
 
         // Accept the invite


### PR DESCRIPTION
Synapse no longer lets you kick yourself from a room with a reason, so instead we'll do the spec compliant thing of sending a leave with a reason. 

https://github.com/turt2live/matrix-bot-sdk/pull/301 is the upstream change we could rely on if it turned up in time.