### PR TITLE
fix: Make sure that the blockquote markdown for github issue comments are valid commonmark

### DIFF
--- a/changelog.d/746.bugfix
+++ b/changelog.d/746.bugfix
@@ -1,0 +1,1 @@
+Fix Github comments not being rendered correctly as blockquotes.

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -912,7 +912,7 @@ export class GitHubRepoConnection extends CommandConnection<GitHubRepoConnection
         }
     
         let message = `**${event.comment.user.login}** [commented](${event.issue.html_url}) on [${event.repository.full_name}#${event.issue.number}](${event.issue.html_url})  `;
-        message += "\n > " + event.comment.body.substring(0, TRUNCATE_COMMENT_SIZE) + (event.comment.body.length > TRUNCATE_COMMENT_SIZE ? "…" : "");
+        message += "\n> " + event.comment.body.substring(0, TRUNCATE_COMMENT_SIZE) + (event.comment.body.length > TRUNCATE_COMMENT_SIZE ? "…" : "");
 
         await this.intent.sendEvent(this.roomId, {
             msgtype: "m.notice",


### PR DESCRIPTION
<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->

Fixes that blockquotes don't get rendered as such. Leading spaces in front of `>` are not valid in commonmark. So they get not properly converted, but instead they seem to get escaped.

This PR was made on the assumption that the lib used follows commonmark spec as closely as it claims, and this being the logical result for this. I didn't have a test env handy to actually validate this.


Signed-off-by: Marcel Radzio <support@nordgedanken.dev>