### PR TITLE
Add toggle for bridge queue config

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -117,7 +117,7 @@ metrics:
 queue:
   # (Optional) Message queue / cache configuration options for large scale deployments.
   # For encryption to work, must be set to monolithic mode and have a host & port specified.
-
+  enabled: false
   monolithic: true
   port: 6379
   host: localhost

--- a/docs/advanced/workers.md
+++ b/docs/advanced/workers.md
@@ -13,11 +13,11 @@ You must first have a working redis instance somewhere which can talk between pr
 
 `docker run --name github-bridge-redis -p 6379:6379 -d redis`.
 
-
 The processes should all share the same config, which should contain the correct config enable redis:
 
 ```yaml
 queue:
+  enabled: true
   monolithic: false
   port: 6379
   host: github-bridge-redis
@@ -26,6 +26,7 @@ queue:
 Note that if [encryption](./encryption.md) is enabled, `queue.monolithic` must be set to `true`, as worker mode is not yet supported with encryption.
 
 Once that is done, you can simply start the processes by name using yarn:
+
 ```
 yarn start:webhooks
 yarn start:matrixsender

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -37,7 +37,7 @@ export enum BridgePermissionLevel {
 interface BridgeConfigGitHubYAML {
     enterpriseUrl?: string;
     auth: {
-        id: number|string;
+        id: number | string;
         privateKeyFile: string;
     };
     webhook: {
@@ -58,7 +58,7 @@ interface BridgeConfigGitHubYAML {
 export class BridgeConfigGitHub {
     @configKey("Authentication for the GitHub App.", false)
     readonly auth: {
-        id: number|string;
+        id: number | string;
         privateKeyFile: string;
     };
     @configKey("Webhook settings for the GitHub app.", false)
@@ -124,7 +124,7 @@ export interface BridgeConfigJiraYAML {
         secret: string;
     };
     url?: string,
-    oauth?: BridgeConfigJiraCloudOAuth|BridgeConfigJiraOnPremOAuth;
+    oauth?: BridgeConfigJiraCloudOAuth | BridgeConfigJiraOnPremOAuth;
 
 }
 export class BridgeConfigJira implements BridgeConfigJiraYAML {
@@ -140,7 +140,7 @@ export class BridgeConfigJira implements BridgeConfigJiraYAML {
     @configKey("URL for the instance if using on prem. Ignore if targetting cloud (atlassian.net)", true)
     readonly url?: string;
     @configKey("OAuth settings for connecting users to JIRA. See documentation for more information", true)
-    readonly oauth?: BridgeConfigJiraCloudOAuth|BridgeConfigJiraOnPremOAuth;
+    readonly oauth?: BridgeConfigJiraCloudOAuth | BridgeConfigJiraOnPremOAuth;
 
     @hideKey()
     readonly instanceUrl?: URL;
@@ -158,7 +158,7 @@ export class BridgeConfigJira implements BridgeConfigJiraYAML {
         if (!yaml.oauth) {
             return;
         }
-        let oauth: BridgeConfigJiraCloudOAuth|BridgeConfigJiraOnPremOAuth;
+        let oauth: BridgeConfigJiraCloudOAuth | BridgeConfigJiraOnPremOAuth;
 
         assert.ok(yaml.oauth.redirect_uri);
         // Validate oauth settings
@@ -191,12 +191,12 @@ export interface BridgeConfigGitLabYAML {
         publicUrl?: string;
         secret: string;
     },
-    instances: {[name: string]: GitLabInstance};
+    instances: { [name: string]: GitLabInstance };
     userIdPrefix: string;
 }
 
 export class BridgeConfigGitLab {
-    readonly instances: {[name: string]: GitLabInstance};
+    readonly instances: { [name: string]: GitLabInstance };
     readonly webhook: {
         publicUrl?: string;
         secret: string;
@@ -226,10 +226,10 @@ export class BridgeConfigGitLab {
     }
 
 
-    public getInstanceByProjectUrl(url: string): {name: string, instance: GitLabInstance}|null {
+    public getInstanceByProjectUrl(url: string): { name: string, instance: GitLabInstance } | null {
         for (const [name, instance] of Object.entries(this.instances)) {
             if (url.startsWith(instance.url)) {
-                return {name, instance};
+                return { name, instance };
             }
         }
         return null;
@@ -266,11 +266,13 @@ export class BridgeConfigFeeds {
 export interface BridgeConfigFigma {
     publicUrl: string;
     overrideUserId?: string;
-    instances: {[name: string]: {
-        teamId: string;
-        accessToken: string;
-        passcode: string;
-    }};
+    instances: {
+        [name: string]: {
+            teamId: string;
+            accessToken: string;
+            passcode: string;
+        }
+    };
 }
 
 export interface BridgeGenericWebhooksConfigYAML {
@@ -391,13 +393,14 @@ interface BridgeConfigWebhook {
 }
 
 export interface BridgeConfigQueue {
+    enabled: boolean;
     monolithic: boolean;
     port?: number;
     host?: string;
 }
 
 export interface BridgeConfigLogging {
-    level: "debug"|"info"|"warn"|"error"|"trace";
+    level: "debug" | "info" | "warn" | "error" | "trace";
     json?: boolean;
     colorize?: boolean;
     timestampFormat?: string;
@@ -526,7 +529,7 @@ export class BridgeConfig {
     @hideKey()
     private readonly bridgePermissions: BridgePermissions;
 
-    constructor(configData: BridgeConfigRoot, env?: {[key: string]: string|undefined}) {
+    constructor(configData: BridgeConfigRoot, env?: { [key: string]: string | undefined }) {
         this.bridge = configData.bridge;
         assert.ok(this.bridge);
         this.github = configData.github && new BridgeConfigGitHub(configData.github);
@@ -560,7 +563,7 @@ export class BridgeConfig {
         this.sentry = configData.sentry;
 
         // To allow DEBUG as well as debug
-        this.logging.level = this.logging.level.toLowerCase() as "debug"|"info"|"warn"|"error"|"trace";
+        this.logging.level = this.logging.level.toLowerCase() as "debug" | "info" | "warn" | "error" | "trace";
         if (!ValidLogLevelStrings.includes(this.logging.level)) {
             throw new ConfigError("logging.level", `Logging level is not valid. Must be one of ${ValidLogLevelStrings.join(', ')}`)
         }
@@ -672,7 +675,7 @@ For more details, see https://github.com/matrix-org/matrix-hookshot/issues/594.
     public async prefillMembershipCache(client: MatrixClient) {
         const permissionRooms = this.bridgePermissions.getInterestedRooms();
         log.info(`Prefilling room membership for permissions for ${permissionRooms.length} rooms`);
-        for(const roomEntry of permissionRooms) {
+        for (const roomEntry of permissionRooms) {
             const membership = await client.getJoinedRoomMembers(await client.resolveRoom(roomEntry));
             membership.forEach(userId => this.bridgePermissions.addMemberToCache(roomEntry, userId));
             log.debug(`Found ${membership.length} users for ${roomEntry}`);
@@ -719,7 +722,7 @@ For more details, see https://github.com/matrix-org/matrix-hookshot/issues/594.
     }
 
     public getPublicConfigForService(serviceName: string): Record<string, unknown> {
-        let config: undefined|Record<string, unknown>;
+        let config: undefined | Record<string, unknown>;
         switch (serviceName) {
             case "feeds":
                 config = this.feeds?.publicConfig;
@@ -746,7 +749,7 @@ For more details, see https://github.com/matrix-org/matrix-hookshot/issues/594.
         return config;
     }
 
-    static async parseConfig(filename: string, env: {[key: string]: string|undefined}) {
+    static async parseConfig(filename: string, env: { [key: string]: string | undefined }) {
         const file = await fs.readFile(filename, "utf-8");
         return new BridgeConfig(YAML.parse(file), env);
     }
@@ -760,7 +763,7 @@ export async function parseRegistrationFile(filename: string) {
 
 // Can be called directly
 if (require.main === module) {
-    Logger.configure({console: "info"});
+    Logger.configure({ console: "info" });
     BridgeConfig.parseConfig(process.argv[2] || "config.yml", process.env).then(() => {
         // eslint-disable-next-line no-console
         console.log('Config successfully validated.');

--- a/src/config/Defaults.ts
+++ b/src/config/Defaults.ts
@@ -16,6 +16,7 @@ export const DefaultConfigRoot: BridgeConfigRoot = {
         bindAddress: "127.0.0.1",
     },
     queue: {
+        enabled: false,
         monolithic: true,
         port: 6379,
         host: "localhost",
@@ -184,9 +185,9 @@ function renderSection(doc: YAML.Document, obj: Record<string, unknown>, parentN
         }
 
         if (parentNode) {
-            parentNode.add({key, value: newNode});
+            parentNode.add({ key, value: newNode });
         } else {
-            doc.add({key, value: newNode});
+            doc.add({ key, value: newNode });
         }
     })
 }
@@ -219,14 +220,14 @@ async function renderRegistrationFile(configPath?: string) {
             aliases: [{
                 exclusive: true,
                 regex: `#github_.+:${bridgeConfig.bridge.domain}`
-            },{
+            }, {
                 exclusive: true,
                 regex: `#gitlab_.+:${bridgeConfig.bridge.domain}`
             }],
             users: [{
                 exclusive: true,
                 regex: `@_github_.+:${bridgeConfig.bridge.domain}`
-            },{
+            }, {
                 exclusive: true,
                 regex: `@_gitlab_.+:${bridgeConfig.bridge.domain}`
             }],


### PR DESCRIPTION
With the [2.6.0](https://github.com/matrix-org/matrix-hookshot/releases/tag/2.6.0) release it looks like worker support with Redis was configured. With the Helm Chart using the default configuration, the values.yaml has a configured `queue` block since it's in the `config.sample.yml` file. 

Given that the chart doesn't yet deploy Redis, this results in a broken config by default unless `.Values.hookshot.config.queue` is set to `{}` as user-specified values will be merged on top of chart default values. 

This will also break user configurations if they set up shop using the `config.sample.yml` file as it exists prior to this commit.

We're just adding an `enabled` flag to the `queue` config key and defaulting it to false - That way Hookshot should never expect a Redis service to be available unless explicitly configured and enabled.