### PR TITLE
Ensure sample config only defaults to bare minimum requirements

### DIFF
--- a/changelog.d/826.misc
+++ b/changelog.d/826.misc
@@ -1,0 +1,1 @@
+Sample config now comments out optional parameters by default.

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -2,185 +2,27 @@
 
 bridge:
   # Basic homeserver configuration
-
   domain: example.com
   url: http://localhost:8008
   mediaUrl: https://example.com
   port: 9993
   bindAddress: 127.0.0.1
-github:
-  # (Optional) Configure this to enable GitHub support
-
-  auth:
-    # Authentication for the GitHub App.
-
-    id: 123
-    privateKeyFile: github-key.pem
-  webhook:
-    # Webhook settings for the GitHub app.
-
-    secret: secrettoken
-  oauth:
-    # (Optional) Settings for allowing users to sign in via OAuth.
-
-    client_id: foo
-    client_secret: bar
-    redirect_uri: https://example.com/bridge_oauth/
-  defaultOptions:
-    # (Optional) Default options for GitHub connections.
-
-    showIssueRoomLink: false
-    hotlinkIssues:
-      prefix: "#"
-  userIdPrefix:
-    # (Optional) Prefix used when creating ghost users for GitHub accounts.
-
-    _github_
-gitlab:
-  # (Optional) Configure this to enable GitLab support
-
-  instances:
-    gitlab.com:
-      url: https://gitlab.com
-  webhook:
-    secret: secrettoken
-    publicUrl: https://example.com/hookshot/
-  userIdPrefix:
-    # (Optional) Prefix used when creating ghost users for GitLab accounts.
-
-    _gitlab_
-  commentDebounceMs:
-    # (Optional) Aggregate comments by waiting this many miliseconds before posting them to Matrix. Defaults to 5000 (5 seconds)
-
-    5000
-figma:
-  # (Optional) Configure this to enable Figma support
-
-  publicUrl: https://example.com/hookshot/
-  instances:
-    your-instance:
-      teamId: your-team-id
-      accessToken: your-personal-access-token
-      passcode: your-webhook-passcode
-jira:
-  # (Optional) Configure this to enable Jira support. Only specify `url` if you are using a On Premise install (i.e. not atlassian.com)
-
-  webhook:
-    # Webhook settings for JIRA
-
-    secret: secrettoken
-  oauth:
-    # (Optional) OAuth settings for connecting users to JIRA. See documentation for more information
-
-    client_id: foo
-    client_secret: bar
-    redirect_uri: https://example.com/bridge_oauth/
-generic:
-  # (Optional) Support for generic webhook events.
-  #'allowJsTransformationFunctions' will allow users to write short transformation snippets in code, and thus is unsafe in untrusted environments
-
-
-  enabled: false
-  enableHttpGet: false
-  urlPrefix: https://example.com/webhook/
-  userIdPrefix: _webhooks_
-  allowJsTransformationFunctions: false
-  waitForComplete: false
-feeds:
-  # (Optional) Configure this to enable RSS/Atom feed support
-
-  enabled: false
-  pollConcurrency: 4
-  pollIntervalSeconds: 600
-  pollTimeoutSeconds: 30
-provisioning:
-  # (Optional) Provisioning API for integration managers
-
-  secret: "!secretToken"
 passFile:
   # A passkey used to encrypt tokens stored inside the bridge.
   # Run openssl genpkey -out passkey.pem -outform PEM -algorithm RSA -pkeyopt rsa_keygen_bits:4096 to generate
-
   passkey.pem
-bot:
-  # (Optional) Define profile information for the bot user
-
-  displayname: Hookshot Bot
-  avatar: mxc://half-shot.uk/2876e89ccade4cb615e210c458e2a7a6883fe17d
-serviceBots:
-  # (Optional) Define additional bot users for specific services
-
-  - localpart: feeds
-    displayname: Feeds
-    avatar: ./assets/feeds_avatar.png
-    prefix: "!feeds"
-    service: feeds
-metrics:
-  # (Optional) Prometheus metrics support
-
-  enabled: true
-queue:
-  # (Optional) Message queue / cache configuration options for large scale deployments.
-  # For encryption to work, must be set to monolithic mode and have a host & port specified.
-
-  monolithic: true
-  port: 6379
-  host: localhost
 logging:
-  # (Optional) Logging settings. You can have a severity debug,info,warn,error
-
+  # Logging settings. You can have a severity debug,info,warn,error
   level: info
   colorize: true
   json: false
   timestampFormat: HH:mm:ss:SSS
-widgets:
-  # (Optional) EXPERIMENTAL support for complimentary widgets
-
-  addToAdminRooms: false
-  disallowedIpRanges:
-    - 127.0.0.0/8
-    - 10.0.0.0/8
-    - 172.16.0.0/12
-    - 192.168.0.0/16
-    - 100.64.0.0/10
-    - 192.0.0.0/24
-    - 169.254.0.0/16
-    - 192.88.99.0/24
-    - 198.18.0.0/15
-    - 192.0.2.0/24
-    - 198.51.100.0/24
-    - 203.0.113.0/24
-    - 224.0.0.0/4
-    - ::1/128
-    - fe80::/10
-    - fc00::/7
-    - 2001:db8::/32
-    - ff00::/8
-    - fec0::/10
-  roomSetupWidget:
-    addOnInvite: false
-  publicUrl: https://example.com/widgetapi/v1/static/
-  branding:
-    widgetTitle: Hookshot Configuration
-sentry:
-  # (Optional) Configure Sentry error reporting
-
-  dsn: https://examplePublicKey@o0.ingest.sentry.io/0
-  environment: production
-permissions:
-  # (Optional) Permissions for using the bridge. See docs/setup.md#permissions for help
-
-  - actor: example.com
-    services:
-      - service: "*"
-        level: admin
 listeners:
-  # (Optional) HTTP Listener configuration.
+  # HTTP Listener configuration.
   # Bind resource endpoints to ports and addresses.
   # 'port' must be specified. Each listener must listen on a unique port.
   # 'bindAddress' will default to '127.0.0.1' if not specified, which may not be suited to Docker environments.
   # 'resources' may be any of webhooks, widgets, metrics, provisioning
-
   - port: 9000
     bindAddress: 0.0.0.0
     resources:
@@ -194,4 +36,151 @@ listeners:
     bindAddress: 0.0.0.0
     resources:
       - widgets
+
+#github:
+#  # (Optional) Configure this to enable GitHub support
+#  auth:
+#    # Authentication for the GitHub App.
+#    id: 123
+#    privateKeyFile: github-key.pem
+#  webhook:
+#    # Webhook settings for the GitHub app.
+#    secret: secrettoken
+#  oauth:
+#    # (Optional) Settings for allowing users to sign in via OAuth.
+#    client_id: foo
+#    client_secret: bar
+#    redirect_uri: https://example.com/bridge_oauth/
+#  defaultOptions:
+#    # (Optional) Default options for GitHub connections.
+#    showIssueRoomLink: false
+#    hotlinkIssues:
+#      prefix: "#"
+#  userIdPrefix:
+#    # (Optional) Prefix used when creating ghost users for GitHub accounts.
+#    _github_
+
+#gitlab:
+#  # (Optional) Configure this to enable GitLab support
+#  instances:
+#    gitlab.com:
+#      url: https://gitlab.com
+#  webhook:
+#    secret: secrettoken
+#    publicUrl: https://example.com/hookshot/
+#  userIdPrefix:
+#    # (Optional) Prefix used when creating ghost users for GitLab accounts.
+#    _gitlab_
+#  commentDebounceMs:
+#    # (Optional) Aggregate comments by waiting this many miliseconds before posting them to Matrix. Defaults to 5000 (5 seconds)
+#    5000
+
+#figma:
+#  # (Optional) Configure this to enable Figma support
+#  publicUrl: https://example.com/hookshot/
+#  instances:
+#    your-instance:
+#      teamId: your-team-id
+#      accessToken: your-personal-access-token
+#      passcode: your-webhook-passcode
+
+#jira:
+#  # (Optional) Configure this to enable Jira support. Only specify `url` if you are using a On Premise install (i.e. not atlassian.com)
+#  webhook:
+#    # Webhook settings for JIRA
+#    secret: secrettoken
+#  oauth:
+#    # (Optional) OAuth settings for connecting users to JIRA. See documentation for more information
+#    client_id: foo
+#    client_secret: bar
+#    redirect_uri: https://example.com/bridge_oauth/
+
+#generic:
+#  # (Optional) Support for generic webhook events.
+#  #'allowJsTransformationFunctions' will allow users to write short transformation snippets in code, and thus is unsafe in untrusted environments
+
+#  enabled: false
+#  enableHttpGet: false
+#  urlPrefix: https://example.com/webhook/
+#  userIdPrefix: _webhooks_
+#  allowJsTransformationFunctions: false
+#  waitForComplete: false
+
+#feeds:
+#  # (Optional) Configure this to enable RSS/Atom feed support
+#  enabled: false
+#  pollConcurrency: 4
+#  pollIntervalSeconds: 600
+#  pollTimeoutSeconds: 30
+
+#provisioning:
+#  # (Optional) Provisioning API for integration managers
+#  secret: "!secretToken"
+
+#bot:
+#  # (Optional) Define profile information for the bot user
+#  displayname: Hookshot Bot
+#  avatar: mxc://half-shot.uk/2876e89ccade4cb615e210c458e2a7a6883fe17d
+
+#serviceBots:
+#  # (Optional) Define additional bot users for specific services
+#  - localpart: feeds
+#    displayname: Feeds
+#    avatar: ./assets/feeds_avatar.png
+#    prefix: "!feeds"
+#    service: feeds
+
+#metrics:
+#  # (Optional) Prometheus metrics support
+#  enabled: true
+
+#queue:
+#  # (Optional) Message queue / cache configuration options for large scale deployments.
+#  # For encryption to work, must be set to monolithic mode and have a host & port specified.
+#  monolithic: true
+#  port: 6379
+#  host: localhost
+
+#widgets:
+#  # (Optional) EXPERIMENTAL support for complimentary widgets
+#  addToAdminRooms: false
+#  disallowedIpRanges:
+#    - 127.0.0.0/8
+#    - 10.0.0.0/8
+#    - 172.16.0.0/12
+#    - 192.168.0.0/16
+#    - 100.64.0.0/10
+#    - 192.0.0.0/24
+#    - 169.254.0.0/16
+#    - 192.88.99.0/24
+#    - 198.18.0.0/15
+#    - 192.0.2.0/24
+#    - 198.51.100.0/24
+#    - 203.0.113.0/24
+#    - 224.0.0.0/4
+#    - ::1/128
+#    - fe80::/10
+#    - fc00::/7
+#    - 2001:db8::/32
+#    - ff00::/8
+#    - fec0::/10
+#  roomSetupWidget:
+#    addOnInvite: false
+#  publicUrl: https://example.com/widgetapi/v1/static/
+#  branding:
+#    widgetTitle: Hookshot Configuration
+
+#sentry:
+#  # (Optional) Configure Sentry error reporting
+#  dsn: https://examplePublicKey@o0.ingest.sentry.io/0
+#  environment: production
+
+#permissions:
+#  # (Optional) Permissions for using the bridge. See docs/setup.md#permissions for help
+#  - actor: example.com
+#    services:
+#      - service: "*"
+#        level: admin
+
+
 

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -491,7 +491,7 @@ export class BridgeConfig {
     @configKey(`Message queue / cache configuration options for large scale deployments.
  For encryption to work, must be set to monolithic mode and have a host & port specified.`, true)
     public readonly queue: BridgeConfigQueue;
-    @configKey("Logging settings. You can have a severity debug,info,warn,error", true)
+    @configKey("Logging settings. You can have a severity debug,info,warn,error")
     public readonly logging: BridgeConfigLogging;
     @configKey(`Permissions for using the bridge. See docs/setup.md#permissions for help`, true)
     public readonly permissions: BridgeConfigActorPermission[];
@@ -527,7 +527,7 @@ export class BridgeConfig {
  Bind resource endpoints to ports and addresses.
  'port' must be specified. Each listener must listen on a unique port.
  'bindAddress' will default to '127.0.0.1' if not specified, which may not be suited to Docker environments.
- 'resources' may be any of ${ResourceTypeArray.join(', ')}`, true)
+ 'resources' may be any of ${ResourceTypeArray.join(', ')}`)
     public readonly listeners: BridgeConfigListener[];
 
     @configKey("go-neb migrator configuration", true)

--- a/src/config/Decorators.ts
+++ b/src/config/Decorators.ts
@@ -7,7 +7,7 @@ export function configKey(comment?: string, optional = false) {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function getConfigKeyMetadata(target: any, propertyKey: string): [string, boolean] {
+export function getConfigKeyMetadata(target: any, propertyKey: string): [string, boolean]|null {
     return Reflect.getMetadata(configKeyMetadataKey, target, propertyKey);
 }
 


### PR DESCRIPTION
The previous version of the config included all the items as enabled, which broke bits of helm. Users should choose which features to enable instead.