### PR TITLE
RSS Spam fix

### DIFF
--- a/changelog.d/694.bugfix
+++ b/changelog.d/694.bugfix
@@ -1,0 +1,1 @@
+Fix the bridge spamming RSS feeds repeatedly.

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -366,7 +366,7 @@ export class FeedReader {
         const elapsed = Date.now() - fetchingStarted;
         Metrics.feedFetchMs.set(elapsed);
 
-        const sleepFor = Math.min(this.sleepingInterval - elapsed, 0);
+        const sleepFor = Math.max(this.sleepingInterval - elapsed, 0);
         log.debug(`Feed fetching took ${elapsed / 1000}s, sleeping for ${sleepFor / 1000}s`);
 
         if (elapsed > this.sleepingInterval) {


### PR DESCRIPTION
Because there is a big difference between `Math.min` and `Math.max`.