### PR TITLE
helm - Ingress configuration QoL fixes

### DIFF
--- a/helm/hookshot/templates/ingress-appservice.yaml
+++ b/helm/hookshot/templates/ingress-appservice.yaml
@@ -1,7 +1,7 @@
 ---
 {{- if .Values.ingress.appservice.enabled -}}
 {{- $fullName := include "hookshot.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
+{{- $svcPort := .Values.service.appservice.port -}}
 {{- if and .Values.ingress.appservice.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.appservice.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.appservice.annotations "kubernetes.io/ingress.class" .Values.ingress.appservice.className}}
@@ -44,18 +44,18 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: {{ .pathType | default "ImplementationSpecific" }}
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ .port }}
+                  number: {{ $svcPort }}
               {{- else }}
               serviceName: {{ $fullName }}
-              servicePort: {{ .port }}
+              servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}
     {{- end }}

--- a/helm/hookshot/templates/ingress.yaml
+++ b/helm/hookshot/templates/ingress.yaml
@@ -1,7 +1,7 @@
 ---
 {{- if .Values.ingress.webhook.enabled -}}
 {{- $fullName := include "hookshot.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
+{{- $svcPort := .Values.service.webhook.port -}}
 {{- if and .Values.ingress.webhook.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.webhook.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.webhook.annotations "kubernetes.io/ingress.class" .Values.ingress.webhook.className}}
@@ -44,18 +44,18 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: {{ .pathType | default "ImplementationSpecific" }}
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ .port }}
+                  number: {{ $svcPort }}
               {{- else }}
               serviceName: {{ $fullName }}
-              servicePort: {{ .port }}
+              servicePort: {{ $svcPort}}
               {{- end }}
           {{- end }}
     {{- end }}

--- a/helm/hookshot/values.yaml
+++ b/helm/hookshot/values.yaml
@@ -73,8 +73,14 @@ ingress:
     className: ""
     # -- Annotations for webhook ingress
     annotations: {}
+
     # -- Host configuration for webhook ingress
-    hosts: []
+    hosts:
+      - host: webhook.hookshot.chart-example.local
+        paths:
+        - path: "/"
+          pathType: ImplementationSpecific
+
     # -- TLS configuration for webhook ingress
     tls: []
 
@@ -86,7 +92,12 @@ ingress:
     # -- Annotations for appservice ingress
     annotations: {}
     # -- Host configuration for appservice ingress
-    hosts: []
+    hosts:
+      - host: webhook.hookshot.chart-example.local
+        paths:
+        - path: "/"
+          pathType: ImplementationSpecific
+
     # -- TLS configuration for appservice ingress
     tls: []
 


### PR DESCRIPTION
Addresses https://github.com/matrix-org/matrix-hookshot/issues/780 partially on two points:

- The value of the service port for webhook / appservice was required for ingress configuration, this is passed directly from it's configured port in the services block now
- Ingress configuration of hosts / paths was unclear and not listed in the `values.yaml` file, `values.yaml` file now has proper defaults for the values