### PR TITLE
Add note about scope for private vs. public repo notifications

### DIFF
--- a/changelog.d/830.doc
+++ b/changelog.d/830.doc
@@ -1,0 +1,1 @@
+Add note about GitHub token scope for private vs. public repo notifications

--- a/docs/usage/auth.md
+++ b/docs/usage/auth.md
@@ -20,7 +20,7 @@ To authenticate with a personal access token:
 1. Click **Generate new token**
 1. Give it a good name, and a sensible expiration date. For scopes you will need:
     - Repo (to access repo information)
-      - If you want notifications for private repos, you need `repo: Full control of private repositories`. If you only want notifications for public repos, you only need:
+      - If you want notifications for private repos, you need `repo: Full control of private repositories`. If you just want notifications for public repos, you only need:
         - repo:status
         - public_repo
     - Workflow (if you want to be able to launch workflows / GitHub actions from Matrix)

--- a/docs/usage/auth.md
+++ b/docs/usage/auth.md
@@ -20,8 +20,9 @@ To authenticate with a personal access token:
 1. Click **Generate new token**
 1. Give it a good name, and a sensible expiration date. For scopes you will need:
     - Repo (to access repo information)
-      - public_repo
-      - repo:status
+      - If you want notifications for private repos, you need `repo: Full control of private repositories`. If you only want notifications for public repos, you only need:
+        - repo:status
+        - public_repo
     - Workflow (if you want to be able to launch workflows / GitHub actions from Matrix)
     - Notifications (if you want to bridge in your notifications to Matrix)
     - User


### PR DESCRIPTION
<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->

In hindsight it's very obvious that it need `repo` to get issue comments and other details for notifications from private repos, but it took me way to much time to think of that.

And, `repo:status` is above `public_repo` on the list of token permissions.