### PR TITLE
Add option to enable/disable feed failure notices.

### DIFF
--- a/changelog.d/716.feature
+++ b/changelog.d/716.feature
@@ -1,0 +1,1 @@
+Notifications for RSS feed failures can now be toggled on and off. The feature is now **off** by default.

--- a/src/Connections/FeedConnection.ts
+++ b/src/Connections/FeedConnection.ts
@@ -25,6 +25,7 @@ export interface FeedConnectionState extends IConnectionState {
     url:    string;
     label?: string;
     template?: string;
+    notifyOnFailure?: boolean;
 }
 
 export interface FeedConnectionSecrets {
@@ -223,6 +224,10 @@ export class FeedConnection extends BaseConnection implements IConnection {
         const wasLastResultSuccessful = this.lastResults[0]?.ok !== false;
         if (wasLastResultSuccessful && error.shouldErrorBeSilent) {
             // To avoid short term failures bubbling up, if the error is serious, we still bubble.
+            return;
+        }
+        if (!this.state.notifyOnFailure) {
+            // User hasn't opted into notifications on failure
             return;
         }
         if (!this.hasError) {

--- a/src/FormatUtil.ts
+++ b/src/FormatUtil.ts
@@ -4,7 +4,7 @@ import emoji from "node-emoji";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore 
 import { JiraIssue } from './Jira/Types';
-import { formatLabels, getPartialBodyForJiraIssue, hashId, getPartialBodyForGithubIssue, getPartialBodyForGithubRepo, MinimalGitHubRepo, MinimalGitHubIssue } from "./libRs";
+import { formatLabels, getPartialBodyForJiraIssue, hashId, getPartialBodyForGithubIssue, getPartialBodyForGithubRepo, MinimalGitHubIssue } from "./libRs";
 
 interface IMinimalPR {
     html_url: string;

--- a/src/Notifications/GitLabWatcher.ts
+++ b/src/Notifications/GitLabWatcher.ts
@@ -29,8 +29,5 @@ export class GitLabWatcher extends EventEmitter implements NotificationWatcherTa
 
     private async getNotifications() {
         log.info(`Fetching events from GitLab for ${this.userId}`);
-        const events = await this.client.getEvents({
-            after: new Date(this.since)
-        });
     }
 }

--- a/src/Widgets/GoNebMigrator.ts
+++ b/src/Widgets/GoNebMigrator.ts
@@ -2,7 +2,7 @@ import { Logger } from "matrix-appservice-bridge";
 import axios from "axios";
 
 import { FeedConnection, FeedConnectionState, GitHubRepoConnection, GitHubRepoConnectionState } from "../Connections";
-import { AllowedEvents as GitHubAllowedEvents, AllowedEventsNames as GitHubAllowedEventsNames } from "../Connections/GithubRepo";
+import { AllowedEventsNames as GitHubAllowedEventsNames } from "../Connections/GithubRepo";
 
 const log = new Logger("GoNebMigrator");
 

--- a/tests/FeedReader.spec.ts
+++ b/tests/FeedReader.spec.ts
@@ -14,7 +14,7 @@ class MockConnectionManager extends EventEmitter {
         super();
     }
     
-    getAllConnectionsOfType(type: unknown) {
+    getAllConnectionsOfType() {
         return this.connections;
     }
 }
@@ -32,7 +32,7 @@ class MockMessageQueue extends EventEmitter implements MessageQueue {
         this.emit('pushed', data, single);
     }
 
-    async pushWait<T, X>(data: MessageQueueMessage<T>, timeout?: number, single?: boolean): Promise<X> {
+    async pushWait<X>(): Promise<X> {
         throw new Error('Not yet implemented');
     }
 }
@@ -73,13 +73,13 @@ describe("FeedReader", () => {
             config, cm, mq,
             {
                 getAccountData: <T>() => Promise.resolve({ 'http://test/': [] } as unknown as T),
-                setAccountData: <T>() => Promise.resolve(),
+                setAccountData: () => Promise.resolve(),
             },
             new MockHttpClient({ headers: {}, data: feedContents } as AxiosResponse) as unknown as AxiosStatic,
         );
 
         const event: any = await new Promise((resolve) => {
-            mq.on('pushed', (data, _) => { resolve(data); feedReader.stop() });
+            mq.on('pushed', (data) => { resolve(data); feedReader.stop() });
         });
 
         expect(event.eventName).to.equal('feed.entry');

--- a/web/components/elements/Button.module.scss
+++ b/web/components/elements/Button.module.scss
@@ -22,4 +22,8 @@
 .remove {
     color: #FF5B55;
     background-color: transparent;
+
+    &:disabled {
+        background-color: transparent;
+    }
 }

--- a/web/components/roomConfig/FeedsConfig.tsx
+++ b/web/components/roomConfig/FeedsConfig.tsx
@@ -28,7 +28,7 @@ const FeedRecentResults: FunctionComponent<{item: FeedResponseItem}> = ({ item }
 }
 const DOCUMENTATION_LINK = "https://matrix-org.github.io/matrix-hookshot/latest/setup/feeds.html#feed-templates";
 
-const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ServiceConfig, FeedResponseItem, FeedConnectionState>> = ({existingConnection, onSave, onRemove, isMigrationCandidate}) => {
+const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ServiceConfig, FeedResponseItem, FeedConnectionState>> = ({existingConnection, onSave, onRemove, isMigrationCandidate, isUpdating}) => {
     const urlRef = createRef<HTMLInputElement>();
     const labelRef = createRef<HTMLInputElement>();
     const templateRef = createRef<HTMLInputElement>();
@@ -47,10 +47,12 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<Se
                 label: labelRef?.current?.value || existingConnection?.config.label,
                 template: templateRef.current?.value || existingConnection?.config.template,
                 notifyOnFailure: notifyRef.current?.checked || existingConnection?.config.notifyOnFailure,
-            });
+            })
         }
     }, [canSave, onSave, urlRef, labelRef, templateRef, notifyRef, existingConnection]);
-    
+
+    const onlyVisibleOnExistingConnection = !!existingConnection;
+
     return <form onSubmit={handleSave}>
         { existingConnection && <FeedRecentResults item={existingConnection} />}
 
@@ -60,16 +62,16 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<Se
         <InputField visible={true} label="Label" noPadding={true}>
             <input ref={labelRef} disabled={!canSave} type="text" value={existingConnection?.config.label} />
         </InputField>
-        <InputField visible={true} label="Template" noPadding={true}>
+        <InputField visible={onlyVisibleOnExistingConnection} label="Send a notice on read failure" noPadding={true}>
+            <input ref={notifyRef} disabled={!canSave} type="checkbox" checked={existingConnection?.config.notifyOnFailure} />
+        </InputField>
+        <InputField visible={onlyVisibleOnExistingConnection} label="Template" noPadding={true}>
             <input ref={templateRef} disabled={!canSave} type="text" value={existingConnection?.config.template} placeholder={DEFAULT_TEMPLATE} />
             <p> See the <a target="_blank" rel="noopener noreferrer" href={DOCUMENTATION_LINK}>documentation</a> for help writing templates. </p>
         </InputField>
-        <InputField visible={true} label="Send a notice on read failure" noPadding={true}>
-            <input ref={notifyRef} disabled={!canSave} type="checkbox" checked={existingConnection?.config.notifyOnFailure} />
-        </InputField>
         <ButtonSet>
-            { canSave && <Button type="submit">{ existingConnection?.id ? "Save" : "Subscribe" }</Button>}
-            { canEdit && existingConnection?.id && <Button intent="remove" onClick={onRemove}>Unsubscribe</Button>}
+            { canSave && <Button type="submit" disabled={isUpdating}>{ existingConnection?.id ? "Save" : "Subscribe" }</Button>}
+            { canEdit && existingConnection?.id && <Button intent="remove" onClick={onRemove} disabled={isUpdating}>Unsubscribe</Button>}
         </ButtonSet>
 
     </form>;

--- a/web/components/roomConfig/FeedsConfig.tsx
+++ b/web/components/roomConfig/FeedsConfig.tsx
@@ -32,6 +32,7 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<Se
     const urlRef = createRef<HTMLInputElement>();
     const labelRef = createRef<HTMLInputElement>();
     const templateRef = createRef<HTMLInputElement>();
+    const notifyRef = createRef<HTMLInputElement>();
     const canSave = !existingConnection?.id || (existingConnection?.canEdit ?? false);
     const canEdit = canSave && !isMigrationCandidate;
     const handleSave = useCallback((evt: Event) => {
@@ -45,9 +46,10 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<Se
                 url,
                 label: labelRef?.current?.value || existingConnection?.config.label,
                 template: templateRef.current?.value || existingConnection?.config.template,
+                notifyOnFailure: notifyRef.current?.checked || existingConnection?.config.notifyOnFailure,
             });
         }
-    }, [canSave, onSave, urlRef, labelRef, templateRef, existingConnection]);
+    }, [canSave, onSave, urlRef, labelRef, templateRef, notifyRef, existingConnection]);
     
     return <form onSubmit={handleSave}>
         { existingConnection && <FeedRecentResults item={existingConnection} />}
@@ -62,7 +64,9 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<Se
             <input ref={templateRef} disabled={!canSave} type="text" value={existingConnection?.config.template} placeholder={DEFAULT_TEMPLATE} />
             <p> See the <a target="_blank" rel="noopener noreferrer" href={DOCUMENTATION_LINK}>documentation</a> for help writing templates. </p>
         </InputField>
-
+        <InputField visible={true} label="Send a notice on read failure" noPadding={true}>
+            <input ref={notifyRef} disabled={!canSave} type="checkbox" checked={existingConnection?.config.notifyOnFailure} />
+        </InputField>
         <ButtonSet>
             { canSave && <Button type="submit">{ existingConnection?.id ? "Save" : "Subscribe" }</Button>}
             { canEdit && existingConnection?.id && <Button intent="remove" onClick={onRemove}>Unsubscribe</Button>}

--- a/web/components/roomConfig/GenericWebhookConfig.tsx
+++ b/web/components/roomConfig/GenericWebhookConfig.tsx
@@ -28,7 +28,7 @@ const EXAMPLE_SCRIPT = `if (data.counter === undefined) {
 const DOCUMENTATION_LINK = "https://matrix-org.github.io/matrix-hookshot/latest/setup/webhooks.html#script-api";
 const CODE_MIRROR_EXTENSIONS = [javascript({})];
 
-const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ServiceConfig, GenericHookResponseItem, GenericHookConnectionState>> = ({serviceConfig, existingConnection, onSave, onRemove}) => {
+const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ServiceConfig, GenericHookResponseItem, GenericHookConnectionState>> = ({serviceConfig, existingConnection, onSave, onRemove, isUpdating}) => {
     const [transFn, setTransFn] = useState<string>(existingConnection?.config.transformationFunction as string || EXAMPLE_SCRIPT);
     const [transFnEnabled, setTransFnEnabled] = useState(serviceConfig.allowJsTransformationFunctions && !!existingConnection?.config.transformationFunction);
     const nameRef = createRef<HTMLInputElement>();
@@ -67,8 +67,8 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<Se
             <p> See the <a target="_blank" rel="noopener noreferrer" href={DOCUMENTATION_LINK}>documentation</a> for help writing transformation functions </p>
         </InputField>
         <ButtonSet>
-            { canEdit && <Button type="submit">{ existingConnection ? "Save" : "Add webhook" }</Button>}
-            { canEdit && existingConnection && <Button intent="remove" onClick={onRemove}>Remove webhook</Button>}
+            { canEdit && <Button disabled={isUpdating} type="submit">{ existingConnection ? "Save" : "Add webhook" }</Button>}
+            { canEdit && existingConnection && <Button disabled={isUpdating} intent="remove" onClick={onRemove}>Remove webhook</Button>}
         </ButtonSet>
     </form>;
 };

--- a/web/components/roomConfig/GithubRepoConfig.tsx
+++ b/web/components/roomConfig/GithubRepoConfig.tsx
@@ -18,7 +18,7 @@ function getRepoFullName(state: GitHubRepoConnectionState) {
 }
 
 const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<never, GitHubRepoResponseItem, GitHubRepoConnectionState>> = ({
-    showAuthPrompt, loginLabel, serviceConfig, api, existingConnection, onSave, onRemove
+    showAuthPrompt, loginLabel, serviceConfig, api, existingConnection, onSave, onRemove, isUpdating
 }) => {
     // Assume true if we have no auth prompt.
     const [authedResponse, setAuthResponse] = useState<GetAuthResponse|null>(null);
@@ -159,8 +159,8 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ne
             </ul>
         </InputField>
         <ButtonSet>
-            { canEdit && consideredAuthenticated && <Button type="submit" disabled={!existingConnection && !connectionState}>{ existingConnection?.id ? "Save" : "Add repository" }</Button>}
-            { canEdit && existingConnection?.id && <Button intent="remove" onClick={onRemove}>Remove repository</Button>}
+            { canEdit && consideredAuthenticated && <Button disabled={isUpdating} type="submit" disabled={!existingConnection && !connectionState}>{ existingConnection?.id ? "Save" : "Add repository" }</Button>}
+            { canEdit && existingConnection?.id && <Button disabled={isUpdating} intent="remove" onClick={onRemove}>Remove repository</Button>}
         </ButtonSet>
     </form>;
 };

--- a/web/components/roomConfig/GithubRepoConfig.tsx
+++ b/web/components/roomConfig/GithubRepoConfig.tsx
@@ -159,7 +159,7 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ne
             </ul>
         </InputField>
         <ButtonSet>
-            { canEdit && consideredAuthenticated && <Button disabled={isUpdating} type="submit" disabled={!existingConnection && !connectionState}>{ existingConnection?.id ? "Save" : "Add repository" }</Button>}
+            { canEdit && consideredAuthenticated && <Button type="submit" disabled={isUpdating || !existingConnection && !connectionState}>{ existingConnection?.id ? "Save" : "Add repository" }</Button>}
             { canEdit && existingConnection?.id && <Button disabled={isUpdating} intent="remove" onClick={onRemove}>Remove repository</Button>}
         </ButtonSet>
     </form>;

--- a/web/components/roomConfig/GitlabRepoConfig.tsx
+++ b/web/components/roomConfig/GitlabRepoConfig.tsx
@@ -10,7 +10,7 @@ import { DropItem } from "../elements/DropdownSearch";
 import { ConnectionSearch } from "../elements/ConnectionSearch";
 
 const EventType = "uk.half-shot.matrix-hookshot.gitlab.repository";
-const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<never, GitLabRepoResponseItem, GitLabRepoConnectionState>> = ({api, existingConnection, onSave, onRemove }) => {
+const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<never, GitLabRepoResponseItem, GitLabRepoConnectionState>> = ({api, existingConnection, onSave, onRemove, isUpdating }) => {
     const [enabledHooks, setEnabledHooks] = useState<string[]>(existingConnection?.config.enableHooks || []);
 
     const toggleEnabledHook = useCallback((evt: any) => {
@@ -107,8 +107,8 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ne
             </ul>
         </InputField>
         <ButtonSet>
-            { canEdit && <Button type="submit" disabled={!existingConnection && !newConnectionState}>{ existingConnection ? "Save" : "Add project" }</Button>}
-            { canEdit && existingConnection && <Button intent="remove" onClick={onRemove}>Remove project</Button>}
+            { canEdit && <Button disabled={isUpdating} type="submit" disabled={!existingConnection && !newConnectionState}>{ existingConnection ? "Save" : "Add project" }</Button>}
+            { canEdit && existingConnection && <Button disabled={isUpdating} intent="remove" onClick={onRemove}>Remove project</Button>}
         </ButtonSet>
     </form>;
 };

--- a/web/components/roomConfig/GitlabRepoConfig.tsx
+++ b/web/components/roomConfig/GitlabRepoConfig.tsx
@@ -107,7 +107,7 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ne
             </ul>
         </InputField>
         <ButtonSet>
-            { canEdit && <Button disabled={isUpdating} type="submit" disabled={!existingConnection && !newConnectionState}>{ existingConnection ? "Save" : "Add project" }</Button>}
+            { canEdit && <Button type="submit" disabled={isUpdating || !existingConnection && !newConnectionState}>{ existingConnection ? "Save" : "Add project" }</Button>}
             { canEdit && existingConnection && <Button disabled={isUpdating} intent="remove" onClick={onRemove}>Remove project</Button>}
         </ButtonSet>
     </form>;

--- a/web/components/roomConfig/JiraProjectConfig.tsx
+++ b/web/components/roomConfig/JiraProjectConfig.tsx
@@ -11,7 +11,7 @@ import { DropItem } from "../elements/DropdownSearch";
 
 const EventType = "uk.half-shot.matrix-hookshot.jira.project";
 
-const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<never, JiraProjectResponseItem, JiraProjectConnectionState>> = ({api, existingConnection, onSave, onRemove }) => {
+const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<never, JiraProjectResponseItem, JiraProjectConnectionState>> = ({api, existingConnection, onSave, onRemove, isUpdating }) => {
     const [allowedEvents, setAllowedEvents] = useState<string[]>(existingConnection?.config.events || ['issue_created']);
 
     const toggleEvent = useCallback((evt: Event) => {
@@ -93,8 +93,8 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ne
             </ul>
         </InputField>
         <ButtonSet>
-            { canEdit && <Button type="submit" disabled={!existingConnection && !newConnectionState}>{ existingConnection ? "Save" : "Add project" }</Button>}
-            { canEdit && existingConnection && <Button intent="remove" onClick={onRemove}>Remove project</Button>}
+            { canEdit && <Button type="submit" disabled={isUpdating || !existingConnection && !newConnectionState}>{ existingConnection ? "Save" : "Add project" }</Button>}
+            { canEdit && existingConnection && <Button disabled={isUpdating} intent="remove" onClick={onRemove}>Remove project</Button>}
         </ButtonSet>
     </form>;
 };


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-hookshot/issues/541
Fixes https://github.com/vector-im/element-integration-manager/issues/63

This disables the notices by default when a feed fails, and adds a checkbox to opt in.

This also fixes a problem with the room configs not visibly changing when state is saved, by disabling the save/delete buttons while a save is in progress.