### PR TITLE
Ensure joined to room when checking widget API permissions.

### DIFF
--- a/changelog.d/691.bugfix
+++ b/changelog.d/691.bugfix
@@ -1,0 +1,1 @@
+Improve resiliency to invite/join races when Hookshot is added by an integration manager.

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -818,7 +818,14 @@ export class Bridge {
         }
 
         // Accept the invite
-        await retry(() => botUser.intent.joinRoom(roomId), 5);
+        await retry(async () => {
+            try {
+                await botUser.intent.joinRoom(roomId);
+            } catch (ex) {
+                log.warn(`Failed to join ${roomId}`, ex);
+                throw ex;
+            }
+        }, 5);
         if (event.content.is_direct) {
             await botUser.intent.underlyingClient.setRoomAccountData(
                 BRIDGE_ROOM_TYPE, roomId, {admin_user: event.sender},

--- a/web/components/roomConfig/RoomConfig.tsx
+++ b/web/components/roomConfig/RoomConfig.tsx
@@ -6,7 +6,7 @@ import style from "./RoomConfig.module.scss";
 import { GetConnectionsResponseItem } from "../../../src/provisioning/api";
 import { IConnectionState } from "../../../src/Connections";
 import { LoadingSpinner } from '../elements/LoadingSpinner';
-import { ApiError, ErrCode } from "../../../src/api";
+import { ErrCode } from "../../../src/api";
 export interface ConnectionConfigurationProps<SConfig, ConnectionType extends GetConnectionsResponseItem, ConnectionState extends IConnectionState> {
     serviceConfig: SConfig;
     loginLabel?: string;

--- a/web/components/roomConfig/RoomConfig.tsx
+++ b/web/components/roomConfig/RoomConfig.tsx
@@ -6,8 +6,7 @@ import style from "./RoomConfig.module.scss";
 import { GetConnectionsResponseItem } from "../../../src/provisioning/api";
 import { IConnectionState } from "../../../src/Connections";
 import { LoadingSpinner } from '../elements/LoadingSpinner';
-
-
+import { ApiError, ErrCode } from "../../../src/api";
 export interface ConnectionConfigurationProps<SConfig, ConnectionType extends GetConnectionsResponseItem, ConnectionState extends IConnectionState> {
     serviceConfig: SConfig;
     loginLabel?: string;
@@ -40,6 +39,9 @@ interface IRoomConfigProps<SConfig, ConnectionType extends GetConnectionsRespons
     migrationCandidates?: ConnectionType[];
     migrationComparator?: (migrated: ConnectionType, native: ConnectionType) => boolean;
 }
+
+const MAX_CONNECTION_FETCH_ATTEMPTS = 10;
+
 export const RoomConfig = function<SConfig, ConnectionType extends GetConnectionsResponseItem, ConnectionState extends IConnectionState>(props: IRoomConfigProps<SConfig, ConnectionType, ConnectionState>) {
     const {
         api,
@@ -67,17 +69,38 @@ export const RoomConfig = function<SConfig, ConnectionType extends GetConnection
     }
 
     useEffect(() => {
-        api.getConnectionsForService<ConnectionType>(roomId, type).then(res => {
+        const fetchConnections = async () => {
+            let attempts = 0;
+            do {
+                try {
+                    return await api.getConnectionsForService<ConnectionType>(roomId, type);
+                } catch (ex) {
+                    console.warn("Failed to fetch existing connections", ex, attempts);
+                    if (ex instanceof BridgeAPIError && ex.errcode === ErrCode.NotInRoom) {
+                        attempts++;
+                        if (attempts < MAX_CONNECTION_FETCH_ATTEMPTS) {
+                            await new Promise(r => setTimeout(r, 1000));
+                        } else {
+                            throw ex;
+                        }
+                    } else {
+                        throw ex;
+                    }
+                }
+            } while (attempts < MAX_CONNECTION_FETCH_ATTEMPTS)
+            throw Error('Too many attempts trying to fetch connections');
+        };
+
+        fetchConnections().then((res) => {
             setCanEditRoom(res.canEdit);
             setConnections(res.connections);
             clearCurrentError();
         }).catch(ex => {
-            console.warn("Failed to fetch existing connections", ex);
             setError({
                 header: "Failed to fetch existing connections",
                 message: ex instanceof BridgeAPIError ? ex.message : "Unknown error"
             });
-        });
+        })
     }, [api, roomId, type, newConnectionKey]);
 
     const [ toMigrate, setToMigrate ] = useState<ConnectionType[]>([]);
@@ -158,7 +181,7 @@ export const RoomConfig = function<SConfig, ConnectionType extends GetConnection
                     showAuthPrompt={showAuthPrompt}
                 />}
             </section>}
-            { connections === null && <LoadingSpinner /> }
+            { !error && connections === null && <LoadingSpinner /> }
             { !!connections?.length && <section>
                 <h2>{ canEditRoom ? text.listCanEdit : text.listCantEdit }</h2>
                 { serviceConfig && connections?.map(c => <ListItem key={c.id} text={listItemName(c)}>

--- a/web/components/roomConfig/RoomConfig.tsx
+++ b/web/components/roomConfig/RoomConfig.tsx
@@ -79,7 +79,10 @@ export const RoomConfig = function<SConfig, ConnectionType extends GetConnection
                     if (ex instanceof BridgeAPIError && ex.errcode === ErrCode.NotInRoom) {
                         attempts++;
                         if (attempts < MAX_CONNECTION_FETCH_ATTEMPTS) {
-                            await new Promise(r => setTimeout(r, 1000));
+                            await new Promise(r => setTimeout(r,
+                                // Space out attempts non-lineraly
+                                Math.pow(1000, 1 + (attempts / 30))
+                            ));
                         } else {
                             throw ex;
                         }


### PR DESCRIPTION
Soft dependency on https://github.com/matrix-org/matrix-appservice-bridge/pull/465

This should fix the cases where users see an error due to the invite not quite succeeding. This works by:

- Always ensuring we're joined to a room before testing permissions
- Making up to 10 (spaced by a second) checks for connections before giving up.
- Ensuring we log errors as JSON so we actually can check why we're failing.