### PR TITLE
Refactor oauth response page and show a pending state for GitHub installations

### DIFF
--- a/changelog.d/666.misc
+++ b/changelog.d/666.misc
@@ -1,0 +1,1 @@
+Show a sensible error when a GitHub installation is pending.

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -36,6 +36,14 @@ export interface NotificationsDisableEvent {
     instanceUrl?: string;
 }
 
+export interface OAuthPageParams {
+    service?: string;
+    result?: string;
+    'oauth-kind'?: 'account'|'organisation';
+    'error'?: string;
+    'errcode'?: ErrCode;
+}
+
 export class Webhooks extends EventEmitter {
     
     public readonly expressRouter = Router();
@@ -187,11 +195,8 @@ export class Webhooks extends EventEmitter {
     }
 
     public async onGitHubGetOauth(req: Request<unknown, unknown, unknown, {error?: string, error_description?: string, code?: string, state?: string, setup_action?: 'install'}> , res: Response) {
-        const oauthUrl = this.config.widgets && new URL("oauth.html", this.config.widgets.parsedPublicUrl);
-        if (oauthUrl) {
-            oauthUrl.searchParams.set('service', 'github');
-            oauthUrl.searchParams.set('oauth-kind', 'account');
-        }
+        const oauthResultParams: OAuthPageParams = {};
+
         const { setup_action, state } = req.query;
         log.info("Got new oauth request", { state, setup_action });
         try {
@@ -201,7 +206,22 @@ export class Webhooks extends EventEmitter {
             if (req.query.error) {
                 throw new ApiError(`GitHub Error: ${req.query.error} ${req.query.error_description}`, ErrCode.Unknown);
             }
-            if (setup_action !== 'install') {
+            if(setup_action === 'install') {
+                // GitHub App successful install.
+                oauthResultParams["oauth-kind"] = 'organisation';
+                oauthResultParams.result = "success";
+            } else if (setup_action === 'request') {
+                // GitHub App install is pending
+                oauthResultParams["oauth-kind"] = 'organisation';
+                oauthResultParams.result = "pending";
+            } else if (setup_action) {
+                // GitHub App install is in another, unknown state.
+                oauthResultParams.service = "organisation";
+                oauthResultParams.result = setup_action;
+            }
+            else {
+                oauthResultParams.service = "github";
+                oauthResultParams['oauth-kind'] = "account";
                 if (!state) {
                     throw new ApiError(`Missing state`, ErrCode.BadValue);
                 }
@@ -230,33 +250,36 @@ export class Webhooks extends EventEmitter {
                 if ("error" in result) {
                     throw new ApiError(`GitHub Error: ${result.error} ${result.error_description}`, ErrCode.Unknown);
                 }
+                oauthResultParams.result = 'success';
                 await this.queue.push<GitHubOAuthTokenResponse>({
                     eventName: "github.oauth.tokens",
                     sender: "GithubWebhooks",
                     data: { ...result, state: req.query.state as string },
                 });
-            } else if (oauthUrl) {
-                // App install.
-                oauthUrl.searchParams.set('oauth-kind', 'organisation');
             }
         } catch (ex) {
             if (ex instanceof ApiError) {
-                if (oauthUrl) {
-                    oauthUrl?.searchParams.set('error', ex.error);
-                    oauthUrl?.searchParams.set('errcode', ex.errcode);
-                } else {
-                    return res.status(ex.statusCode).send(ex.message);
-                }
+                oauthResultParams.result = 'error';
+                oauthResultParams.error = ex.error;
+                oauthResultParams.errcode = ex.errcode;
             } else {
                 log.error("Failed to handle oauth request:", ex);
                 return res.status(500).send('Failed to handle oauth request');
             }
         }
+        const oauthUrl = this.config.widgets && new URL("oauth.html", this.config.widgets.parsedPublicUrl);
         if (oauthUrl) {
             // If we're serving widgets, do something prettier.
+            Object.entries(oauthResultParams).forEach(([key, value]) => oauthUrl.searchParams.set(key, value));
             return res.redirect(oauthUrl.toString());
         } else {
-            return res.send(`<p> Your account has been bridged </p>`);
+            if (oauthResultParams.result === 'success') {
+                return res.send(`<p> Your ${oauthResultParams.service} ${oauthResultParams["oauth-kind"]} has been bridged </p>`);
+            } else if (oauthResultParams.result === 'error') {
+                return res.status(500).send(`<p> There was an error bridging your ${oauthResultParams.service} ${oauthResultParams["oauth-kind"]}. ${oauthResultParams.error} ${oauthResultParams.errcode} </p>`);
+            } else {
+                return res.status(500).send(`<p> Your ${oauthResultParams.service} ${oauthResultParams["oauth-kind"]} is in state ${oauthResultParams.result} </p>`);
+            }
         }
     }
 

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -195,7 +195,9 @@ export class Webhooks extends EventEmitter {
     }
 
     public async onGitHubGetOauth(req: Request<unknown, unknown, unknown, {error?: string, error_description?: string, code?: string, state?: string, setup_action?: 'install'}> , res: Response) {
-        const oauthResultParams: OAuthPageParams = {};
+        const oauthResultParams: OAuthPageParams = {
+            service: "github"
+        };
 
         const { setup_action, state } = req.query;
         log.info("Got new oauth request", { state, setup_action });
@@ -216,11 +218,11 @@ export class Webhooks extends EventEmitter {
                 oauthResultParams.result = "pending";
             } else if (setup_action) {
                 // GitHub App install is in another, unknown state.
-                oauthResultParams.service = "organisation";
+                oauthResultParams["oauth-kind"] = 'organisation';
                 oauthResultParams.result = setup_action;
             }
             else {
-                oauthResultParams.service = "github";
+                // This is a user account setup flow.
                 oauthResultParams['oauth-kind'] = "account";
                 if (!state) {
                     throw new ApiError(`Missing state`, ErrCode.BadValue);

--- a/web/components/elements/ConnectionSearch.tsx
+++ b/web/components/elements/ConnectionSearch.tsx
@@ -116,7 +116,7 @@ export function ConnectionSearch({
             addNewInstance = <p> You have not connected any {serviceName} instances.</p>;
         }
     } else if (addNewInstanceUrl) {
-        addNewInstance = <p><a href={addNewInstanceUrl} rel="noreferrer" target="_blank">Add a new instances</a>.</p>
+        addNewInstance = <p><a href={addNewInstanceUrl} rel="noreferrer" target="_blank">Add a new instance</a>.</p>
     } // otherwise, empty
 
     return <div>

--- a/web/oauth.tsx
+++ b/web/oauth.tsx
@@ -3,6 +3,7 @@ import "./styling.scss";
 import "./oauth.scss";
 import { render } from 'preact';
 import 'preact/devtools';
+import type { OAuthPageParams } from '../src/Webhooks';
 
 const root = document.getElementsByTagName('main')[0];
 
@@ -15,24 +16,41 @@ const ServiceToName: Record<string,string> = {
 
 function RenderOAuth() {
     const params = new URLSearchParams(window.location.search);
-    const service = params.get('service') ?? 'default';
-    const error = params.get('error');
-    const errcode = params.get('errcode');
-    const oauthKind = params.get('oauth-kind') ?? 'account';
+    const service = (params.get('service') as OAuthPageParams['service']) ?? 'default';
+    const error = (params.get('error') as OAuthPageParams['error']);
+    const errcode = (params.get('errcode') as OAuthPageParams['errcode']);
+    const oauthKind = (params.get('oauth-kind') as OAuthPageParams['oauth-kind']) ?? 'account';
+    const result = (params.get('result') as OAuthPageParams['result']);
 
-    if (error) {
+    const serviceName = ServiceToName[service];
+
+    if (result === 'error') {
         return <>
-            <h1>Could not connect your { ServiceToName[service] } {oauthKind} to Hookshot.</h1>
+            <h1>Could not connect your { serviceName } {oauthKind} to Hookshot.</h1>
             <p>
                 <code>{errcode}</code> {error}
             </p>
         </>;
+    } else if (result === 'pending') {
+        return <>
+            <h1>Your connection to { serviceName } {oauthKind} is pending.</h1>
+            <p>
+                The owner may need to approve this.
+            </p>
+        </>;
+    } else if (result === 'success') {
+        return <>
+            <h1>Your { serviceName } {oauthKind} has been connected.</h1>
+            <p>You may close this window.</p>
+        </>;
     }
-
     return <>
-        <h1>Your { ServiceToName[service] } {oauthKind} has been connected.</h1>
-        <p>You may close this window.</p>
+        <h1>Your connection to { serviceName } {oauthKind} is {result}.</h1>
+        <p>
+            This is an unknown state, you may need to contact your systems administrator.
+        </p>
     </>;
+
 }
 
 if (root) {


### PR DESCRIPTION
I felt like we should show a state for when an installation is pending. Also, refactor the oauth page to use proper typing.