### PR TITLE
Rust message queues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +283,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "libc"
+version = "0.2.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc207893e85c5d6be840e969b496b53d94cec8be2d501b214f50daa97fa8024"
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +304,7 @@ version = "1.8.1"
 dependencies = [
  "atom_syndication",
  "contrast",
+ "glob",
  "hex",
  "md-5",
  "napi",
@@ -292,6 +316,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -313,9 +338,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "napi"
-version = "2.12.4"
+version = "2.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556470a21074b55be8adee5f27ca04389cfdaca323a28b4b0e9c15466de94731"
+checksum = "49ac8112fe5998579b22e29903c7b277fc7f91c7860c0236f35792caf8156e18"
 dependencies = [
  "bitflags",
  "ctor",
@@ -413,6 +438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +469,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -604,6 +665,22 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "uuid"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
+dependencies = [
+ "getrandom",
+ "rand",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-napi = {version="2", features=["serde-json"]}
+napi = {version="2.12.6", features=["serde-json", "napi6"]}
 napi-derive = "2"
 url = "2"
 serde_json = "1"
@@ -19,6 +19,9 @@ md-5 = "0.8.0"
 hex = "0.4.3"
 rss = "2.0.3"
 atom_syndication = "0.12"
+glob = "0.3.1"
+uuid = {version="1.3.2", features=["v4", "fast-rng"]}
+
 
 [build-dependencies]
 napi-build = "1"

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -40,6 +40,8 @@ import { GenericWebhookEvent, GenericWebhookEventResult } from "./generic/types"
 import { SetupWidget } from "./Widgets/SetupWidget";
 import { FeedEntry, FeedError, FeedReader, FeedSuccess } from "./feeds/FeedReader";
 import PQueue from "p-queue";
+import { LocalMQ } from "./libRs";
+import { RsLocalMq } from "./messagequeue/wrapper";
 const log = new Logger("Bridge");
 
 export class Bridge {
@@ -65,7 +67,7 @@ export class Bridge {
         private readonly storage: IBridgeStorageProvider,
         private readonly botUsersManager: BotUsersManager,
     ) {
-        this.queue = createMessageQueue(this.config.queue);
+        this.queue = new RsLocalMq() as any as MessageQueue;
         this.messageClient = new MessageSenderClient(this.queue);
         this.commentProcessor = new CommentProcessor(this.as, this.config.bridge.mediaUrl || this.config.bridge.url);
         this.notifProcessor = new NotificationProcessor(this.storage, this.messageClient);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod Github;
 pub mod Jira;
 pub mod feeds;
 pub mod format_util;
+pub mod messagequeue;
 
 #[macro_use]
 extern crate napi_derive;

--- a/src/messagequeue/localmq.rs
+++ b/src/messagequeue/localmq.rs
@@ -1,0 +1,242 @@
+use std::{collections::{HashSet, HashMap}};
+use glob::{Pattern, PatternError};
+use napi::{JsFunction};
+use serde_json::Value;
+use uuid::Uuid;
+use napi::{
+  threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode},
+  JsString,
+};
+pub enum Callback {
+  RsCallback(fn(&MessageQueueMessage)),
+  JsCallback(ThreadsafeFunction<MessageQueueMessage>)
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[napi(object)]
+pub struct MessageQueueMessage {
+  pub sender: String,
+  pub event_name: String,
+  pub data: Value,
+  pub id: String,
+  pub destination: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[napi(object)]
+pub struct MessageQueueMessagePushJsPush {
+  pub sender: String,
+  pub event_name: String,
+  pub data: Option<Value>,
+  pub id: Option<String>,
+  pub destination: Option<String>,
+}
+
+
+pub struct LocalMQ {
+  subscriptions: HashSet<Pattern>,
+  once_callbacks: HashMap<String, Vec<Callback>>,
+  push_callbacks: HashMap<String, Vec<Callback>>,
+}
+
+impl MessageQueueMessage {
+  pub fn new(event_name: &str, sender: &str, data: Value) -> Self {
+    MessageQueueMessage {
+      event_name: String::from(event_name),
+      sender: String::from(sender),
+      data,
+      destination: None,
+      id: Uuid::new_v4().to_string(),
+    }
+  }
+
+  pub fn with_destination(event_name: &str, sender: &str, data: Value, destination: &str) -> Self {
+    MessageQueueMessage {
+      event_name: String::from(event_name),
+      sender: String::from(sender),
+      data,
+      destination: Some(String::from(destination)),
+      id: Uuid::new_v4().to_string(),
+    }
+  }
+
+  pub fn from_js_message(message: &MessageQueueMessagePushJsPush) -> Self {
+    MessageQueueMessage {
+      event_name: message.event_name.clone(),
+      sender: message.sender.clone(),
+      data: message.data.clone().unwrap_or(Value::Null),
+      destination: message.destination.clone(),
+      id: message.id.clone().unwrap_or_else(|| Uuid::new_v4().to_string()),
+    }
+  }
+}
+
+impl LocalMQ {
+
+  pub fn new() -> Self {
+    LocalMQ {
+      subscriptions: HashSet::new(),
+      once_callbacks: HashMap::new(),
+      push_callbacks: HashMap::new(),
+    }
+  }
+
+  pub fn subscribe(&mut self, event_glob: String) -> Result<bool, PatternError> {
+    Pattern::new(&event_glob).and_then(|f| Ok(self.subscriptions.insert(f)))  
+  }
+
+  pub fn unsubscribe(&mut self, event_glob: String) -> Result<bool, PatternError> {
+    Pattern::new(&event_glob).and_then(|f| Ok(self.subscriptions.remove(&f)))
+  }
+  
+  pub fn on(&mut self, event_glob: String, callback: Callback) {
+    match self.push_callbacks.get_mut(&event_glob) {
+        Some(existing) => {
+          existing.push(callback);
+        }
+        None => {
+          self.push_callbacks.insert(event_glob, vec![callback]);
+        }
+    }
+  }
+  
+  pub fn once(&mut self, event_glob: String, callback: Callback) {
+    match self.once_callbacks.get_mut(&event_glob) {
+        Some(existing) => {
+          existing.push(callback);
+        }
+        None => {
+          self.once_callbacks.insert(event_glob, vec![callback]);
+        }
+    }
+  }
+
+  pub fn push(&mut self, message: MessageQueueMessage) {
+    if self.subscriptions.iter().find(
+      |&glob| glob.matches(message.event_name.as_str())
+    ).is_none() {
+      println!("no pattern match");
+      return;
+    }
+
+    let push_msg = MessageQueueMessage {
+      sender: message.sender.clone(),
+      event_name: message.event_name.clone(),
+      data: message.data.clone(),
+      id: message.id,
+      destination: message.destination.clone()
+    };
+
+    let once_vec = self.once_callbacks.remove(&message.event_name);
+
+    if once_vec.is_some() {
+      for callback in once_vec.unwrap() {
+        match callback {
+          Callback::RsCallback(cb) => 
+            cb(&push_msg)
+          ,
+          Callback::JsCallback(cb) => {
+            let cb_instance = cb.clone();
+            cb_instance.call(Ok(push_msg.clone()), ThreadsafeFunctionCallMode::NonBlocking);
+          }
+        }
+      }
+    }
+
+
+    let push_vec = self.push_callbacks.get(&message.event_name);
+
+    if push_vec.is_some() {
+        for callback in push_vec.unwrap() {
+          match callback {
+            Callback::RsCallback(cb) => 
+              cb(&push_msg)
+            ,
+            Callback::JsCallback(cb) => {
+              let cb_instance: ThreadsafeFunction<MessageQueueMessage> = cb.clone();
+              cb_instance.call(Ok(push_msg.clone()), ThreadsafeFunctionCallMode::NonBlocking);
+            }
+          }
+        }
+      }
+  }
+
+}
+
+#[napi(js_name = "LocalMQ")]
+pub struct JsLocalMQ {
+  mq: LocalMQ,
+}
+
+
+#[napi]
+impl JsLocalMQ {
+  #[napi(constructor)]
+  pub fn new() -> Self {
+    JsLocalMQ {
+      mq: LocalMQ::new()
+    }
+  }
+
+  #[napi]
+  pub fn subscribe(&mut self, event_glob: String) -> napi::Result<bool> {
+    match self.mq.subscribe(event_glob) {
+      Err(e) => Err(napi::Error::new(
+          napi::Status::InvalidArg,
+          e.to_string(),
+      )),
+      Ok(v) => Ok(v)
+    }
+  }
+
+  #[napi]
+  pub fn unsubscribe(&mut self, event_glob: String) -> napi::Result<bool> {
+    match self.mq.unsubscribe(event_glob) {
+      Err(e) => Err(napi::Error::new(
+        napi::Status::InvalidArg,
+        e.to_string(),
+    )),
+    Ok(v) => Ok(v)
+    }
+  }
+
+  #[napi]
+  pub fn on(&mut self, event_glob: String, callback: JsFunction) -> napi::Result<()> {
+    let tsfn: ThreadsafeFunction<MessageQueueMessage> =
+    callback.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
+    self.mq.on(event_glob, Callback::JsCallback(tsfn));
+    Ok(())
+  }
+
+  #[napi]
+  pub fn once(&mut self, event_glob: String, callback: JsFunction) -> napi::Result<()> {
+    let tsfn: ThreadsafeFunction<MessageQueueMessage> =
+    callback.create_threadsafe_function(0, |ctx| Ok(vec![ctx.value]))?;
+    self.mq.once(event_glob, Callback::JsCallback(tsfn));
+    Ok(())
+  }
+
+  #[napi]
+  pub fn push(&mut self, message: MessageQueueMessagePushJsPush) {
+    self.mq.push(MessageQueueMessage::from_js_message(&message));
+  }
+}
+
+#[test]
+fn test_callback() {
+  let mut mq = LocalMQ::new();
+
+  mq.on(
+    "test-ev".to_owned(),
+    Callback::RsCallback(|msg: &MessageQueueMessage| { println!("hello there! {}", msg.event_name);}));
+
+  mq.subscribe("test-ev".to_owned()).unwrap();
+
+  mq.push(
+    MessageQueueMessage::new(
+      "test-ev", 
+      "fibble", 
+      Value::Null,
+    )
+  );
+}

--- a/src/messagequeue/mod.rs
+++ b/src/messagequeue/mod.rs
@@ -1,0 +1,1 @@
+pub mod localmq;

--- a/src/messagequeue/wrapper.ts
+++ b/src/messagequeue/wrapper.ts
@@ -1,0 +1,23 @@
+import { LocalMQ } from "../libRs";
+
+export class RsLocalMq extends LocalMQ {
+    public on(eventGlob: string, callback: (...args: any[]) => any): void {
+        super.on(eventGlob, (err, ...args) => {
+            if (err) {
+                // TODO: Handle this better
+                throw Error(err);
+            }
+            callback(...args)
+        })
+    }
+
+    public once(eventGlob: string, callback: (...args: any[]) => any): void {
+        super.once(eventGlob, (err, ...args) => {
+            if (err) {
+                // TODO: Handle this better
+                throw Error(err);
+            }
+            callback(...args)
+        })
+    }
+}

--- a/tests/MessageQueuePerf.ts
+++ b/tests/MessageQueuePerf.ts
@@ -1,0 +1,61 @@
+import { randomBytes } from "crypto";
+import { LocalMQ as JsLocalMQ } from "../src/MessageQueue/LocalMQ";
+import { LocalMQ as RsLocalMQ } from "../src/libRs";
+
+async function testSimpleEvent(mq: JsLocalMQ|RsLocalMQ, iterations: number ) {
+    mq.subscribe("test");
+    let o = { resolver: (n = 1) => {} }
+    mq.on('test', (_, d) => { o.resolver(d) });
+    for (let index = 0; index < iterations; index++) {
+        const res = new Promise((resolve) => o.resolver = resolve as any);
+        await mq.push({
+            sender: "hi",
+            eventName: "test",
+            data: {},
+            id: "hi",
+        });
+        console.log(await res);        
+    }
+}
+
+async function testWithData(mq: JsLocalMQ|RsLocalMQ, iterations: number ) {
+    mq.subscribe("test");
+    let o = { resolver: (n = 1) => {} }
+    mq.on('test', (_, d) => { o.resolver(d) });
+    for (let index = 0; index < iterations; index++) {
+        const res = new Promise((resolve) => o.resolver = resolve as any);
+        const data = {
+            data: randomBytes(512).toJSON()
+        };
+        await mq.push({
+            sender: "hi",
+            eventName: "test",
+            data: data,
+            id: "hi",
+        });
+        console.log(await res);  
+    }
+}
+
+const jsMq = new JsLocalMQ();
+const rsMq = new RsLocalMQ();
+
+async function main() {
+    console.time('JS:testSimpleEvent');
+    await testSimpleEvent(jsMq, 1000);
+    console.timeEnd('JS:testSimpleEvent');
+    console.time('RS:testSimpleEvent');
+    await testSimpleEvent(rsMq, 1000);
+    console.timeEnd('RS:testSimpleEvent');
+
+    console.time('JS:testWithData');
+    await testWithData(jsMq, 100);
+    console.timeEnd('JS:testWithData');
+    console.time('RS:testWithData');
+    await testWithData(rsMq, 100);
+    console.timeEnd('RS:testWithData');
+}
+
+main().finally(() => {
+    console.log('Done!');
+})


### PR DESCRIPTION
Arguably the biggest blocker to getting various components ported to Rust is that hookshot relies upon a central message queue for passing between components. While building a redis compatible one would be trivial, building a in-process one is trickier. This PR adds a nearly functionally complete version of our "LocalMQ" class, written in Rust.

Performance is...patchy. Rust does slightly better when the message contains no data, but is on the whole worse than JS when the data payload is populated. This is likely due to jumping the N-API barrier, and having to clone the content of the message *each* time it's used.

I'm sure more experienced rust folks might be able to tidy up the impl, but the performance issues only really show at the 1000Hz and above range. Hookshot will certainly bottleneck in other places before we ever reach that kind of throughput. For now with some cleanup I think this would allow us to begin looking at porting the RSS feed component to Rust.