### PR TITLE
Fix release script

### DIFF
--- a/changelog.d/693.misc
+++ b/changelog.d/693.misc
@@ -1,0 +1,1 @@
+Fix release script setting the tag message to "-".

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -38,7 +38,7 @@ towncrier build --version $VERSION
 git commit CHANGELOG.md changelog.d/ package.json -m $TAG
 
 echo "Proceeding to generate tags"
-cat draft-release.txt | git tag --force -m - -s $TAG
+git tag -F draft-release.txt -s $TAG
 rm draft-release.txt
 echo "Generated tag $TAG"
 


### PR DESCRIPTION
Noticed while doing 3.1.0 that we had outputted "-" as the release message.