### PR TITLE
Support GitHub push events in repo connections

### DIFF
--- a/changelog.d/696.feature
+++ b/changelog.d/696.feature
@@ -1,0 +1,1 @@
+Add support for push events on Github repo connections.

--- a/docs/usage/room_configuration/github_repo.md
+++ b/docs/usage/room_configuration/github_repo.md
@@ -65,6 +65,7 @@ the events marked as default below will be enabled. Otherwise, this is ignored.
   - pull_request.opened *
   - pull_request.ready_for_review *
   - pull_request.reviewed *
+- push
 - release *
   - release.created *
   - release.drafted

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -293,10 +293,10 @@ export class Bridge {
             (c, data) => c.onPROpened(data),
         );
 
-        this.bindHandlerToQueue<GitHubWebhookTypes.PullRequestOpenedEvent, GitHubRepoConnection>(
+        this.bindHandlerToQueue<GitHubWebhookTypes.PushEvent, GitHubRepoConnection>(
             "github.push",
             (data) => connManager.getConnectionsForGithubRepo(data.repository.owner.login, data.repository.name),
-            (c, data) => c.onPROpened(data),
+            (c, data) => c.onPush(data),
         );
 
         this.bindHandlerToQueue<GitHubWebhookTypes.PullRequestClosedEvent, GitHubRepoConnection>(

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -293,6 +293,12 @@ export class Bridge {
             (c, data) => c.onPROpened(data),
         );
 
+        this.bindHandlerToQueue<GitHubWebhookTypes.PullRequestOpenedEvent, GitHubRepoConnection>(
+            "github.push",
+            (data) => connManager.getConnectionsForGithubRepo(data.repository.owner.login, data.repository.name),
+            (c, data) => c.onPROpened(data),
+        );
+
         this.bindHandlerToQueue<GitHubWebhookTypes.PullRequestClosedEvent, GitHubRepoConnection>(
             "github.pull_request.closed",
             (data) => connManager.getConnectionsForGithubRepo(data.repository.owner.login, data.repository.name),

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -334,9 +334,8 @@ interface IPushEventContent {
     external_url: string,
     "uk.half-shot.matrix-hookshot.github.push": {
         commits: string[],
-        commit_count: number,
         ref: string,
-        base_ref: string,
+        base_ref: string|null,
         pusher: string,
     },
     "uk.half-shot.matrix-hookshot.github.repo": GitHubRepoMessageBody["uk.half-shot.matrix-hookshot.github.repo"],
@@ -1283,8 +1282,7 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
         }
     
         const content = `**${event.sender.login}** pushed [${event.commits.length} commit${event.commits.length === 1 ? '' : 's'}](${event.compare}) in ${event.ref} for ${event.repository.full_name}`;
-
-        await this.intent.sendEvent(this.roomId, {
+        const eventContent: IPushEventContent = {
             ...FormatUtil.getPartialBodyForGithubRepo(event.repository),
             external_url: event.compare,
             "uk.half-shot.matrix-hookshot.github.push": {
@@ -1297,7 +1295,8 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
             body: content,
             formatted_body: md.render(content),
             format: "org.matrix.custom.html",
-        } as IPushEventContent);
+        };
+        await this.intent.sendEvent(this.roomId, eventContent);
     }
 
     public toString() {

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -1281,7 +1281,7 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
             return;
         }
     
-        const content = `**${event.sender.login}** pushed [${event.commits.length} commit${event.commits.length === 1 ? '' : 's'}](${event.compare}) in ${event.ref} for ${event.repository.full_name}`;
+        const content = `**${event.sender.login}** pushed [${event.commits.length} commit${event.commits.length === 1 ? '' : 's'}](${event.compare}) to \`${event.ref}\` for ${event.repository.full_name}`;
         const eventContent: IPushEventContent = {
             ...FormatUtil.getPartialBodyForGithubRepo(event.repository),
             external_url: event.compare,

--- a/web/components/roomConfig/GithubRepoConfig.tsx
+++ b/web/components/roomConfig/GithubRepoConfig.tsx
@@ -136,6 +136,7 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ne
                     <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="pull_request" hookEventName="pull_request.ready_for_review" onChange={toggleEnabledHook}>Ready for review</EventHookCheckbox>
                     <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="pull_request" hookEventName="pull_request.reviewed" onChange={toggleEnabledHook}>Reviewed</EventHookCheckbox>
                 </ul>
+                <EventHookCheckbox enabledHooks={enabledHooks} hookEventName="push" onChange={toggleEnabledHook}>Pushed commits</EventHookCheckbox>
                 <EventHookCheckbox enabledHooks={enabledHooks} hookEventName="workflow.run" onChange={toggleEnabledHook}>Workflow Runs</EventHookCheckbox>
                 <ul>
                     <EventHookCheckbox enabledHooks={enabledHooks} parentEvent="workflow.run" hookEventName="workflow.run.success" onChange={toggleEnabledHook}>Success</EventHookCheckbox>


### PR DESCRIPTION
I've even gone and revitalized the concept of storing extra keys in the event body, so you can inspect which commits etc.