### PR TITLE
Fix grants supplying the wrong state

### DIFF
--- a/changelog.d/672.bugfix
+++ b/changelog.d/672.bugfix
@@ -1,0 +1,1 @@
+Fix GitHub repo connections not always applying state updates.

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -568,14 +568,14 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
         return this.state.priority || super.priority;
     }
 
-    public async ensureGrant(sender?: string, state = this.state) {
+    public async ensureGrant(sender?: string, state = { org: this.org, repo: this.repo }) {
         await this.grantChecker.assertConnectionGranted(this.roomId, state, sender);
     }
 
     protected async validateConnectionState(content: unknown) {
         const state = GitHubRepoConnection.validateState(content);
         // Validate the permissions of this state
-        await this.ensureGrant(undefined, state);
+        await this.ensureGrant(undefined, { org: this.org, repo: this.repo });
         return state;
     }
 


### PR DESCRIPTION
We should only supply the exact state required.