### PR TITLE
Fix #598; setup issues when the bot has PL 0 and room default isn't 0

### DIFF
--- a/changelog.d/755.bugfix
+++ b/changelog.d/755.bugfix
@@ -1,0 +1,1 @@
+Fix setup issues when the bot has PL 0 and room default isn't 0.

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -1143,9 +1143,9 @@ export class Bridge {
                 if (this.config.widgets?.roomSetupWidget?.addOnInvite && event.type === "m.room.power_levels" && event.state_key === "" && !this.connectionManager.isRoomConnected(roomId)) {
                     log.debug(`${roomId} got a new powerlevel change and isn't connected to any connections, testing to see if we should create a setup widget`)
                     const plEvent = new PowerLevelsEvent(event);
-                    const currentPl = plEvent.content.users?.[botUser.userId] || plEvent.defaultUserLevel;
-                    const previousPl = plEvent.previousContent?.users?.[botUser.userId] || plEvent.previousContent?.users_default;
-                    const requiredPl = plEvent.content.events?.["im.vector.modular.widgets"] || plEvent.defaultStateEventLevel;
+                    const currentPl = plEvent.content.users?.[botUser.userId] ?? plEvent.defaultUserLevel;
+                    const previousPl = plEvent.previousContent?.users?.[botUser.userId] ?? plEvent.previousContent?.users_default;
+                    const requiredPl = plEvent.content.events?.["im.vector.modular.widgets"] ?? plEvent.defaultStateEventLevel;
                     if (currentPl !== previousPl && currentPl >= requiredPl) {
                         // PL changed for bot user, check to see if the widget can be created.
                         try {


### PR DESCRIPTION
If the bot has PL 0, the bot incorrectly used the default power level.

Signed-off-by: Christian Paul <inbox-for-job-offers-from-element@chrpaul.de>
