### PR TITLE
Apply cargo clippy suggestions to reduce not needed allocations

### DIFF
--- a/changelog.d/750.misc
+++ b/changelog.d/750.misc
@@ -1,0 +1,1 @@
+Apply non-style suggestions by `cargo clippy` to reduce allocations in the rust code.

--- a/src/Config/permissions.rs
+++ b/src/Config/permissions.rs
@@ -76,7 +76,7 @@ impl BridgePermissions {
 
     #[napi]
     pub fn get_interested_rooms(&self) -> Vec<String> {
-        self.room_membership.keys().map(|k| k.clone()).collect()
+        self.room_membership.keys().cloned().collect()
     }
 
     #[napi]


### PR DESCRIPTION
Hi,

I applied the non style related clippy suggestions. (apart from the `map_clone` one and `single_match` in some places)

Namely:

- https://rust-lang.github.io/rust-clippy/master/index.html#single_match
- https://rust-lang.github.io/rust-clippy/master/index.html#explicit_counter_loop
- https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
- https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone (coming from `to_string`)
- https://rust-lang.github.io/rust-clippy/master/index.html#map_clone

I also removed some calls to `format!` which should be not needed and allocate a `String` while not needed. (Though I am not sure if napi will do this anyway for FFI)

Signed-off-by: Marcel Radzio <support@nordgedanken.dev>