### PR TITLE
Replace vm2 with quickjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,11 +65,11 @@
     "nyc": "^15.1.0",
     "p-queue": "^6.6.2",
     "prom-client": "^14.2.0",
+    "quickjs-emscripten": "^0.23.0",
     "reflect-metadata": "^0.1.13",
     "source-map-support": "^0.5.21",
     "string-argv": "^0.3.1",
     "tiny-typed-emitter": "^2.1.0",
-    "vm2": "^3.9.18",
     "winston": "^3.3.3",
     "xml2js": "^0.5.0",
     "yaml": "^2.2.2"

--- a/src/App/BridgeApp.ts
+++ b/src/App/BridgeApp.ts
@@ -10,6 +10,7 @@ import { LogService } from "matrix-bot-sdk";
 import { getAppservice } from "../appservice";
 import BotUsersManager from "../Managers/BotUsersManager";
 import * as Sentry from '@sentry/node';
+import { GenericHookConnection } from "../Connections";
 
 Logger.configure({console: "info"});
 const log = new Logger("App");
@@ -47,6 +48,10 @@ async function start() {
             includeLocalVariables: true,
         });
         log.info("Sentry reporting enabled");
+    }
+
+    if (config.generic?.allowJsTransformationFunctions) {
+        await GenericHookConnection.initaliseQuickJS();
     }
 
     const botUsersManager = new BotUsersManager(config, appservice);

--- a/src/Connections/GenericHook.ts
+++ b/src/Connections/GenericHook.ts
@@ -321,9 +321,11 @@ export class GenericHookConnection extends BaseConnection implements IConnection
             const ctxResult = ctx.evalCode(`const data = ${JSON.stringify(data)};\n\n${this.transformationFunction}`);
     
             if (ctxResult.error){
-                throw Error("Transformation failed to run " + ctxResult.error);
+                const err = ctx.dump(ctxResult.error);
+                throw Error("Transformation failed to run " + err);
             } else {
-                result = ctx.dump(result.value);
+                const value = ctx.getProp(ctx.global, 'result');
+                result = ctx.dump(value);
             }
         } finally {
             ctx.dispose();

--- a/tests/connections/GenericHookTest.ts
+++ b/tests/connections/GenericHookTest.ts
@@ -56,6 +56,9 @@ function handleMessage(mq: LocalMQ): Promise<IMatrixSendMessage> {
 }
 
 describe("GenericHookConnection", () => {
+    before(async () => {
+        await GenericHookConnection.initaliseQuickJS();
+    })
     it("will handle simple hook events", async () => {
         const [connection, mq] = createGenericHook();
         await testSimpleWebhook(connection, mq, "data");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1754,12 +1754,12 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn-walk@^8.1.1, acorn-walk@^8.2.0:
+acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.4.1, acorn@^8.7.0:
+acorn@^8.4.1:
   version "8.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
@@ -5240,6 +5240,11 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+quickjs-emscripten@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#94f412d0ee5f3021fc12ddf6c0b00bd8ce0d28b9"
+  integrity sha512-CIP+NDRYDDqbT3cTiN8Bon1wsZ7IgISVYCJHYsPc86oxszpepVMPXFfttyQgn1u1okg1HPnCnM7Xv1LrCO/VmQ==
+
 railroad-diagrams@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
@@ -6165,14 +6170,6 @@ vite@^4.1.5:
     rollup "^3.10.0"
   optionalDependencies:
     fsevents "~2.3.2"
-
-vm2@^3.9.18:
-  version "3.9.18"
-  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.18.tgz#d919848bee191a0410c5cc1c5aac58adfd03ce9a"
-  integrity sha512-iM7PchOElv6Uv6Q+0Hq7dcgDtWWT6SizYqVcvol+1WQc+E9HlgTCnPozbQNSP3yDV9oXHQOEQu530w2q/BCVZg==
-  dependencies:
-    acorn "^8.7.0"
-    acorn-walk "^8.2.0"
 
 w3c-keyname@^2.2.4:
   version "2.2.6"


### PR DESCRIPTION
`vm2` is no longer supported (https://github.com/patriksimek/vm2#%EF%B8%8F-project-discontinued-%EF%B8%8F). In the interests of keeping the experimental transformation function code safe and secure, we've going to try out quickjs within a wasm wrapper to ensure things are still safe to run.

This passes our basic sanity tests, but it will likely result in some breakages. 