### PR TITLE
Fix GitHub events not verifying

### DIFF
--- a/changelog.d/875.bugfix
+++ b/changelog.d/875.bugfix
@@ -1,0 +1,1 @@
+Fix GitHub events not working due to verification failures.

--- a/spec/github.spec.ts
+++ b/spec/github.spec.ts
@@ -1,0 +1,123 @@
+import { E2ESetupTestTimeout, E2ETestEnv } from "./util/e2e-test";
+import { describe, it, beforeEach, afterEach } from "@jest/globals";
+import { createHmac, randomUUID } from "crypto";
+import { GitHubRepoConnection, GitHubRepoConnectionState } from "../src/Connections";
+import { MessageEventContent } from "matrix-bot-sdk";
+import { getBridgeApi } from "./util/bridge-api";
+
+describe('GitHub', () => {
+    let testEnv: E2ETestEnv;
+    const webhooksPort = 9500 + E2ETestEnv.workerId;
+
+    beforeEach(async () => {
+        testEnv = await E2ETestEnv.createTestEnv({matrixLocalparts: ['user'], config: {
+            github: {
+                webhook: {
+                    secret: randomUUID(),
+                },
+                auth: {
+                    privateKeyFile: 'replaced',
+                    id: '1234',
+                }
+            },
+            widgets: {
+                publicUrl: `http://localhost:${webhooksPort}`
+            },
+            listeners: [{
+                port: webhooksPort,
+                bindAddress: '0.0.0.0',
+                // Bind to the SAME listener to ensure we don't have conflicts.
+                resources: ['webhooks', 'widgets'],
+            }],
+            
+        }});
+        await testEnv.setUp();
+    }, E2ESetupTestTimeout);
+
+    afterEach(() => {
+        return testEnv?.tearDown();
+    });
+
+    it('should be able to handle a GitHub event', async () => {
+        const user = testEnv.getUser('user');
+        const bridgeApi = await getBridgeApi(testEnv.opts.config?.widgets?.publicUrl!, user);
+        const testRoomId = await user.createRoom({ name: 'Test room', invite:[testEnv.botMxid] });
+        await user.setUserPowerLevel(testEnv.botMxid, testRoomId, 50);
+        await user.waitForRoomJoin({sender: testEnv.botMxid, roomId: testRoomId });
+        // Now hack in a GitHub connection.
+        await testEnv.app.appservice.botClient.sendStateEvent(testRoomId, GitHubRepoConnection.CanonicalEventType, "my-test", {
+            org: 'my-org',
+            repo: 'my-repo'
+        } satisfies GitHubRepoConnectionState);
+
+        // Wait for connection to be accepted.
+        await new Promise<void>(r => {
+            let interval: NodeJS.Timeout;
+            interval = setInterval(() => {
+                bridgeApi.getConnectionsForRoom(testRoomId).then(conns => {
+                    if (conns.length > 0) {
+                        clearInterval(interval);
+                        r();
+                    }
+                })
+            }, 500);
+        });
+
+        const webhookNotice = user.waitForRoomEvent<MessageEventContent>({
+            eventType: 'm.room.message', sender: testEnv.botMxid, roomId: testRoomId
+        });
+
+        const webhookPayload = JSON.stringify({
+            "action": "opened",
+            "number": 1,
+            "pull_request": {
+              id: 1,
+              "url": "https://api.github.com/repos/my-org/my-repo/pulls/1",
+              "html_url": "https://github.com/my-org/my-repo/pulls/1",
+              "number": 1,
+              "state": "open",
+              "locked": false,
+              "title": "My test pull request",
+              "user": {
+                "login": "alice",
+              },
+            },
+            repository: {
+                id: 1,
+                "html_url": "https://github.com/my-org/my-repo",
+                name: 'my-repo',
+                full_name: 'my-org/my-repo',
+                owner: {
+                    login: 'my-org',
+                }
+            },
+            sender: {
+                login: 'alice',
+            }
+        });
+
+        const hmac = createHmac('sha256', testEnv.opts.config?.github?.webhook.secret!);
+        hmac.write(webhookPayload);
+        hmac.end();
+
+        // Send a webhook
+        const req = await fetch(`http://localhost:${webhooksPort}/`, {
+            method: 'POST',
+            headers: {
+                'x-github-event': 'pull_request',
+                'X-Hub-Signature-256': `sha256=${hmac.read().toString('hex')}`,
+                'X-GitHub-Delivery': randomUUID(),
+                'Content-Type': 'application/json'
+            },
+            body: webhookPayload,
+        });
+        expect(req.status).toBe(200);
+        expect(await req.text()).toBe('OK');
+        
+        // And await the notice.
+        const { body } = (await webhookNotice).data.content;
+        expect(body).toContain('**alice** opened a new PR');
+        expect(body).toContain('https://github.com/my-org/my-repo/pulls/1');
+        expect(body).toContain('My test pull request');
+    });
+});

--- a/spec/util/bridge-api.ts
+++ b/spec/util/bridge-api.ts
@@ -1,0 +1,14 @@
+import { MatrixClient } from "matrix-bot-sdk";
+import { BridgeAPI } from "../../web/BridgeAPI";
+import { WidgetApi } from "matrix-widget-api";
+
+export async function getBridgeApi(publicUrl: string, user: MatrixClient) {
+    return BridgeAPI.getBridgeAPI(publicUrl, {
+        requestOpenIDConnectToken: () => {
+            return user.getOpenIDConnectToken()
+        },
+    } as unknown as WidgetApi, {
+        getItem() { return null},
+        setItem() { },
+    } as unknown as Storage);
+}

--- a/spec/util/e2e-test.ts
+++ b/spec/util/e2e-test.ts
@@ -188,6 +188,11 @@ export class E2ETestEnv {
                 'hookshot': homeserver.url,
             }
         }
+
+        if (providedConfig?.github) {
+            providedConfig.github.auth.privateKeyFile = keyPath;
+        }
+
         const config = new BridgeConfig({
             bridge: {
                 domain: homeserver.domain,

--- a/spec/widgets.spec.ts
+++ b/spec/widgets.spec.ts
@@ -1,7 +1,6 @@
 import { E2ESetupTestTimeout, E2ETestEnv } from "./util/e2e-test";
 import { describe, it, beforeEach, afterEach } from "@jest/globals";
-import { BridgeAPI } from "../web/BridgeAPI";
-import { WidgetApi } from "matrix-widget-api";
+import { getBridgeApi } from "./util/bridge-api";
 
 describe('Widgets', () => {
     let testEnv: E2ETestEnv;
@@ -29,14 +28,7 @@ describe('Widgets', () => {
 
     it('should be able to authenticate with the widget API', async () => {
         const user = testEnv.getUser('user');
-        const bridgeApi = await BridgeAPI.getBridgeAPI(testEnv.opts.config?.widgets?.publicUrl!, {
-            requestOpenIDConnectToken: () => {
-                return user.getOpenIDConnectToken()
-            },
-        } as unknown as WidgetApi, {
-            getItem() { return null},
-            setItem() { },
-        } as unknown as Storage);
+        const bridgeApi = await getBridgeApi(testEnv.opts.config?.widgets?.publicUrl!, user);
         expect(await bridgeApi.verify()).toEqual({
             "type": "widget",
             "userId": "@user:hookshot",

--- a/src/App/BridgeApp.ts
+++ b/src/App/BridgeApp.ts
@@ -61,6 +61,7 @@ export async function start(config: BridgeConfig, registration: IAppserviceRegis
         storage.disconnect?.();
     });
     return {
+        appservice,
         bridgeApp,
         storage,
         listener,

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -1,3 +1,4 @@
+
 /* eslint-disable camelcase */
 import { BridgeConfig } from "./config/Config";
 import { Router, default as express, Request, Response } from "express";
@@ -42,6 +43,11 @@ export interface OAuthPageParams {
     'oauth-kind'?: 'account'|'organisation';
     'error'?: string;
     'errcode'?: ErrCode;
+}
+
+interface GitHubRequestData {
+    payload: string;
+    signature: string;
 }
 
 export class Webhooks extends EventEmitter {
@@ -162,11 +168,12 @@ export class Webhooks extends EventEmitter {
                     return;
                 }
                 this.handledGuids.set(githubGuid);
+                const githubData = (req as any).github as GitHubRequestData;
                 this.ghWebhooks.verifyAndReceive({
                     id: githubGuid as string,
                     name: req.headers["x-github-event"] as EmitterWebhookEventName,
-                    payload: body,
-                    signature: req.headers["x-hub-signature-256"] as string,
+                    payload: githubData.payload,
+                    signature: githubData.signature,
                 }).catch((err) => {
                     log.error(`Failed handle GitHubEvent: ${err}`);
                 });
@@ -285,7 +292,7 @@ export class Webhooks extends EventEmitter {
         }
     }
 
-    private verifyRequest(req: Request, res: Response) {
+    private verifyRequest(req: Request, res: Response, buffer: Buffer, encoding: BufferEncoding) {
         if (req.headers['x-gitlab-token']) {
             // GitLab
             if (!this.config.gitlab) {
@@ -301,9 +308,21 @@ export class Webhooks extends EventEmitter {
                 res.sendStatus(403);
                 throw Error("Invalid signature.");
             }
-        } else if (req.headers["x-hub-signature"]) {
+        } else if (req.headers["x-hub-signature-256"] && this.ghWebhooks) {
             // GitHub
-            // Verified within handler.
+            if (typeof req.headers["x-hub-signature-256"] !== "string") {
+                throw new ApiError("Unexpected multiple headers for x-hub-signature-256", ErrCode.BadValue, 400);
+            }
+            let jsonStr;
+            try {
+                jsonStr = buffer.toString(encoding)
+            } catch (ex) {
+                throw new ApiError("Could not decode buffer", ErrCode.BadValue, 400);
+            }
+            (req as any).github = {
+                payload: jsonStr,
+                signature: req.headers["x-hub-signature-256"]
+            } satisfies GitHubRequestData;
             return true;
         } else if (JiraWebhooksRouter.IsJIRARequest(req)) {
             // JIRA

--- a/src/github/GithubInstance.ts
+++ b/src/github/GithubInstance.ts
@@ -135,7 +135,7 @@ export class GithubInstance {
             privateKey: this.privateKey,
         };
 
-        
+
         this.internalOctokit = new Octokit({
             authStrategy: createAppAuth,
             auth,
@@ -149,7 +149,6 @@ export class GithubInstance {
         let page = 1;
         do {
             const installations = await this.internalOctokit.apps.listInstallations({ per_page: 100, page: page++ });
-            console.log(installations);
             for (const install of installations.data) {
                 await this.addInstallation(install);
             }


### PR DESCRIPTION
At some point the API on the @octokit/webhooks library changed and it started requiring a full raw payload of the JSON data rather than a parsed body. To get around this, we store the raw string value of the body on the request object after verifying that the fields are valid. 

Ideally we'd validate in the verification function, but alas the GitHub function is async and the verifier expects a synchronous throw. 