### PR TITLE
Add command to list feeds in JSON and YAML format

### DIFF
--- a/changelog.d/876.feature
+++ b/changelog.d/876.feature
@@ -1,0 +1,1 @@
+Add `webhook list-yaml` command to easily export all feeds from a room.

--- a/changelog.d/876.feature
+++ b/changelog.d/876.feature
@@ -1,1 +1,1 @@
-Add `webhook list-yaml` command to easily export all feeds from a room.
+Add command to list feeds in JSON and YAML format to easily export all feeds from a room.

--- a/docs/setup/feeds.md
+++ b/docs/setup/feeds.md
@@ -19,7 +19,7 @@ Each feed will only be checked once, regardless of the number of rooms to which 
 
 No entries will be bridged upon the “initial sync” -- all entries that exist at the moment of setup will be considered to be already seen.
 
-Please note that Hookshot **must** be configued with Redis to retain seen entries between restarts. By default, Hookshot will
+Please note that Hookshot **must** be configured with Redis to retain seen entries between restarts. By default, Hookshot will
 run an "initial sync" on each startup and will not process any entries from feeds from before the first sync.
 
 ## Usage
@@ -28,34 +28,35 @@ run an "initial sync" on each startup and will not process any entries from feed
 
 To add a feed to your room:
 
-  - Invite the bot user to the room.
-  - Make sure the bot able to send state events (usually the Moderator power level in clients)
-  - Say `!hookshot feed <URL>` where `<URL>` links to an RSS/Atom feed you want to subscribe to.
+- Invite the bot user to the room.
+- Make sure the bot able to send state events (usually the Moderator power level in clients)
+- Say `!hookshot feed <URL>` where `<URL>` links to an RSS/Atom feed you want to subscribe to.
 
 ### Listing feeds
 
 You can list all feeds that a room you're in is currently subscribed to with `!hookshot feed list`.
-It requires no special permissions from the user issuing the command.
+It requires no special permissions from the user issuing the command. Optionally you can format the list as `json` or
+`yaml` with `!hookshot feed list <format>`.
 
 ### Removing feeds
 
 To remove a feed from a room, say `!hookshot feed remove <URL>`, with the URL specifying which feed you want to unsubscribe from.
-
 
 ### Feed templates
 
 You can optionally give a feed a specific template to use when sending a message into a room. A template
 may include any of the following tokens:
 
-|Token     |Description                                 |
-|----------|--------------------------------------------|
-|$FEEDNAME | Either the label, title or url of the feed.|
-|$FEEDURL  | The URL of the feed.                       |
-|$FEEDTITLE| The title of the feed.                     |
-|$TITLE    | The title of the feed entry.               |
-|$LINK     | The link of the feed entry.                |
-|$AUTHOR   | The author of the feed entry.              |
-|$DATE     | The publish date (`pubDate`) of the entry. |
-|$SUMMARY  | The summary of the entry.                  |
+| Token      | Description                                                |
+| ---------- | ---------------------------------------------------------- |
+| $FEEDNAME  | Either the label, title or url of the feed.                |
+| $FEEDURL   | The URL of the feed.                                       |
+| $FEEDTITLE | The title of the feed.                                     |
+| $TITLE     | The title of the feed entry.                               |
+| $URL       | The URL of the feed entry.                                 |
+| $LINK      | The link of the feed entry. Formatted as `[$TITLE]($URL)`. |
+| $AUTHOR    | The author of the feed entry.                              |
+| $DATE      | The publish date (`pubDate`) of the entry.                 |
+| $SUMMARY   | The summary of the entry.                                  |
 
 If not specified, the default template is `New post in $FEEDNAME: $LINK`.

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -358,7 +358,7 @@ export class SetupConnection extends CommandConnection {
         }
     }
 
-    @botCommand("feed list-yaml", { help: "Show feeds currently subscribed to formatted into YAML", category: "feeds"})
+    @botCommand("feed list-yaml", { help: "Show feeds currently subscribed to formatted into YAML.", category: "feeds"})
     public async onFeedListYaml() {
         const feeds: FeedConnectionState[] = await this.client.getRoomState(this.roomId).catch((err: any) => {
             if (err.body.errcode === 'M_NOT_FOUND') {

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -377,9 +377,9 @@ export class SetupConnection extends CommandConnection {
             const feedDescriptions = feeds.sort(
                 (a, b) => (a.label ?? a.url).localeCompare(b.label ?? b.url)
             ).map(feed => {
-                return `- url: ${feed.url}` +
-                `  label: ${feed.label || 'null'}` +
-                `  notifyOnFailure: ${feed.notifyOnFailure || 'false'}` +
+                return `- url: ${feed.url}\n` +
+                `  label: ${feed.label || 'null'}\n` +
+                `  notifyOnFailure: ${feed.notifyOnFailure || 'false'}\n` +
                 `  template: ${feed.template || 'null'}`;
             });
 


### PR DESCRIPTION
<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->

The only other way currently to export all feeds from a room without loosing info is manually parsing the room state.


![Screenshot 2024-01-04 at 11 08 41 AM](https://github.com/matrix-org/matrix-hookshot/assets/19155609/c9aa2615-ba28-4015-be78-f4ac41062a5a)

![Screenshot 2024-01-04 at 11 09 03 AM](https://github.com/matrix-org/matrix-hookshot/assets/19155609/3d8f6e50-b0cf-472d-a170-f1de2503e2b1)
