### PR TITLE
Fix hookshot showing connections as editable when the user has no permission

### DIFF
--- a/changelog.d/660.bugfix
+++ b/changelog.d/660.bugfix
@@ -1,0 +1,1 @@
+Fix Hookshot presenting room connections as editable if the user has a default-or-greater power levels. This was only a presentation bug, power levels were and are proeprly checked at creation/edit time.

--- a/src/Widgets/BridgeWidgetApi.ts
+++ b/src/Widgets/BridgeWidgetApi.ts
@@ -115,7 +115,6 @@ export class BridgeWidgetApi {
             // If we have a service filter.
             .filter(c => typeof serviceFilter !== "string" || c?.service === serviceFilter) as GetConnectionsResponseItem[];
         const userPl = powerlevel.content.users?.[req.userId] || powerlevel.defaultUserLevel;
-
         for (const c of connections) {
             const requiredPl = Math.max(powerlevel.content.events?.[c.type] || 0, powerlevel.defaultStateEventLevel);
             c.canEdit = userPl >= requiredPl;
@@ -126,7 +125,7 @@ export class BridgeWidgetApi {
 
         return {
             connections,
-            canEdit: userPl >= powerlevel.defaultUserLevel
+            canEdit: userPl >= powerlevel.defaultStateEventLevel,
         };
     }
 


### PR DESCRIPTION
Note, this only affected the UX of the frontend. Proper checks for user PL are still made at edit/creation time.