### PR TITLE
Do more to shut down quickly and start RSS feeds later

### DIFF
--- a/src/UserTokenStore.ts
+++ b/src/UserTokenStore.ts
@@ -81,6 +81,12 @@ export class UserTokenStore extends TypedEmitter<Emitter> {
         this.key = await fs.readFile(this.keyPath);
     }
 
+    public stop() {
+        for (const session of this.oauthSessionStore.values()) {
+            clearTimeout(session.timeout);
+        }
+    }
+
     public async storeUserToken(type: TokenType, userId: string, token: string, instanceUrl?: string): Promise<void> {
         if (!this.config.checkPermission(userId, type, BridgePermissionLevel.login)) {
             throw new ApiError('User does not have permission to log in to service', ErrCode.ForbiddenUser);


### PR DESCRIPTION
This does two things:

- We now start the feed reader *after* all the connections have been found.
- We now stop the RSS reader and any timeouts on close.

Which should help to make hookshot shut down faster and spam less on startup.