### PR TITLE
Fix logged errors not being properly formatted (and tone down the error verbosity a bit)

### DIFF
--- a/changelog.d/874.bugfix
+++ b/changelog.d/874.bugfix
@@ -1,0 +1,2 @@
+Fix hookshot failing to format API errors.
+Only log a stacktrace of API errors on debug level logging, log limited error on info.

--- a/spec/util/e2e-test.ts
+++ b/spec/util/e2e-test.ts
@@ -228,6 +228,7 @@ export class E2ETestEnv {
             }
         };
         const app = await start(config, registration);
+        app.listener.finaliseListeners();
         
         return new E2ETestEnv(homeserver, app, opts, config, dir);
     }

--- a/src/App/BridgeApp.ts
+++ b/src/App/BridgeApp.ts
@@ -72,8 +72,9 @@ async function startFromFile() {
     const registrationFile = process.argv[3] || "./registration.yml";
     const config = await BridgeConfig.parseConfig(configFile, process.env);
     const registration = await parseRegistrationFile(registrationFile);
-    const { bridgeApp } = await start(config, registration);
+    const { bridgeApp, listener } = await start(config, registration);
     await bridgeApp.start();
+    listener.finaliseListeners();
 }
 
 if (require.main === module) {

--- a/src/App/GithubWebhookApp.ts
+++ b/src/App/GithubWebhookApp.ts
@@ -30,6 +30,7 @@ async function start() {
     }
     const webhookHandler = new Webhooks(config);
     listener.bindResource('webhooks', webhookHandler.expressRouter);
+    listener.finaliseListeners();
     const userWatcher = new UserNotificationWatcher(config);
     userWatcher.start();
     process.once("SIGTERM", () => {

--- a/src/App/MatrixSenderApp.ts
+++ b/src/App/MatrixSenderApp.ts
@@ -32,6 +32,7 @@ async function start() {
             listener.bindResource('metrics', Metrics.expressRouter);
         }
     }
+    listener.finaliseListeners();
     sender.listen();
     process.once("SIGTERM", () => {
         log.error("Got SIGTERM");


### PR DESCRIPTION
So we go from:

```
Error: API error HS_METHOD_NOT_ALLOWED: Invalid Method. Expecting PUT or POST
    at GenericWebhooksRouter.onWebhook (/usr/bin/matrix-hookshot/generic/Router.js:41:19)
    at Layer.handle [as handle_request] (/usr/bin/matrix-hookshot/node_modules/express/lib/router/layer.js:95:5)
    at next (/usr/bin/matrix-hookshot/node_modules/express/lib/router/route.js:144:13)
    at textParser (/usr/bin/matrix-hookshot/node_modules/body-parser/lib/types/text.js:69:7)
    at Layer.handle [as handle_request] (/usr/bin/matrix-hookshot/node_modules/express/lib/router/layer.js:95:5)
    at next (/usr/bin/matrix-hookshot/node_modules/express/lib/router/route.js:144:13)
    at jsonParser (/usr/bin/matrix-hookshot/node_modules/body-parser/lib/types/json.js:110:7)
    at Layer.handle [as handle_request] (/usr/bin/matrix-hookshot/node_modules/express/lib/router/layer.js:95:5)
    at next (/usr/bin/matrix-hookshot/node_modules/express/lib/router/route.js:144:13)
    at urlencodedParser (/usr/bin/matrix-hookshot/node_modules/body-parser/lib/types/urlencoded.js:91:7)
    at Layer.handle [as handle_request] (/usr/bin/matrix-hookshot/node_modules/express/lib/router/layer.js:95:5)
    at next (/usr/bin/matrix-hookshot/node_modules/express/lib/router/route.js:144:13)
    at /usr/bin/matrix-hookshot/generic/Router.js:94:17
    at textParser (/usr/bin/matrix-hookshot/node_modules/body-parser/lib/types/text.js:69:7)
    at xmlHandler (/usr/bin/matrix-hookshot/generic/Router.js:88:60)
    at Layer.handle [as handle_request] (/usr/bin/matrix-hookshot/node_modules/express/lib/router/layer.js:95:5)
```

to 

```
INFO 13:09:06:567 [ListenerService] GET /sadsa 405 - HS_METHOD_NOT_ALLOWED - Invalid Method. Expecting PUT or POST
DEBUG 13:09:06:567 [ListenerService] ApiError: API error HS_METHOD_NOT_ALLOWED: Invalid Method. Expecting PUT or POST
    at GenericWebhooksRouter.onWebhook (/home/will/git/matrix-hookshot/src/generic/Router.ts:16:18)
    at Layer.handle [as handle_request] (/home/will/git/matrix-hookshot/node_modules/express/lib/router/layer.js:95:5)
    at next (/home/will/git/matrix-hookshot/node_modules/express/lib/router/route.js:144:13)
    at textParser (/home/will/git/matrix-hookshot/node_modules/body-parser/lib/types/text.js:69:7)
    at Layer.handle [as handle_request] (/home/will/git/matrix-hookshot/node_modules/express/lib/router/layer.js:95:5)
    at next (/home/will/git/matrix-hookshot/node_modules/express/lib/router/route.js:144:13)
    at jsonParser (/home/will/git/matrix-hookshot/node_modules/body-parser/lib/types/json.js:110:7)
    at Layer.handle [as handle_request] (/home/will/git/matrix-hookshot/node_modules/express/lib/router/layer.js:95:5)
    at next (/home/will/git/matrix-hookshot/node_modules/express/lib/router/route.js:144:13)
    at urlencodedParser (/home/will/git/matrix-hookshot/node_modules/body-parser/lib/types/urlencoded.js:91:7)
    at Layer.handle [as handle_request] (/home/will/git/matrix-hookshot/node_modules/express/lib/router/layer.js:95:5)
    at next (/home/will/git/matrix-hookshot/node_modules/express/lib/router/route.js:144:13)
    at /home/will/git/matrix-hookshot/src/generic/Router.ts:70:17
    at textParser (/home/will/git/matrix-hookshot/node_modules/body-parser/lib/types/text.js:69:7)
    at xmlHandler (/home/will/git/matrix-hookshot/src/generic/Router.ts:64:50)
    at Layer.handle [as handle_request] (/home/will/git/matrix-hookshot/node_modules/express/lib/router/layer.js:95:5) {
  error: 'Invalid Method. Expecting PUT or POST',
  errcode: 'HS_METHOD_NOT_ALLOWED',
  statusCode: 405,
  additionalContent: {}
}
```

