### PR TITLE
Add ability to respond to webhooks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+4.5.1 (2023-11-09)
+==================
+
+Internal Changes
+----------------
+
+- Update the release script to check for consistency between Node & Rust package versions. ([\#819](https://github.com/matrix-org/matrix-hookshot/issues/819))
+- Chart version 0.1.14
+  Do not populate optional values in default helm config, as default values are not valid. ([\#821](https://github.com/matrix-org/matrix-hookshot/issues/821))
+
+
 4.5.1 (2023-09-26)
 ==================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,3 @@
-4.5.1 (2023-11-09)
-==================
-
-Internal Changes
-----------------
-
-- Update the release script to check for consistency between Node & Rust package versions. ([\#819](https://github.com/matrix-org/matrix-hookshot/issues/819))
-- Chart version 0.1.14
-  Do not populate optional values in default helm config, as default values are not valid. ([\#821](https://github.com/matrix-org/matrix-hookshot/issues/821))
-
-
 4.5.1 (2023-09-26)
 ==================
 

--- a/changelog.d/839.feature
+++ b/changelog.d/839.feature
@@ -1,0 +1,1 @@
+Add new `webhookResponse` field to the transformation API to specify your own response data. See the documentation for help.

--- a/docs/setup/webhooks.md
+++ b/docs/setup/webhooks.md
@@ -105,7 +105,7 @@ variable, so it will contain proper float values.
 ### Wait for complete
 
 It is possible to choose whether a webhook response should be instant, or after hookshot has handled the message. The reason
-for this is that some services expect a quick response time (Slack) whereas others will wait for the request to complete. You
+for this is that some services expect a quick response time (like Slack) whereas others will wait for the request to complete. You
 can specify this either globally in your config, or on the widget with `waitForComplete`.
 
 If you make use of the `webhookResponse` feature, you will need to enable `waitForComplete` as otherwise hookshot will

--- a/docs/setup/webhooks.md
+++ b/docs/setup/webhooks.md
@@ -75,6 +75,7 @@ If the body *also* contains a `username` key, then the message will be prepended
 
 If the body does NOT contain a `text` field, the full payload will be sent to the room. This can be adapted into a message by creating a **JavaScript transformation function**.
 
+
 ### Payload formats
 
 If the request is a `POST`/`PUT`, the body of the request will be decoded and stored inside the event. Currently, Hookshot supports:
@@ -100,6 +101,15 @@ Matrix does NOT support floating point values in JSON, so the <code>uk.half-shot
 to a string representation of that value. This change is <strong>not applied</strong> to the JavaScript transformation <code>data</code>
 variable, so it will contain proper float values.
 </section>
+
+### Wait for complete
+
+It is possible to choose whether a webhook response should be instant, or after hookshot has handled the message. The reason
+for this is that some services expect a quick response time (Slack) whereas others will wait for the request to complete. You
+can specify this either globally in your config, or on the widget with `waitForComplete`.
+
+If you make use of the `webhookResponse` feature, you will need to enable `waitForComplete` as otherwise hookshot will
+immeditately respond with it's default response values.
 
 ## JavaScript Transformations
 
@@ -142,6 +152,11 @@ The `v2` api expects an object to be returned from the `result` variable.
   "plain": "Some text", // The plaintext value to be used for the Matrix message.
   "html": "<b>Some</b> text", // The HTML value to be used for the Matrix message. If not provided, plain will be interpreted as markdown.
   "msgtype": "some.type", // The message type, such as m.notice or m.text, to be used for the Matrix message. If not provided, m.notice will be used.
+  "webhookResponse": { // Optional response to send to the webhook requestor. All fields are optional. Defaults listed.
+    "body": "{ \"ok\": true }",
+    "contentType": "application/json",
+    "statusCode": 200
+  }
 }
 ```
 

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -620,17 +620,22 @@ export class Bridge {
                         const result = await c.onGenericHook(data.hookData);
                         successful = result.successful;
                         response = result.response;
-                    }
-                    await this.queue.push<GenericWebhookEventResult>({
-                        data: {successful, response},
-                        sender: "Bridge",
-                        messageId,
-                        eventName: "response.generic-webhook.event",
-                    });
-                    didPush = true;
-                    if (!this.config.generic?.waitForComplete) {
+                        await this.queue.push<GenericWebhookEventResult>({
+                            data: {successful, response},
+                            sender: "Bridge",
+                            messageId,
+                            eventName: "response.generic-webhook.event",
+                        });
+                    } else {
+                        await this.queue.push<GenericWebhookEventResult>({
+                            data: {},
+                            sender: "Bridge",
+                            messageId,
+                            eventName: "response.generic-webhook.event",
+                        });
                         await c.onGenericHook(data.hookData);
                     }
+                    didPush = true;
                 }
                 catch (ex) {
                     log.warn(`Failed to handle generic webhook`, ex);

--- a/src/Connections/GenericHook.ts
+++ b/src/Connections/GenericHook.ts
@@ -388,10 +388,10 @@ export class GenericHookConnection extends BaseConnection implements IConnection
             if (typeof transformationResult.plain !== "string") {
                 throw Error("Result returned from transformation didn't provide a string value for plain");
             }
-            if (transformationResult.html && typeof transformationResult.html !== "string") {
+            if (transformationResult.html !== undefined && typeof transformationResult.html !== "string") {
                 throw Error("Result returned from transformation didn't provide a string value for html");
             }
-            if (transformationResult.msgtype && typeof transformationResult.msgtype !== "string") {
+            if (transformationResult.msgtype !== undefined && typeof transformationResult.msgtype !== "string") {
                 throw Error("Result returned from transformation didn't provide a string value for msgtype");
             }
             content = {
@@ -405,10 +405,10 @@ export class GenericHookConnection extends BaseConnection implements IConnection
             if (typeof transformationResult.webhookResponse.body !== "string") {
                 throw Error("Result returned from transformation didn't provide a string value for webhookResponse.body");
             }
-            if (transformationResult.webhookResponse.statusCode && typeof transformationResult.webhookResponse.statusCode !== "number" && Number.isInteger(transformationResult.webhookResponse.statusCode)) {
+            if (transformationResult.webhookResponse.statusCode !== undefined && typeof transformationResult.webhookResponse.statusCode !== "number" && Number.isInteger(transformationResult.webhookResponse.statusCode)) {
                 throw Error("Result returned from transformation didn't provide a number value for webhookResponse.statusCode");
             }
-            if (transformationResult.webhookResponse.contentType && typeof transformationResult.webhookResponse.contentType !== "string") {
+            if (transformationResult.webhookResponse.contentType !== undefined && typeof transformationResult.webhookResponse.contentType !== "string") {
                 throw Error("Result returned from transformation didn't provide a contentType value for msgtype");
             }
         }

--- a/src/Connections/GenericHook.ts
+++ b/src/Connections/GenericHook.ts
@@ -486,6 +486,7 @@ export class GenericHookConnection extends BaseConnection implements IConnection
             id: this.connectionId,
             config: {
                 transformationFunction: this.state.transformationFunction,
+                waitForComplete: this.waitForComplete,
                 name: this.state.name,
             },
             ...(showSecrets ? { secrets: {

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -325,6 +325,7 @@ export class BridgeConfigGenericWebhooks {
         return {
             userIdPrefix: this.userIdPrefix,
             allowJsTransformationFunctions: this.allowJsTransformationFunctions,
+            waitForComplete: this.waitForComplete,
         }
     }
 

--- a/src/generic/types.ts
+++ b/src/generic/types.ts
@@ -1,3 +1,5 @@
+import { WebhookResponse } from "../Connections";
+
 export interface GenericWebhookEvent {
     hookData: unknown;
     hookId: string;
@@ -5,5 +7,6 @@ export interface GenericWebhookEvent {
 
 export interface GenericWebhookEventResult {
     successful?: boolean|null;
+    response?: WebhookResponse,
     notFound?: boolean;
 }

--- a/web/components/roomConfig/GenericWebhookConfig.tsx
+++ b/web/components/roomConfig/GenericWebhookConfig.tsx
@@ -31,7 +31,7 @@ const CODE_MIRROR_EXTENSIONS = [javascript({})];
 const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ServiceConfig, GenericHookResponseItem, GenericHookConnectionState>> = ({serviceConfig, existingConnection, onSave, onRemove, isUpdating}) => {
     const [transFn, setTransFn] = useState<string>(existingConnection?.config.transformationFunction as string || EXAMPLE_SCRIPT);
     const [transFnEnabled, setTransFnEnabled] = useState(serviceConfig.allowJsTransformationFunctions && !!existingConnection?.config.transformationFunction);
-    const [waitForComplete, setWaitForComplete] = useState(!!existingConnection?.config.waitForComplete);
+    const [waitForComplete, setWaitForComplete] = useState(existingConnection?.config.waitForComplete ?? false);
 
     const nameRef = createRef<HTMLInputElement>();
 
@@ -63,7 +63,7 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<Se
 
 
         <InputField visible={serviceConfig.allowJsTransformationFunctions && transFnEnabled} label="Respond after function completes" noPadding={true}>
-            <input disabled={!canEdit} type="checkbox" checked={waitForComplete} onChange={useCallback(() => setWaitForComplete(v => !v), [])} />
+            <input disabled={!canEdit || serviceConfig.waitForComplete} type="checkbox" checked={waitForComplete || serviceConfig.waitForComplete} onChange={useCallback(() => setWaitForComplete(v => !v), [])} />
         </InputField>
 
         <InputField visible={transFnEnabled} noPadding={true}>
@@ -82,7 +82,8 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<Se
 };
 
 interface ServiceConfig {
-    allowJsTransformationFunctions: boolean
+    allowJsTransformationFunctions: boolean,
+    waitForComplete: boolean,
 }
 
 const RoomConfigText = {

--- a/web/components/roomConfig/GenericWebhookConfig.tsx
+++ b/web/components/roomConfig/GenericWebhookConfig.tsx
@@ -31,6 +31,8 @@ const CODE_MIRROR_EXTENSIONS = [javascript({})];
 const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<ServiceConfig, GenericHookResponseItem, GenericHookConnectionState>> = ({serviceConfig, existingConnection, onSave, onRemove, isUpdating}) => {
     const [transFn, setTransFn] = useState<string>(existingConnection?.config.transformationFunction as string || EXAMPLE_SCRIPT);
     const [transFnEnabled, setTransFnEnabled] = useState(serviceConfig.allowJsTransformationFunctions && !!existingConnection?.config.transformationFunction);
+    const [waitForComplete, setWaitForComplete] = useState(!!existingConnection?.config.waitForComplete);
+
     const nameRef = createRef<HTMLInputElement>();
 
     const canEdit = !existingConnection || (existingConnection?.canEdit ?? false);
@@ -42,6 +44,7 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<Se
         onSave({
             name: nameRef?.current?.value || existingConnection?.config.name || "Generic Webhook",
             ...(transFnEnabled ? { transformationFunction: transFn } : undefined),
+            ...(waitForComplete ? { waitForComplete } : undefined),
         });
     }, [canEdit, onSave, nameRef, transFn, existingConnection, transFnEnabled]);
 
@@ -66,6 +69,11 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<Se
             />
             <p> See the <a target="_blank" rel="noopener noreferrer" href={DOCUMENTATION_LINK}>documentation</a> for help writing transformation functions </p>
         </InputField>
+
+        <InputField visible={serviceConfig.allowJsTransformationFunctions} label="Wait for webhook function to complete before responding." noPadding={true}>
+            <input disabled={!canEdit && transFnEnabled} type="checkbox" checked={waitForComplete} onChange={useCallback(() => setWaitForComplete(v => !v), [])} />
+        </InputField>
+
         <ButtonSet>
             { canEdit && <Button disabled={isUpdating} type="submit">{ existingConnection ? "Save" : "Add webhook" }</Button>}
             { canEdit && existingConnection && <Button disabled={isUpdating} intent="remove" onClick={onRemove}>Remove webhook</Button>}

--- a/web/components/roomConfig/GenericWebhookConfig.tsx
+++ b/web/components/roomConfig/GenericWebhookConfig.tsx
@@ -43,10 +43,10 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<Se
         }
         onSave({
             name: nameRef?.current?.value || existingConnection?.config.name || "Generic Webhook",
+            waitForComplete,
             ...(transFnEnabled ? { transformationFunction: transFn } : undefined),
-            ...(waitForComplete ? { waitForComplete } : undefined),
         });
-    }, [canEdit, onSave, nameRef, transFn, existingConnection, transFnEnabled]);
+    }, [canEdit, onSave, nameRef, transFn, existingConnection, transFnEnabled, waitForComplete]);
 
     return <form onSubmit={handleSave}>
         <InputField visible={!existingConnection} label="Friendly name" noPadding={true}>
@@ -61,6 +61,11 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<Se
             <input disabled={!canEdit} type="checkbox" checked={transFnEnabled} onChange={useCallback(() => setTransFnEnabled(v => !v), [])} />
         </InputField>
 
+
+        <InputField visible={serviceConfig.allowJsTransformationFunctions && transFnEnabled} label="Respond after function completes" noPadding={true}>
+            <input disabled={!canEdit} type="checkbox" checked={waitForComplete} onChange={useCallback(() => setWaitForComplete(v => !v), [])} />
+        </InputField>
+
         <InputField visible={transFnEnabled} noPadding={true}>
             <CodeMirror
                 value={transFn}
@@ -69,11 +74,6 @@ const ConnectionConfiguration: FunctionComponent<ConnectionConfigurationProps<Se
             />
             <p> See the <a target="_blank" rel="noopener noreferrer" href={DOCUMENTATION_LINK}>documentation</a> for help writing transformation functions </p>
         </InputField>
-
-        <InputField visible={serviceConfig.allowJsTransformationFunctions} label="Wait for webhook function to complete before responding." noPadding={true}>
-            <input disabled={!canEdit && transFnEnabled} type="checkbox" checked={waitForComplete} onChange={useCallback(() => setWaitForComplete(v => !v), [])} />
-        </InputField>
-
         <ButtonSet>
             { canEdit && <Button disabled={isUpdating} type="submit">{ existingConnection ? "Save" : "Add webhook" }</Button>}
             { canEdit && existingConnection && <Button disabled={isUpdating} intent="remove" onClick={onRemove}>Remove webhook</Button>}


### PR DESCRIPTION
Fixes #837 

This adds two new features to the generic webhook connection type:
 - The ability to set a response value for webhooks.
 - The ability for connections to choose whether to block on the webhook function before responding.