### PR TITLE
Continue even if localstorage is inaccessible

### DIFF
--- a/changelog.d/678.bugfix
+++ b/changelog.d/678.bugfix
@@ -1,0 +1,1 @@
+Ensure the widget still works without needing to store local storage data.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-hookshot/issues/677

This means we have to bake a new token each time, which in the worst case might mean we hit ratelimits. These tokens are not terribly "expensive" as they only persist in memory/redis.