### PR TITLE
Add feeds failing metric

### DIFF
--- a/changelog.d/681.misc
+++ b/changelog.d/681.misc
@@ -1,0 +1,1 @@
+Add `feed_failing` metric to track the number of feeds failing to be read or parsed.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -43,6 +43,7 @@ Below is the generated list of Prometheus metrics for Hookshot.
 |--------|------|--------|
 | feed_count | The number of RSS feeds that hookshot is subscribed to |  |
 | feed_fetch_ms | The time taken for hookshot to fetch all feeds |  |
+| feed_failing | The number of RSS feeds that hookshot is failing to read | reason |
 ## process
 | Metric | Help | Labels |
 |--------|------|--------|

--- a/src/Metrics.ts
+++ b/src/Metrics.ts
@@ -26,6 +26,7 @@ export class Metrics {
 
     public readonly feedsCount = new Gauge({ name: "feed_count", help: "The number of RSS feeds that hookshot is subscribed to", labelNames: [], registers: [this.registry]});
     public readonly feedFetchMs = new Gauge({ name: "feed_fetch_ms", help: "The time taken for hookshot to fetch all feeds", labelNames: [], registers: [this.registry]});
+    public readonly feedsFailing = new Gauge({ name: "feed_failing", help: "The number of RSS feeds that hookshot is failing to read", labelNames: ["reason"], registers: [this.registry]});
 
 
     constructor(private registry: Registry = register) {


### PR DESCRIPTION
A simple counter that lets us see whether we are having HTTP failures or parsing failures, to track relative success when we modify the parser.