### PR TITLE
Run docker CI for pull requests too

### DIFF
--- a/.github/workflows/docker-hub-latest.yml
+++ b/.github/workflows/docker-hub-latest.yml
@@ -4,6 +4,9 @@ name: "Docker Hub - Latest"
 
 on:
   push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 env:
   DOCKER_NAMESPACE: halfshot

--- a/.github/workflows/docker-hub-latest.yml
+++ b/.github/workflows/docker-hub-latest.yml
@@ -4,7 +4,6 @@ name: "Docker Hub - Latest"
 
 on:
   push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/changelog.d/662.misc
+++ b/changelog.d/662.misc
@@ -1,0 +1,1 @@
+Run docker-latest CI for incoming pull requests.


### PR DESCRIPTION
We need to include `pull_request` so docker builds are executed for community PRs.