### PR TITLE
Staggered RSS feed polling

### DIFF
--- a/changelog.d/685.misc
+++ b/changelog.d/685.misc
@@ -1,0 +1,1 @@
+Stagger RSS feed polling over the interval period, rather than attempting to poll all feeds at once. Should reduce memory / CPU spikes.

--- a/src/Connections/FeedConnection.ts
+++ b/src/Connections/FeedConnection.ts
@@ -6,11 +6,9 @@ import { FeedEntry, FeedError, FeedReader} from "../feeds/FeedReader";
 import { Logger } from "matrix-appservice-bridge";
 import { IBridgeStorageProvider } from "../Stores/StorageProvider";
 import { BaseConnection } from "./BaseConnection";
-import axios from "axios";
 import markdown from "markdown-it";
 import { Connection, ProvisionConnectionOpts } from "./IConnection";
 import { GetConnectionsResponseItem } from "../provisioning/api";
-import { StatusCodes } from "http-status-codes";
 const log = new Logger("FeedConnection");
 const md = new markdown();
 

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -182,7 +182,7 @@ export class FeedReader {
         try {
             const accountData = await this.matrixClient.getAccountData<AccountData>(FeedReader.seenEntriesEventType).catch((err: MatrixError|unknown) => {
                 if (err instanceof MatrixError && err.statusCode === 404) {
-                    return {};
+                    return {} as AccountData;
                 } else {
                     throw err;
                 }

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -118,7 +118,7 @@ export class FeedReader {
     private timeout?: NodeJS.Timeout;
 
     get pollInterval() {
-        return (this.config.pollIntervalSeconds * 1000) / this.feedQueue.length
+        return (this.config.pollIntervalSeconds * 1000) / (this.feedQueue.length || 1);
     }
 
     constructor(


### PR DESCRIPTION
Rather than polling all the RSS feeds at once, let's stagger them and poll all the feeds within a single cycle of the poll interval. That way we at least spread the resource costs and stop memory spiking so much

Having tried this in "staging", this made things better:

![image](https://user-images.githubusercontent.com/2072976/227667767-b5c38a9f-d3cd-4b53-b126-c178172a1cdf.png)
![image](https://user-images.githubusercontent.com/2072976/227667790-101239dc-7879-4622-a58f-923b5ba3d357.png)
