### PR TITLE
Fix crash from exceptions in handlers

### DIFF
--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -786,8 +786,8 @@ export class Bridge {
         this.ready = true;
     }
 
-    private handleHookshotEvent<EventType, ConnType extends IConnection>(msg: MessageQueueMessageOut<EventType>, connection: ConnType, handler: (c: ConnType, data: EventType) => Promise<unknown>|unknown) {
-        Sentry.withScope((scope) => {
+    private async handleHookshotEvent<EventType, ConnType extends IConnection>(msg: MessageQueueMessageOut<EventType>, connection: ConnType, handler: (c: ConnType, data: EventType) => Promise<unknown>|unknown) {
+        Sentry.withScope(async (scope) => {
             scope.setTransactionName('handleHookshotEvent');
             scope.setTags({
                 eventType: msg.eventName,
@@ -796,11 +796,13 @@ export class Bridge {
             scope.setContext("connection", {
                 id: connection.connectionId,
             });
-            new Promise(() => handler(connection, msg.data)).catch((ex) => {
-                Sentry.captureException(ex, scope);
+            try {
+                await handler(connection, msg.data);
+            } catch (e) {
+                log.warn(`Connection ${connection.toString()} failed to handle ${msg.eventName}:`, e);
                 Metrics.connectionsEventFailed.inc({ event: msg.eventName, connectionId: connection.connectionId });
-                log.warn(`Connection ${connection.toString()} failed to handle ${msg.eventName}:`, ex);
-            });
+                Sentry.captureException(e, scope);
+            }
         });
     }
 
@@ -810,8 +812,8 @@ export class Bridge {
             const connections = connectionFetcherBound(msg.data);
             log.debug(`${event} for ${connections.map(c => c.toString()).join(', ') || '[empty]'}`);
             connections.forEach((connection) => {
-                this.handleHookshotEvent(msg, connection, handler);
-            })
+                void this.handleHookshotEvent(msg, connection, handler);
+            });
         });
     }
 
@@ -1167,7 +1169,7 @@ export class Bridge {
         }
 
         for (const connection of this.connectionManager.getAllConnectionsForRoom(roomId)) {
-            if (!connection.onEvent) { 
+            if (!connection.onEvent) {
                 continue;
             }
             const scope = new Sentry.Scope();


### PR DESCRIPTION
Fixes the whole application crashing when an exception happens in a handler.
Typically this was failing to send a message due to lacking permissions.

This seems like it may have regressed in #754 due to changes wrapping in `Sentry.withScope`, which has this [caveat](https://docs.sentry.io/platforms/node/enriching-events/scopes/#using-platformidentifier-namewith-scope-):
> Any exceptions that occur within the callback function for withScope will not be caught, and all errors that occur will be silently ignored and not reported.

Fixes #769