### PR TITLE
Performance improvements to Feeds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +104,12 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -133,6 +145,22 @@ checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "ctor"
@@ -238,10 +266,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -260,6 +333,45 @@ checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
 dependencies = [
  "mac",
  "new_debug_unreachable",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
 ]
 
 [[package]]
@@ -283,10 +395,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex"
@@ -306,6 +452,77 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "http"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "hyper"
+version = "0.14.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -336,10 +553,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
+name = "js-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "js_int"
@@ -382,6 +634,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "984e109462d46ad18314f10e392c286c3d47bce203088a09012de1015b45b737"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +654,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
@@ -447,6 +711,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "reqwest",
  "rgb",
  "rss",
  "ruma",
@@ -474,6 +739,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "napi"
 version = "2.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +768,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -532,6 +815,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "never"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +864,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +884,50 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "openssl"
+version = "0.10.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.14",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -592,9 +947,9 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -690,6 +1045,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +1146,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +1170,43 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "reqwest"
+version = "0.11.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
 
 [[package]]
 name = "rgb"
@@ -883,16 +1296,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.37.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "security-framework"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -954,16 +1413,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
+name = "slab"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "socket2"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "string_cache"
@@ -1020,6 +1510,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "tendril"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1570,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokio"
+version = "1.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1644,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
 name = "tracing"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1680,12 @@ checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
@@ -1182,10 +1738,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.14",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.14",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "web-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "wildmatch"
@@ -1217,11 +1864,35 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -1230,13 +1901,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -1246,10 +1932,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1258,10 +1956,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1270,10 +1980,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1282,10 +2004,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
 name = "winnow"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-napi = {version="2", features=["serde-json"]}
+napi = {version="2", features=["serde-json", "async"]}
 napi-derive = "2"
 url = "2"
 serde_json = "1"
@@ -20,6 +20,7 @@ hex = "0.4.3"
 rss = "2.0.3"
 atom_syndication = "0.12"
 ruma = { version = "0.8.2", features = ["events", "unstable-sanitize"] }
+reqwest = "0.11"
 
 [build-dependencies]
 napi-build = "1"

--- a/changelog.d/786.bugfix
+++ b/changelog.d/786.bugfix
@@ -1,0 +1,1 @@
+Refactor Hookshot to use Redis for caching of feed information, massively improving memory usage.

--- a/changelog.d/786.bugfix
+++ b/changelog.d/786.bugfix
@@ -1,1 +1,5 @@
 Refactor Hookshot to use Redis for caching of feed information, massively improving memory usage.
+
+Please note that this is a behavioural change: Hookshots configured to use in-memory caching (not Redis),
+will no longer bridge any RSS entries it may have missed during downtime, and will instead perform an initial
+sync instead.

--- a/changelog.d/786.bugfix
+++ b/changelog.d/786.bugfix
@@ -2,4 +2,4 @@ Refactor Hookshot to use Redis for caching of feed information, massively improv
 
 Please note that this is a behavioural change: Hookshots configured to use in-memory caching (not Redis),
 will no longer bridge any RSS entries it may have missed during downtime, and will instead perform an initial
-sync instead.
+sync (not reporting any entries) instead.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -70,6 +70,8 @@ Below is the generated list of Prometheus metrics for Hookshot.
 | nodejs_eventloop_lag_p50_seconds | The 50th percentile of the recorded event loop delays. |  |
 | nodejs_eventloop_lag_p90_seconds | The 90th percentile of the recorded event loop delays. |  |
 | nodejs_eventloop_lag_p99_seconds | The 99th percentile of the recorded event loop delays. |  |
+| nodejs_active_resources | Number of active resources that are currently keeping the event loop alive, grouped by async resource type. | type |
+| nodejs_active_resources_total | Total number of active resources. |  |
 | nodejs_active_handles | Number of active libuv handles grouped by handle type. Every handle type is C++ class name. | type |
 | nodejs_active_handles_total | Total number of active handles. |  |
 | nodejs_active_requests | Number of active libuv requests grouped by request type. Every request type is C++ class name. | type |

--- a/docs/setup/feeds.md
+++ b/docs/setup/feeds.md
@@ -19,6 +19,9 @@ Each feed will only be checked once, regardless of the number of rooms to which 
 
 No entries will be bridged upon the “initial sync” -- all entries that exist at the moment of setup will be considered to be already seen.
 
+Please note that Hookshot **must** be configued with Redis to retain seen entries between restarts. By default, Hookshot will
+run an "initial sync" on each startup and will not process any entries from feeds from before the first sync.
+
 ## Usage
 
 ### Adding new feeds

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "node-emoji": "^1.11.0",
     "nyc": "^15.1.0",
     "p-queue": "^6.6.2",
-    "prom-client": "^14.0.1",
+    "prom-client": "^14.2.0",
     "reflect-metadata": "^0.1.13",
     "source-map-support": "^0.5.21",
     "string-argv": "^0.3.1",
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@codemirror/lang-javascript": "^6.0.2",
-    "@napi-rs/cli": "^2.2.0",
+    "@napi-rs/cli": "^2.13.2",
     "@preact/preset-vite": "^2.2.0",
     "@tsconfig/node18": "^2.0.0",
     "@types/ajv": "^1.0.0",
@@ -105,7 +105,7 @@
     "rimraf": "^3.0.2",
     "sass": "^1.51.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.4",
+    "typescript": "^5.1.3",
     "vite": "^4.1.5",
     "vite-svg-loader": "^4.0.0"
   }

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -777,8 +777,6 @@ export class Bridge {
                 this.connectionManager,
                 this.queue,
                 this.storage,
-                // Use default bot when storing account data
-                this.as.botClient,
             );
         }
 

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -776,6 +776,7 @@ export class Bridge {
                 this.config.feeds,
                 this.connectionManager,
                 this.queue,
+                this.storage,
                 // Use default bot when storing account data
                 this.as.botClient,
             );

--- a/src/Metrics.ts
+++ b/src/Metrics.ts
@@ -7,33 +7,58 @@ const log = new Logger("Metrics");
 export class Metrics {
     public readonly expressRouter = Router();
 
-    public readonly webhooksHttpRequest = new Counter({ name: "hookshot_webhooks_http_request", help: "Number of requests made to the hookshot webhooks handler", labelNames: ["path", "method"], registers: [this.registry]});
-    public readonly provisioningHttpRequest = new Counter({ name: "hookshot_provisioning_http_request", help: "Number of requests made to the hookshot webhooks handler", labelNames: ["path", "method"], registers: [this.registry]});
+    public readonly webhooksHttpRequest;
+    public readonly provisioningHttpRequest;
 
-    public readonly messageQueuePushes = new Counter({ name: "hookshot_queue_event_pushes", help: "Number of events pushed through the queue", labelNames: ["event"], registers: [this.registry]});
-    public readonly connectionsEventFailed = new Counter({ name: "hookshot_connection_event_failed", help: "The number of events that failed to process", labelNames: ["event", "connectionId"], registers: [this.registry]});
-    public readonly connections = new Gauge({ name: "hookshot_connections", help: "The number of active hookshot connections", labelNames: ["service"], registers: [this.registry]});
+    public readonly messageQueuePushes;
+    public readonly connectionsEventFailed;
+    public readonly connections;
 
-    public readonly notificationsPush = new Counter({ name: "hookshot_notifications_push", help: "Number of notifications pushed", labelNames: ["service"], registers: [this.registry]});
-    public readonly notificationsServiceUp = new Gauge({ name: "hookshot_notifications_service_up", help: "Is the notification service up or down", labelNames: ["service"], registers: [this.registry]});
-    public readonly notificationsWatchers = new Gauge({ name: "hookshot_notifications_watchers", help: "Number of notifications watchers running", labelNames: ["service"], registers: [this.registry]});
+    public readonly notificationsPush;
+    public readonly notificationsServiceUp;
+    public readonly notificationsWatchers;
 
-    private readonly matrixApiCalls = new Counter({ name: "matrix_api_calls", help: "The number of Matrix client API calls made", labelNames: ["method"], registers: [this.registry]});
-    private readonly matrixApiCallsFailed = new Counter({ name: "matrix_api_calls_failed", help: "The number of Matrix client API calls which failed", labelNames: ["method"], registers: [this.registry]});
+    private readonly matrixApiCalls;
+    private readonly matrixApiCallsFailed;
 
-    public readonly matrixAppserviceEvents = new Counter({ name: "matrix_appservice_events", help: "The number of events sent over the AS API", labelNames: [], registers: [this.registry]});
-    public readonly matrixAppserviceDecryptionFailed = new Counter({ name: "matrix_appservice_decryption_failed", help: "The number of events sent over the AS API that failed to decrypt", registers: [this.registry]});
+    public readonly matrixAppserviceEvents;
+    public readonly matrixAppserviceDecryptionFailed;
 
-    public readonly feedsCount = new Gauge({ name: "hookshot_feeds_count", help: "The number of RSS feeds that hookshot is subscribed to", labelNames: [], registers: [this.registry]});
-    public readonly feedFetchMs = new Gauge({ name: "hookshot_feeds_fetch_ms", help: "The time taken for hookshot to fetch all feeds", labelNames: [], registers: [this.registry]});
-    public readonly feedsFailing = new Gauge({ name: "hookshot_feeds_failing", help: "The number of RSS feeds that hookshot is failing to read", labelNames: ["reason"], registers: [this.registry]});
-    public readonly feedsCountDeprecated = new Gauge({ name: "feed_count", help: "(Deprecated) The number of RSS feeds that hookshot is subscribed to", labelNames: [], registers: [this.registry]});
-    public readonly feedsFetchMsDeprecated = new Gauge({ name: "feed_fetch_ms", help: "(Deprecated) The time taken for hookshot to fetch all feeds", labelNames: [], registers: [this.registry]});
-    public readonly feedsFailingDeprecated = new Gauge({ name: "feed_failing", help: "(Deprecated) The number of RSS feeds that hookshot is failing to read", labelNames: ["reason"], registers: [this.registry]});
+    public readonly feedsCount;
+    public readonly feedFetchMs;
+    public readonly feedsFailing;
+    public readonly feedsCountDeprecated;
+    public readonly feedsFetchMsDeprecated;
+    public readonly feedsFailingDeprecated;
 
 
     constructor(private registry: Registry = register) {
         this.expressRouter.get('/metrics', this.metricsFunc.bind(this));
+
+        this.webhooksHttpRequest = new Counter({ name: "hookshot_webhooks_http_request", help: "Number of requests made to the hookshot webhooks handler", labelNames: ["path", "method"], registers: [this.registry]});
+        this.provisioningHttpRequest = new Counter({ name: "hookshot_provisioning_http_request", help: "Number of requests made to the hookshot webhooks handler", labelNames: ["path", "method"], registers: [this.registry]});
+
+        this.messageQueuePushes = new Counter({ name: "hookshot_queue_event_pushes", help: "Number of events pushed through the queue", labelNames: ["event"], registers: [this.registry]});
+        this.connectionsEventFailed = new Counter({ name: "hookshot_connection_event_failed", help: "The number of events that failed to process", labelNames: ["event", "connectionId"], registers: [this.registry]});
+        this.connections = new Gauge({ name: "hookshot_connections", help: "The number of active hookshot connections", labelNames: ["service"], registers: [this.registry]});
+
+        this.notificationsPush = new Counter({ name: "hookshot_notifications_push", help: "Number of notifications pushed", labelNames: ["service"], registers: [this.registry]});
+        this.notificationsServiceUp = new Gauge({ name: "hookshot_notifications_service_up", help: "Is the notification service up or down", labelNames: ["service"], registers: [this.registry]});
+        this.notificationsWatchers = new Gauge({ name: "hookshot_notifications_watchers", help: "Number of notifications watchers running", labelNames: ["service"], registers: [this.registry]});
+
+        this.matrixApiCalls = new Counter({ name: "matrix_api_calls", help: "The number of Matrix client API calls made", labelNames: ["method"], registers: [this.registry]});
+        this.matrixApiCallsFailed = new Counter({ name: "matrix_api_calls_failed", help: "The number of Matrix client API calls which failed", labelNames: ["method"], registers: [this.registry]});
+
+        this.matrixAppserviceEvents = new Counter({ name: "matrix_appservice_events", help: "The number of events sent over the AS API", labelNames: [], registers: [this.registry]});
+        this.matrixAppserviceDecryptionFailed = new Counter({ name: "matrix_appservice_decryption_failed", help: "The number of events sent over the AS API that failed to decrypt", registers: [this.registry]});
+
+        this.feedsCount = new Gauge({ name: "hookshot_feeds_count", help: "The number of RSS feeds that hookshot is subscribed to", labelNames: [], registers: [this.registry]});
+        this.feedFetchMs = new Gauge({ name: "hookshot_feeds_fetch_ms", help: "The time taken for hookshot to fetch all feeds", labelNames: [], registers: [this.registry]});
+        this.feedsFailing = new Gauge({ name: "hookshot_feeds_failing", help: "The number of RSS feeds that hookshot is failing to read", labelNames: ["reason"], registers: [this.registry]});
+        this.feedsCountDeprecated = new Gauge({ name: "feed_count", help: "(Deprecated) The number of RSS feeds that hookshot is subscribed to", labelNames: [], registers: [this.registry]});
+        this.feedsFetchMsDeprecated = new Gauge({ name: "feed_fetch_ms", help: "(Deprecated) The time taken for hookshot to fetch all feeds", labelNames: [], registers: [this.registry]});
+        this.feedsFailingDeprecated = new Gauge({ name: "feed_failing", help: "(Deprecated) The number of RSS feeds that hookshot is failing to read", labelNames: ["reason"], registers: [this.registry]});
+
         collectDefaultMetrics({
             register: this.registry,
         })

--- a/src/Stores/MemoryStorageProvider.ts
+++ b/src/Stores/MemoryStorageProvider.ts
@@ -34,7 +34,7 @@ export class MemoryStorageProvider extends MSP implements IBridgeStorageProvider
     }
 
     async hasSeenFeedGuid(url: string, guid: string): Promise<boolean> {
-        return this.feedGuids.get(url)?.has(guid) ?? false;
+        return this.feedGuids.get(url)?.includes(guid) ?? false;
     }
 
     public async setGithubIssue(repo: string, issueNumber: string, data: IssuesGetResponseData, scope = "") {

--- a/src/Stores/MemoryStorageProvider.ts
+++ b/src/Stores/MemoryStorageProvider.ts
@@ -17,7 +17,7 @@ export class MemoryStorageProvider extends MSP implements IBridgeStorageProvider
         super();
     }
 
-    async storeFeedGuid(url: string, ...guids: string[]): Promise<void> {
+    async storeFeedGuids(url: string, ...guids: string[]): Promise<void> {
         let set = this.feedGuids.get(url);
         if (!set) {
             set = []

--- a/src/Stores/MemoryStorageProvider.ts
+++ b/src/Stores/MemoryStorageProvider.ts
@@ -11,26 +11,27 @@ export class MemoryStorageProvider extends MSP implements IBridgeStorageProvider
     private figmaCommentIds: Map<string, string> = new Map();
     private widgetSessions: Map<string, ProvisionSession> = new Map();
     private storedFiles = new QuickLRU<string, string>({ maxSize: 128 });
+    private feedGuids = new Map<string, Set<string>>();
 
     constructor() {
         super();
     }
 
-    storeAllFeedGuids(data: { [url: string]: string[]; }): Promise<void> {
-        throw new Error("Method not implemented.");
-    }
-    storeFeedGuid(url: string, string: string): Promise<void> {
-        throw new Error("Method not implemented.");
-    }
-    hasSeenFeed(url: string): Promise<boolean> {
-        throw new Error("Method not implemented.");
-    }
-    hasSeenFeedGuid(url: string, guid: string): Promise<boolean> {
-        throw new Error("Method not implemented.");
+    async storeFeedGuid(url: string, guid: string): Promise<void> {
+        let set = this.feedGuids.get(url);
+        if (!set) {
+            set = new Set<string>();
+            this.feedGuids.set(url, set);
+        }
+        set.add(guid);
     }
 
-    getAllFeedGuids(urls: string[]): Promise<Record<string, string[]>> {
-        throw new Error("Method not implemented.");
+    async hasSeenFeed(url: string): Promise<boolean> {
+        return this.feedGuids.has(url);
+    }
+
+    async hasSeenFeedGuid(url: string, guid: string): Promise<boolean> {
+        return this.feedGuids.get(url)?.has(guid) ?? false;
     }
 
     public async setGithubIssue(repo: string, issueNumber: string, data: IssuesGetResponseData, scope = "") {

--- a/src/Stores/MemoryStorageProvider.ts
+++ b/src/Stores/MemoryStorageProvider.ts
@@ -17,13 +17,13 @@ export class MemoryStorageProvider extends MSP implements IBridgeStorageProvider
         super();
     }
 
-    async storeFeedGuid(url: string, guid: string): Promise<void> {
+    async storeFeedGuid(url: string, ...guids: string[]): Promise<void> {
         let set = this.feedGuids.get(url);
         if (!set) {
             set = []
             this.feedGuids.set(url, set);
         }
-        set.splice(0, 0, guid);
+        set.unshift(...guids);
         while (set.length > MAX_FEED_ITEMS) {
             set.pop();
         } 

--- a/src/Stores/MemoryStorageProvider.ts
+++ b/src/Stores/MemoryStorageProvider.ts
@@ -15,6 +15,24 @@ export class MemoryStorageProvider extends MSP implements IBridgeStorageProvider
     constructor() {
         super();
     }
+
+    storeAllFeedGuids(data: { [url: string]: string[]; }): Promise<void> {
+        throw new Error("Method not implemented.");
+    }
+    storeFeedGuid(url: string, string: string): Promise<void> {
+        throw new Error("Method not implemented.");
+    }
+    hasSeenFeed(url: string): Promise<boolean> {
+        throw new Error("Method not implemented.");
+    }
+    hasSeenFeedGuid(url: string, guid: string): Promise<boolean> {
+        throw new Error("Method not implemented.");
+    }
+
+    getAllFeedGuids(urls: string[]): Promise<Record<string, string[]>> {
+        throw new Error("Method not implemented.");
+    }
+
     public async setGithubIssue(repo: string, issueNumber: string, data: IssuesGetResponseData, scope = "") {
         this.issues.set(`${scope}${repo}/${issueNumber}`, data);
     }

--- a/src/Stores/RedisStorageProvider.ts
+++ b/src/Stores/RedisStorageProvider.ts
@@ -204,7 +204,7 @@ export class RedisStorageProvider extends RedisStorageContextualProvider impleme
         await this.redis.set(STORED_FILES_KEY + key, value);
     }
 
-    public async storeFeedGuid(url: string, ...guid: string[]): Promise<void> {
+    public async storeFeedGuids(url: string, ...guid: string[]): Promise<void> {
         const feedKey = `${FEED_GUIDS}${url}`;
         await this.redis.lpush(feedKey, ...guid);
         await this.redis.ltrim(feedKey, 0, MAX_FEED_ITEMS);

--- a/src/Stores/StorageProvider.ts
+++ b/src/Stores/StorageProvider.ts
@@ -15,4 +15,10 @@ export interface IBridgeStorageProvider extends IAppserviceStorageProvider, ISto
     getFigmaCommentEventId(roomId: string, figmaCommentId: string): Promise<string|null>;
     getStoredTempFile(key: string): Promise<string|null>;
     setStoredTempFile(key: string, value: string): Promise<void>;
+    storeAllFeedGuids(data: {[url: string]: string[]}): Promise<void>;
+    getAllFeedGuids(urls: string[]): Promise<Record<string, string[]>>;
+    storeFeedGuid(url: string, ...guid: string[]): Promise<void>;
+    hasSeenFeed(url: string, ...guid: string[]): Promise<boolean>;
+    hasSeenFeedGuid(url: string, guid: string): Promise<boolean>;
+    
 }

--- a/src/Stores/StorageProvider.ts
+++ b/src/Stores/StorageProvider.ts
@@ -2,6 +2,13 @@ import { ProvisioningStore } from "matrix-appservice-bridge";
 import { IAppserviceStorageProvider, IStorageProvider } from "matrix-bot-sdk";
 import { IssuesGetResponseData } from "../github/Types";
 
+// Some RSS feeds can return a very small number of items then bounce
+// back to their "normal" size, so we cannot just clobber the recent GUID list per request or else we'll
+// forget what we sent and resend it. Instead, we'll keep 2x the max number of items that we've ever
+// seen from this feed, up to a max of 10,000.
+// Adopted from https://github.com/matrix-org/go-neb/blob/babb74fa729882d7265ff507b09080e732d060ae/services/rssbot/rssbot.go#L304
+export const MAX_FEED_ITEMS = 10_000;
+
 export interface IBridgeStorageProvider extends IAppserviceStorageProvider, IStorageProvider, ProvisioningStore {
     connect?(): Promise<void>;
     disconnect?(): Promise<void>;

--- a/src/Stores/StorageProvider.ts
+++ b/src/Stores/StorageProvider.ts
@@ -22,7 +22,7 @@ export interface IBridgeStorageProvider extends IAppserviceStorageProvider, ISto
     getFigmaCommentEventId(roomId: string, figmaCommentId: string): Promise<string|null>;
     getStoredTempFile(key: string): Promise<string|null>;
     setStoredTempFile(key: string, value: string): Promise<void>;
-    storeFeedGuid(url: string, ...guid: string[]): Promise<void>;
+    storeFeedGuids(url: string, ...guid: string[]): Promise<void>;
     hasSeenFeed(url: string, ...guid: string[]): Promise<boolean>;
     hasSeenFeedGuid(url: string, guid: string): Promise<boolean>;
 }

--- a/src/Stores/StorageProvider.ts
+++ b/src/Stores/StorageProvider.ts
@@ -15,10 +15,7 @@ export interface IBridgeStorageProvider extends IAppserviceStorageProvider, ISto
     getFigmaCommentEventId(roomId: string, figmaCommentId: string): Promise<string|null>;
     getStoredTempFile(key: string): Promise<string|null>;
     setStoredTempFile(key: string, value: string): Promise<void>;
-    storeAllFeedGuids(data: {[url: string]: string[]}): Promise<void>;
-    getAllFeedGuids(urls: string[]): Promise<Record<string, string[]>>;
     storeFeedGuid(url: string, ...guid: string[]): Promise<void>;
     hasSeenFeed(url: string, ...guid: string[]): Promise<boolean>;
     hasSeenFeedGuid(url: string, guid: string): Promise<boolean>;
-    
 }

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -104,7 +104,7 @@ export class FeedReader {
     get sleepingInterval() {
         return (
             // Calculate the number of MS to wait in between feeds.
-            (this.config.pollIntervalSeconds * 1000) / (this.feedQueue.length ?? 1)
+            (this.config.pollIntervalSeconds * 1000) / (this.feedQueue.length || 1)
             // And multiply by the number of concurrent readers
         ) * this.config.pollConcurrency;
     }
@@ -178,7 +178,6 @@ export class FeedReader {
                 pollTimeoutSeconds: this.config.pollTimeoutSeconds,
                 etag,
                 lastModified,
-                // TODO: Make this static in Rust somehow.
                 userAgent: UserAgent,
             });
 

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -241,7 +241,7 @@ export class FeedReader {
                 }
     
                 if (seenEntriesChanged) {
-                    await this.storage.storeFeedGuid(url, ...newGuids);
+                    await this.storage.storeFeedGuids(url, ...newGuids);
                 }
     
             }

--- a/tests/FeedReader.spec.ts
+++ b/tests/FeedReader.spec.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse, AxiosStatic } from "axios";
 import { expect } from "chai";
 import EventEmitter from "events";
 import { BridgeConfigFeeds } from "../src/config/Config";
@@ -7,6 +6,8 @@ import { IConnection } from "../src/Connections";
 import { FeedEntry, FeedReader } from "../src/feeds/FeedReader";
 import { MessageQueue, MessageQueueMessage } from "../src/MessageQueue";
 import { MemoryStorageProvider } from "../src/Stores/MemoryStorageProvider";
+import { Server, createServer } from 'http';
+import { AddressInfo } from "net";
 
 class MockConnectionManager extends EventEmitter {
     constructor(
@@ -38,39 +39,41 @@ class MockMessageQueue extends EventEmitter implements MessageQueue {
     }
 }
 
-class MockHttpClient {
-    constructor(public response: AxiosResponse) {}
-
-    get(): Promise<AxiosResponse> {
-        return Promise.resolve(this.response);
-    }
-}
-
-const FEED_URL = 'http://test/';
-
-function constructFeedReader(feedResponse: () => {headers: Record<string,string>, data: string}) {
+async function constructFeedReader(feedResponse: () => {headers: Record<string,string>, data: string}) {
+    const httpServer = await new Promise<Server>(resolve => {
+        const srv = createServer((_req, res) => {
+            res.writeHead(200);
+            const { headers, data } = feedResponse();
+            Object.entries(headers).forEach(([key,value]) => {
+                res.setHeader(key, value);
+            });
+            res.write(data);
+            res.end();
+        }).listen(0, '127.0.0.1', () => {
+            resolve(srv);
+        });
+    });
+    const address = httpServer.address() as AddressInfo;
+    const feedUrl = `http://127.0.0.1:${address.port}/`
     const config = new BridgeConfigFeeds({
         enabled: true,
         pollIntervalSeconds: 1,
         pollTimeoutSeconds: 1,
     });
-    const cm = new MockConnectionManager([{ feedUrl: FEED_URL } as unknown as IConnection]) as unknown as ConnectionManager
+    const cm = new MockConnectionManager([{ feedUrl } as unknown as IConnection]) as unknown as ConnectionManager
     const mq = new MockMessageQueue();
+    const storage = new MemoryStorageProvider();
+    // Ensure we don't initial sync by storing a guid.
+    await storage.storeFeedGuid(feedUrl, '-test-guid-');
     const feedReader = new FeedReader(
-        config, cm, mq,
-        new MemoryStorageProvider(),
-        {
-            getAccountData: <T>() => Promise.resolve({ [FEED_URL]: [] } as unknown as T),
-            setAccountData: () => Promise.resolve(),
-        },
-        new MockHttpClient({ ...feedResponse() } as AxiosResponse) as unknown as AxiosStatic,
+        config, cm, mq, storage,
     );
-    return {config, cm, mq, feedReader};   
+    return {config, cm, mq, feedReader, feedUrl, httpServer};   
 }
 
 describe("FeedReader", () => {
     it("should correctly handle empty titles", async () => {
-        const { mq, feedReader} = constructFeedReader(() => ({
+        const { mq, feedReader, httpServer } = await constructFeedReader(() => ({
             headers: {}, data: `
             <?xml version="1.0" encoding="UTF-8"?>
             <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
@@ -86,6 +89,8 @@ describe("FeedReader", () => {
         `
         }));
 
+        after(() => httpServer.close());
+
         const event: any = await new Promise((resolve) => {
             mq.on('pushed', (data) => { resolve(data); feedReader.stop() });
         });
@@ -95,7 +100,7 @@ describe("FeedReader", () => {
         expect(event.data.title).to.equal(null);
     });
     it("should handle RSS 2.0 feeds", async () => {
-        const { mq, feedReader} = constructFeedReader(() => ({
+        const { mq, feedReader, httpServer } = await constructFeedReader(() => ({
             headers: {}, data: `
             <?xml version="1.0" encoding="UTF-8" ?>
                 <rss version="2.0">
@@ -120,6 +125,8 @@ describe("FeedReader", () => {
         `
         }));
 
+        after(() => httpServer.close());
+
         const event: MessageQueueMessage<FeedEntry> = await new Promise((resolve) => {
             mq.on('pushed', (data) => { resolve(data); feedReader.stop() });
         });
@@ -133,7 +140,7 @@ describe("FeedReader", () => {
         expect(event.data.pubdate).to.equal('Sun, 6 Sep 2009 16:20:00 +0000');
     });
     it("should handle RSS feeds with a permalink url", async () => {
-        const { mq, feedReader} = constructFeedReader(() => ({
+        const { mq, feedReader, httpServer } = await constructFeedReader(() => ({
             headers: {}, data: `
             <?xml version="1.0" encoding="UTF-8" ?>
                 <rss version="2.0">
@@ -157,6 +164,8 @@ describe("FeedReader", () => {
         `
         }));
 
+        after(() => httpServer.close());
+
         const event: MessageQueueMessage<FeedEntry> = await new Promise((resolve) => {
             mq.on('pushed', (data) => { resolve(data); feedReader.stop() });
         });
@@ -170,7 +179,7 @@ describe("FeedReader", () => {
         expect(event.data.pubdate).to.equal('Sun, 6 Sep 2009 16:20:00 +0000');
     });
     it("should handle Atom feeds", async () => {
-        const { mq, feedReader} = constructFeedReader(() => ({
+        const { mq, feedReader, httpServer } = await constructFeedReader(() => ({
             headers: {}, data: `
             <?xml version="1.0" encoding="utf-8"?>
             <feed xmlns="http://www.w3.org/2005/Atom">
@@ -198,6 +207,8 @@ describe("FeedReader", () => {
         `
         }));
 
+        after(() => httpServer.close());
+
         const event: MessageQueueMessage<FeedEntry> = await new Promise((resolve) => {
             mq.on('pushed', (data) => { resolve(data); feedReader.stop() });
         });
@@ -211,7 +222,7 @@ describe("FeedReader", () => {
         expect(event.data.pubdate).to.equal('Sat, 13 Dec 2003 18:30:02 +0000');
     });
     it("should not duplicate feed entries", async () => {
-        const { mq, feedReader} = constructFeedReader(() => ({
+        const { mq, feedReader, httpServer, feedUrl } = await constructFeedReader(() => ({
             headers: {}, data: `
             <?xml version="1.0" encoding="utf-8"?>
             <feed xmlns="http://www.w3.org/2005/Atom">
@@ -229,11 +240,13 @@ describe("FeedReader", () => {
         `
         }));
 
+        after(() => httpServer.close());
+
         const events: MessageQueueMessage<FeedEntry>[] = [];
         mq.on('pushed', (data) => { if (data.eventName === 'feed.entry') {events.push(data);} });
-        await feedReader.pollFeed(FEED_URL);
-        await feedReader.pollFeed(FEED_URL);
-        await feedReader.pollFeed(FEED_URL);
+        await feedReader.pollFeed(feedUrl);
+        await feedReader.pollFeed(feedUrl);
+        await feedReader.pollFeed(feedUrl);
         feedReader.stop();
         expect(events).to.have.lengthOf(1);
     });

--- a/tests/FeedReader.spec.ts
+++ b/tests/FeedReader.spec.ts
@@ -6,6 +6,7 @@ import { ConnectionManager } from "../src/ConnectionManager";
 import { IConnection } from "../src/Connections";
 import { FeedEntry, FeedReader } from "../src/feeds/FeedReader";
 import { MessageQueue, MessageQueueMessage } from "../src/MessageQueue";
+import { MemoryStorageProvider } from "../src/Stores/MemoryStorageProvider";
 
 class MockConnectionManager extends EventEmitter {
     constructor(
@@ -57,6 +58,7 @@ function constructFeedReader(feedResponse: () => {headers: Record<string,string>
     const mq = new MockMessageQueue();
     const feedReader = new FeedReader(
         config, cm, mq,
+        new MemoryStorageProvider(),
         {
             getAccountData: <T>() => Promise.resolve({ [FEED_URL]: [] } as unknown as T),
             setAccountData: () => Promise.resolve(),

--- a/tests/FeedReader.spec.ts
+++ b/tests/FeedReader.spec.ts
@@ -64,7 +64,7 @@ async function constructFeedReader(feedResponse: () => {headers: Record<string,s
     const mq = new MockMessageQueue();
     const storage = new MemoryStorageProvider();
     // Ensure we don't initial sync by storing a guid.
-    await storage.storeFeedGuid(feedUrl, '-test-guid-');
+    await storage.storeFeedGuids(feedUrl, '-test-guid-');
     const feedReader = new FeedReader(
         config, cm, mq, storage,
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -919,10 +919,10 @@
   resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-4.1.14.tgz#45b45f2fcd8fe766950e5abc40efde94b4348efd"
   integrity sha512-pndsgd4jXIGcgWKPXkN5AL1rdwhgQpLXWyK25jb42SUaeujs/GhRK8+Q4W97RTiCirf/DoaahcTI/3Op6+/gfw==
 
-"@napi-rs/cli@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@napi-rs/cli/-/cli-2.2.0.tgz#0129406192c2dfff6e8fc3de0c8be1d2ec286e3f"
-  integrity sha512-lXOKq0EZWztzHIlpXhKG0Nrv/PDZAl/yBsqQTG0aDfdjGCJudtPgWLR7zzaJoYzkkdFJo0r+teYYzgC+cXB4KQ==
+"@napi-rs/cli@^2.13.2":
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/cli/-/cli-2.16.1.tgz#912e1169be6ff8bb5e1e22bb702adcc5e73e232b"
+  integrity sha512-L0Gr5iEQIDEbvWdDr1HUaBOxBSHL1VZhWSk1oryawoT8qJIY+KGfLFelU+Qma64ivCPbxYpkfPoKYVG3rcoGIA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -3303,10 +3303,15 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.14.0, follow-redirects@^1.14.4:
+follow-redirects@^1.14.0:
   version "1.14.8"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
   integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
+
+follow-redirects@^1.14.4:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 follow-redirects@^1.14.9:
   version "1.15.1"
@@ -5145,14 +5150,7 @@ process-on-spawn@^1.0.0:
   dependencies:
     fromentries "^1.2.0"
 
-prom-client@^14.0.1:
-  version "14.0.1"
-  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.0.1.tgz#bdd9583e02ec95429677c0e013712d42ef1f86a8"
-  integrity sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==
-  dependencies:
-    tdigest "^0.1.1"
-
-prom-client@^14.1.0:
+prom-client@^14.1.0, prom-client@^14.2.0:
   version "14.2.0"
   resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.2.0.tgz#ca94504e64156f6506574c25fb1c34df7812cf11"
   integrity sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==
@@ -6027,10 +6025,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
+  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Fixes #789 

This PR does several important perf fixes to the feed reader system. In particular we're trying to fix memory / storage consumption. To achieve this, the PR does two things:

- We drop the account data used by feed reader entirely, instead using Redis. This avoids having to store things in Hookshot's memory, and doing expensive load/save operations. Deployments of Hookshot using an in-memory storage provider will always initial sync on startup. This is a regression, but in practice it only means you miss items that were published during downtime. Anyone wishing for better reliability should be using Redis.
- We now read the feeds from Rust, avoiding the memory cost of shifting potentially huge blocks of XML across the native module boundary.
 