### PR TITLE
Fix case where GitHub repos aren't connectable if the GitHub App was manually approved

### DIFF
--- a/changelog.d/718.bugfix
+++ b/changelog.d/718.bugfix
@@ -1,0 +1,1 @@
+Fix cases of GitHub repos not being bridgable if the GitHub App had to be manually approved.

--- a/src/Github/GrantChecker.ts
+++ b/src/Github/GrantChecker.ts
@@ -2,7 +2,6 @@ import { Appservice } from "matrix-bot-sdk";
 import { GitHubRepoConnection } from "../Connections";
 import { GrantChecker } from "../grants/GrantCheck";
 import { UserTokenStore } from "../UserTokenStore";
-import { GithubInstance } from "./GithubInstance";
 import { Logger } from 'matrix-appservice-bridge';
 
 const log = new Logger('GitHubGrantChecker');
@@ -14,7 +13,7 @@ interface GitHubGrantConnectionId {
 
 
 export class GitHubGrantChecker extends GrantChecker<GitHubGrantConnectionId> {
-    constructor(private readonly as: Appservice, private readonly github: GithubInstance, private readonly tokenStore: UserTokenStore) {
+    constructor(private readonly as: Appservice, private readonly tokenStore: UserTokenStore) {
         super(as.botIntent, "github")
     }
 
@@ -29,7 +28,7 @@ export class GitHubGrantChecker extends GrantChecker<GitHubGrantConnectionId> {
             return true;
         }
         try {
-            await GitHubRepoConnection.assertUserHasAccessToRepo(sender, connectionId.org, connectionId.repo, this.github, this.tokenStore);
+            await GitHubRepoConnection.assertUserHasAccessToRepo(sender, connectionId.org, connectionId.repo, this.tokenStore);
             return true;
         } catch (ex) {
             log.info(`Tried to check fallback for ${roomId}: ${sender} does not have access to ${connectionId.org}/${connectionId.repo}`, ex);


### PR DESCRIPTION
Believe this fixes #711 

Instead of relying on our internal cache for GitHub apps, let's just check on provisionConnection to see if GitHub has access to a repo.