### PR TITLE
Don't remove the oauth state on polling the status of the auth request

### DIFF
--- a/changelog.d/663.bugfix
+++ b/changelog.d/663.bugfix
@@ -1,0 +1,1 @@
+Fix GitHub OAuth button causing a "Could not find user which authorised this request" error .

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -190,7 +190,7 @@ export class Webhooks extends EventEmitter {
         const oauthUrl = this.config.widgets && new URL("oauth.html", this.config.widgets.parsedPublicUrl);
         if (oauthUrl) {
             oauthUrl.searchParams.set('service', 'github');
-            oauthUrl?.searchParams.set('oauth-kind', 'account');
+            oauthUrl.searchParams.set('oauth-kind', 'account');
         }
         const { setup_action, state } = req.query;
         log.info("Got new oauth request", { state, setup_action });

--- a/src/Widgets/BridgeWidgetApi.ts
+++ b/src/Widgets/BridgeWidgetApi.ts
@@ -333,7 +333,7 @@ export class BridgeWidgetApi {
         }
         
         // N.B. Service isn't really used.
-        const stateUserId = this.tokenStore.getUserIdForOAuthState(state);
+        const stateUserId = this.tokenStore.getUserIdForOAuthState(state, false);
 
         if (!stateUserId || req.userId !== stateUserId) {
             // If the state isn't found then either the state has been completed or the key is wrong.


### PR DESCRIPTION
Basically, polling for the status of the oauth request causes the state to be removed, which makes the button useless.