### PR TITLE
Do not pin widget to light theme

### DIFF
--- a/changelog.d/873.bugfix
+++ b/changelog.d/873.bugfix
@@ -1,0 +1,1 @@
+Fix widget pinning to light theme.

--- a/web/index.html
+++ b/web/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>GitHub Bridge Widget</title>
+    <title>Hookshot Widget</title>
   </head>
-  <body class="cpd-theme-light">
+  <body class="cpd-theme">
     <main id="root"></main>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script type="module" src="/index.tsx"></script>


### PR DESCRIPTION
A small fuckup from before, the theme was being pinned to compound light causing things to look weird in dark mode.