### PR TITLE
Ensure all forms of request failure on a feed are not treated as a parsing failure by metrics

### DIFF
--- a/changelog.d/816.bugfix
+++ b/changelog.d/816.bugfix
@@ -1,0 +1,1 @@
+Fix feed metrics treating request failures as parsing failures.

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -240,7 +240,7 @@ export class FeedReader {
                     this.queue.push<FeedEntry>({ eventName: 'feed.entry', sender: 'FeedReader', data: entry });
                 }
     
-                if (seenEntriesChanged) {
+                if (seenEntriesChanged && newGuids.length) {
                     await this.storage.storeFeedGuids(url, ...newGuids);
                 }
     

--- a/src/feeds/parser.rs
+++ b/src/feeds/parser.rs
@@ -226,10 +226,13 @@ pub async fn js_read_feed(url: String, options: ReadFeedOptions) -> Result<FeedR
                 }),
                 status => Err(JsError::new(
                     Status::Unknown,
-                    format!("Failed to fetch feed due to HTTP {}", status),
+                    format!("Failed to fetch feed due to HTTP status {}", status),
                 )),
             }
         }
-        Err(err) => Err(JsError::new(Status::Unknown, err)),
+        Err(err) => Err(JsError::new(
+            Status::Unknown,
+            format!("Failed to fetch feed due to HTTP error {}", err),
+        ))
     }
 }

--- a/src/feeds/parser.rs
+++ b/src/feeds/parser.rs
@@ -233,6 +233,6 @@ pub async fn js_read_feed(url: String, options: ReadFeedOptions) -> Result<FeedR
         Err(err) => Err(JsError::new(
             Status::Unknown,
             format!("Failed to fetch feed due to HTTP error {}", err),
-        ))
+        )),
     }
 }


### PR DESCRIPTION
Things like TLS fails and timeouts were coming through as parsing failures, which is unfortunate because it was incorrectly highlighting a bug with our parser.

We also ensure that a `lpush` is not attempted with a empty array. 