### PR TITLE
Try to find an HTML-type link first when parsing atom feeds

### DIFF
--- a/changelog.d/784.bugfix
+++ b/changelog.d/784.bugfix
@@ -1,0 +1,1 @@
+Feeds now tries to find an HTML-type link before falling back to the first link when parsing atom feeds

--- a/src/feeds/parser.rs
+++ b/src/feeds/parser.rs
@@ -81,7 +81,12 @@ fn parse_feed_to_js_result(feed: &Feed) -> JsRssChannel {
             .iter()
             .map(|item| FeedItem {
                 title: Some(item.title().value.clone()),
-                link: item.links().first().map(|f| f.href.clone()),
+                link: item
+                    .links()
+                    .iter()
+                    .find(|l| l.mime_type.as_ref().map_or(false, |t| t == "text/html"))
+                    .or_else(|| item.links().first())
+                    .map(|f| f.href.clone()),
                 id: Some(item.id.clone()),
                 // No equivalent
                 id_is_permalink: false,


### PR DESCRIPTION
<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->
Fixes #781