### PR TITLE
Add a ready probe to each listener and start the listeners immediately

### DIFF
--- a/changelog.d/676.misc
+++ b/changelog.d/676.misc
@@ -1,0 +1,1 @@
+Add a /ready and /live endpoint to each listener, so that it can be checked independently.

--- a/src/App/BridgeApp.ts
+++ b/src/App/BridgeApp.ts
@@ -19,6 +19,7 @@ async function start() {
     const config = await BridgeConfig.parseConfig(configFile, process.env);
     const registration = await parseRegistrationFile(registrationFile);
     const listener = new ListenerService(config.listeners);
+    listener.start();
     Logger.configure({
         console: config.logging.level,
         colorize: config.logging.colorize,
@@ -53,8 +54,6 @@ async function start() {
         const webhookHandler = new Webhooks(config);
         listener.bindResource('webhooks', webhookHandler.expressRouter);
     }
-
-    listener.start();
 }
 
 start().catch((ex) => {

--- a/src/App/GithubWebhookApp.ts
+++ b/src/App/GithubWebhookApp.ts
@@ -20,6 +20,7 @@ async function start() {
     });
     LogService.setLogger(Logger.botSdkLogger);
     const listener = new ListenerService(config.listeners);
+    listener.start();
     if (config.metrics) {
         if (!config.metrics.port) {
             log.warn(`Not running metrics for service, no port specified`);
@@ -31,7 +32,6 @@ async function start() {
     listener.bindResource('webhooks', webhookHandler.expressRouter);
     const userWatcher = new UserNotificationWatcher(config);
     userWatcher.start();
-    listener.start();
     process.once("SIGTERM", () => {
         log.error("Got SIGTERM");
         webhookHandler.stop();

--- a/src/App/MatrixSenderApp.ts
+++ b/src/App/MatrixSenderApp.ts
@@ -22,6 +22,7 @@ async function start() {
     });
     LogService.setLogger(Logger.botSdkLogger);
     const listener = new ListenerService(config.listeners);
+    listener.start();
     const sender = new MatrixSender(config, getAppservice(config, registration).appservice);
     if (config.metrics) {
         if (!config.metrics.port) {
@@ -31,7 +32,6 @@ async function start() {
         }
     }
     sender.listen();
-    listener.start();
     process.once("SIGTERM", () => {
         log.error("Got SIGTERM");
         sender.stop();

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -71,6 +71,7 @@ export class Bridge {
         this.tokenStore = new UserTokenStore(this.config.passFile || "./passkey.pem", this.as.botIntent, this.config);
         this.tokenStore.on("onNewToken", this.onTokenUpdated.bind(this));
 
+        // Legacy routes, to be removed.
         this.as.expressAppInstance.get("/live", (_, res) => res.send({ok: true}));
         this.as.expressAppInstance.get("/ready", (_, res) => res.status(this.ready ? 200 : 500).send({ready: this.ready}));
     }


### PR DESCRIPTION
This should help us out a bit with few small issues:

 - The ready state of each listener is directly mapped to whether it has resources bound, and we apply resources after the application is ready.
 - This allows applications to check whether independent listeners of hookshot are ready.
 - Liveness checks no longer wait for connections to start up...which is currently the case.
 - As a bonus, we no longer logspam each ready check.