### PR TITLE
Backoff failing RSS feeds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "rand",
  "reqwest",
  "rgb",
  "rss",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rss = "2.0"
 atom_syndication = "0.12"
 ruma = { version = "0.9", features = ["events", "html"] }
 reqwest = "0.11"
+rand = "0.8.5"
 
 [build-dependencies]
 napi-build = "2"

--- a/changelog.d/890.misc
+++ b/changelog.d/890.misc
@@ -1,0 +1,1 @@
+Failing RSS/atom feeds are now backed off before being retried. This should result in a speedup for large public deployments where failing feeds may result in a slowdown.

--- a/spec/github.spec.ts
+++ b/spec/github.spec.ts
@@ -58,7 +58,7 @@ describe('GitHub', () => {
         return testEnv?.tearDown();
     });
 
-    it.only('should be able to handle a GitHub event', async () => {
+    it('should be able to handle a GitHub event', async () => {
         const user = testEnv.getUser('user');
         const bridgeApi = await getBridgeApi(testEnv.opts.config?.widgets?.publicUrl!, user);
         const testRoomId = await user.createRoom({ name: 'Test room', invite:[testEnv.botMxid] });

--- a/src/Connections/FeedConnection.ts
+++ b/src/Connections/FeedConnection.ts
@@ -220,15 +220,16 @@ export class FeedConnection extends BaseConnection implements IConnection {
 
         // We want to retry these sends, because sometimes the network / HS
         // craps out.
+        const content = {
+            msgtype: 'm.notice',
+            format: "org.matrix.custom.html",
+            formatted_body: md.renderInline(message),
+            body: message,
+            external_url: entry.link ?? undefined,
+            "uk.half-shot.matrix-hookshot.feeds.item": entry,
+        };
         await retry(
-            () => this.intent.sendEvent(this.roomId, {
-                msgtype: 'm.notice',
-                format: "org.matrix.custom.html",
-                formatted_body: md.renderInline(message),
-                body: message,
-                external_url: entry.link ?? undefined,
-                "uk.half-shot.matrix-hookshot.feeds.item": entry,
-            }),
+            () => this.intent.sendEvent(this.roomId, content),
             SEND_EVENT_MAX_ATTEMPTS,
             SEND_EVENT_INTERVAL_MS,
             // Filter for showstopper errors like 4XX errors, but otherwise

--- a/src/Stores/MemoryStorageProvider.ts
+++ b/src/Stores/MemoryStorageProvider.ts
@@ -35,8 +35,8 @@ export class MemoryStorageProvider extends MSP implements IBridgeStorageProvider
         return this.feedGuids.has(url);
     }
 
-    async hasSeenFeedGuid(url: string, guid: string): Promise<boolean> {
-        return this.feedGuids.get(url)?.includes(guid) ?? false;
+    async hasSeenFeedGuids(url: string, ...guids: string[]): Promise<string[]> {
+        return this.feedGuids.get(url)?.filter((existingGuid) => guids.includes(existingGuid)) ?? [];
     }
 
     public async setGithubIssue(repo: string, issueNumber: string, data: IssuesGetResponseData, scope = "") {

--- a/src/Stores/MemoryStorageProvider.ts
+++ b/src/Stores/MemoryStorageProvider.ts
@@ -36,7 +36,8 @@ export class MemoryStorageProvider extends MSP implements IBridgeStorageProvider
     }
 
     async hasSeenFeedGuids(url: string, ...guids: string[]): Promise<string[]> {
-        return this.feedGuids.get(url)?.filter((existingGuid) => guids.includes(existingGuid)) ?? [];
+        const existing = this.feedGuids.get(url);
+        return existing ? guids.filter((existingGuid) => existing.includes(existingGuid)) : [];
     }
 
     public async setGithubIssue(repo: string, issueNumber: string, data: IssuesGetResponseData, scope = "") {

--- a/src/Stores/StorageProvider.ts
+++ b/src/Stores/StorageProvider.ts
@@ -25,7 +25,7 @@ export interface IBridgeStorageProvider extends IAppserviceStorageProvider, ISto
     setStoredTempFile(key: string, value: string): Promise<void>;
     getGitlabDiscussionThreads(connectionId: string): Promise<SerializedGitlabDiscussionThreads>;
     setGitlabDiscussionThreads(connectionId: string, value: SerializedGitlabDiscussionThreads): Promise<void>;
-    storeFeedGuids(url: string, ...guid: string[]): Promise<void>;
-    hasSeenFeed(url: string, ...guid: string[]): Promise<boolean>;
-    hasSeenFeedGuid(url: string, guid: string): Promise<boolean>;
+    storeFeedGuids(url: string, ...guids: string[]): Promise<void>;
+    hasSeenFeed(url: string): Promise<boolean>;
+    hasSeenFeedGuids(url: string, ...guids: string[]): Promise<string[]>;
 }

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -12,6 +12,11 @@ import UserAgent from "../UserAgent";
 import { QueueWithBackoff } from "../libRs";
 
 const log = new Logger("FeedReader");
+
+const BACKOFF_TIME_MAX_MS = 24 * 60 * 60 * 1000;
+const BACKOFF_POW = 1.05;
+const BACKOFF_TIME_MS = 5 * 1000;
+
 export class FeedError extends Error {
     constructor(
         public url: string,
@@ -78,7 +83,7 @@ export class FeedReader {
 
     private connections: FeedConnection[];
 
-    private feedQueue = new QueueWithBackoff();
+    private feedQueue = new QueueWithBackoff(BACKOFF_TIME_MS, BACKOFF_POW, BACKOFF_TIME_MAX_MS);
 
     // A set of last modified times for each url.
     private cacheTimes: Map<string, { etag?: string, lastModified?: string}> = new Map();

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -272,7 +272,6 @@ export class FeedReader {
             const feedError = new FeedError(url.toString(), error, fetchKey);
             log.error("Unable to read feed:", feedError.message, `backing off for ${backoffDuration}ms`);
             this.queue.push<FeedError>({ eventName: 'feed.error', sender: 'FeedReader', data: feedError});
-        } finally {
         }
         return seenEntriesChanged;
     }

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -12,7 +12,7 @@ import UserAgent from "../UserAgent";
 
 const FEED_BACKOFF_TIME_MS = 5 * 1000;
 const FEED_BACKOFF_POW = 1.05;
-const FEED_BACKOFF_TIME_MAX_MS = 60 * 60 * 1000;
+const FEED_BACKOFF_TIME_MAX_MS = 24 * 60 * 60 * 1000;
 
 const log = new Logger("FeedReader");
 export class FeedError extends Error {

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -274,7 +274,7 @@ export class FeedReader {
 
         const fetchingStarted = Date.now();
 
-        const url = this.feedQueue.next();
+        const url = this.feedQueue.pop();
         let sleepFor = this.sleepingInterval;
 
         if (url) {

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -148,7 +148,6 @@ export class FeedReader {
                 log.error(`Invalid feedUrl for connection ${conn.connectionId}: ${conn.feedUrl}. It will not be tracked`);
             }
         }
-        observedFeedUrls.add("http://example.com/not-an-rss-feed");
         observedFeedUrls.forEach(url => this.feedQueue.push(url));
         this.feedQueue.shuffle();
 

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -200,6 +200,10 @@ export class FeedReader {
      * @returns A boolean that returns if we saw any changes on the feed since the last poll time.
      */
     public async pollFeed(url: string): Promise<boolean> {
+        // If a feed is deleted while it is being polled, we need
+        // to remember NOT to add it back to the queue. This
+        // set keeps track of all the feeds that *should* be
+        // requeued.
         this.feedsToRetain.add(url);
         let seenEntriesChanged = false;
         const fetchKey = randomUUID();

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -124,6 +124,7 @@ export class FeedReader {
             }
             const normalisedUrl = normalizeUrl(newConnection.feedUrl);
             if (!feeds.has(normalisedUrl)) {
+                log.info(`Connection added, adding "${normalisedUrl}" to queue`);
                 this.feedQueue.push(normalisedUrl);
                 feeds.add(normalisedUrl);
             }
@@ -142,6 +143,12 @@ export class FeedReader {
                 }
                 return false;
             });
+            if (shouldKeepUrl) {
+                log.info(`Connection removed, but not removing "${normalisedUrl}" as it is still in use`);
+                return;
+            }
+            log.info(`Connection removed, removing "${normalisedUrl}" from queue`);
+            this.feedsToRetain.delete(normalisedUrl);
             this.feedQueue.remove(normalisedUrl);
             feeds.delete(normalisedUrl);
             this.feedsFailingHttp.delete(normalisedUrl);

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -127,6 +127,8 @@ export class FeedReader {
                 log.info(`Connection added, adding "${normalisedUrl}" to queue`);
                 this.feedQueue.push(normalisedUrl);
                 feeds.add(normalisedUrl);
+                Metrics.feedsCount.inc();
+                Metrics.feedsCountDeprecated.inc();
             }
         });
         connectionManager.on('connection-removed', removed => {
@@ -153,6 +155,8 @@ export class FeedReader {
             feeds.delete(normalisedUrl);
             this.feedsFailingHttp.delete(normalisedUrl);
             this.feedsFailingParsing.delete(normalisedUrl);
+            Metrics.feedsCount.dec();
+            Metrics.feedsCountDeprecated.dec();
         });
 
         log.debug('Loaded feed URLs:', [...feeds].join(', '));

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -10,6 +10,10 @@ import { readFeed } from "../libRs";
 import { IBridgeStorageProvider } from "../Stores/StorageProvider";
 import UserAgent from "../UserAgent";
 
+const FEED_BACKOFF_TIME_MS = 5 * 1000;
+const FEED_BACKOFF_POW = 1.05;
+const FEED_BACKOFF_TIME_MAX_MS = 60 * 60 * 1000;
+
 const log = new Logger("FeedReader");
 export class FeedError extends Error {
     constructor(
@@ -88,6 +92,9 @@ export class FeedReader {
     private observedFeedUrls: Set<string> = new Set();
 
     private feedQueue: string[] = [];
+
+    private feedBackoff: Map<string, number> = new Map();
+    private feedLastBackoff: Map<string, number> = new Map();
 
     // A set of last modified times for each url.
     private cacheTimes: Map<string, { etag?: string, lastModified?: string}> = new Map();
@@ -249,6 +256,8 @@ export class FeedReader {
             // Clear any feed failures
             this.feedsFailingHttp.delete(url);
             this.feedsFailingParsing.delete(url);
+            this.feedLastBackoff.delete(url);
+            this.feedQueue.push(url);
         } catch (err: unknown) {
             // TODO: Proper Rust Type error.
             if ((err as Error).message.includes('Failed to fetch feed due to HTTP')) {
@@ -256,12 +265,14 @@ export class FeedReader {
             } else {
                 this.feedsFailingParsing.add(url);
             }
+            const backoffDuration = Math.min(FEED_BACKOFF_TIME_MAX_MS, (
+                Math.ceil((Math.random() + 0.5) * FEED_BACKOFF_TIME_MS)) + Math.pow(this.feedLastBackoff.get(url) ?? 0, FEED_BACKOFF_POW));
+            this.feedBackoff.set(url, Date.now() + backoffDuration);
             const error = err instanceof Error ? err : new Error(`Unknown error ${err}`);
             const feedError = new FeedError(url.toString(), error, fetchKey);
-            log.error("Unable to read feed:", feedError.message);
+            log.error("Unable to read feed:", feedError.message, `backing off for ${backoffDuration}ms`);
             this.queue.push<FeedError>({ eventName: 'feed.error', sender: 'FeedReader', data: feedError});
         } finally {
-            this.feedQueue.push(url);
         }
         return seenEntriesChanged;
     }
@@ -308,5 +319,15 @@ export class FeedReader {
             }
             void this.pollFeeds(workerId);
         }, sleepFor);
+
+        // Reinsert any feeds that we may have backed off.
+        for (const [feedUrl, retryAfter] of this.feedBackoff.entries()) {
+            if (retryAfter < Date.now()) {
+                log.debug(`Adding back ${feedUrl} from backoff set`);
+                this.feedQueue.push(feedUrl);
+                // Store the last backoff time.
+                this.feedBackoff.delete(feedUrl)
+            }
+        }
     }
 }

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -150,8 +150,6 @@ export class FeedReader {
         }
         observedFeedUrls.forEach(url => this.feedQueue.push(url));
         this.feedQueue.shuffle();
-
-
         Metrics.feedsCount.set(observedFeedUrls.size);
         Metrics.feedsCountDeprecated.set(observedFeedUrls.size);
         return observedFeedUrls;

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -268,6 +268,7 @@ export class FeedReader {
             const backoffDuration = Math.min(FEED_BACKOFF_TIME_MAX_MS, (
                 Math.ceil((Math.random() + 0.5) * FEED_BACKOFF_TIME_MS)) + Math.pow(this.feedLastBackoff.get(url) ?? 0, FEED_BACKOFF_POW));
             this.feedBackoff.set(url, Date.now() + backoffDuration);
+            this.feedLastBackoff.set(url, backoffDuration);
             const error = err instanceof Error ? err : new Error(`Unknown error ${err}`);
             const feedError = new FeedError(url.toString(), error, fetchKey);
             log.error("Unable to read feed:", feedError.message, `backing off for ${backoffDuration}ms`);

--- a/src/feeds/parser.rs
+++ b/src/feeds/parser.rs
@@ -70,7 +70,8 @@ fn parse_channel_to_js_result(channel: &Channel) -> JsRssChannel {
                     .map(|f| f.value)
                     .or(item.link.clone())
                     .or(item.title.clone())
-                    .and_then(|f| Some(format!("md5:{:?}", hash_id(f)))),
+                    .and_then(|f| hash_id(f).ok())
+                    .and_then(|f| Some(format!("md5:{}", f)))
             })
             .collect(),
     }

--- a/src/feeds/parser.rs
+++ b/src/feeds/parser.rs
@@ -71,7 +71,7 @@ fn parse_channel_to_js_result(channel: &Channel) -> JsRssChannel {
                     .or(item.link.clone())
                     .or(item.title.clone())
                     .and_then(|f| hash_id(f).ok())
-                    .and_then(|f| Some(format!("md5:{}", f)))
+                    .and_then(|f| Some(format!("md5:{}", f))),
             })
             .collect(),
     }

--- a/src/feeds/parser.rs
+++ b/src/feeds/parser.rs
@@ -71,7 +71,7 @@ fn parse_channel_to_js_result(channel: &Channel) -> JsRssChannel {
                     .or(item.link.clone())
                     .or(item.title.clone())
                     .and_then(|f| hash_id(f).ok())
-                    .and_then(|f| Some(format!("md5:{}", f))),
+                    .map(|f| format!("md5:{}", f)),
             })
             .collect(),
     }

--- a/src/feeds/parser.rs
+++ b/src/feeds/parser.rs
@@ -70,7 +70,7 @@ fn parse_channel_to_js_result(channel: &Channel) -> JsRssChannel {
                     .map(|f| f.value)
                     .or(item.link.clone())
                     .or(item.title.clone())
-                    .and_then(|f| hash_id(f).ok()),
+                    .and_then(|f| Some(format!("md5:{:?}", hash_id(f)))),
             })
             .collect(),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod feeds;
 pub mod format_util;
 pub mod github;
 pub mod jira;
+pub mod util;
 
 #[macro_use]
 extern crate napi_derive;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -132,8 +132,7 @@ impl QueueWithBackoff {
         self.queue.len() as u32
     }
 
-    #[napi]
-    pub fn shuffle(&mut self) {
+    fn shuffle(&mut self) {
         let mut rng = rand::thread_rng();
         self.queue.make_contiguous().shuffle(&mut rng);
     }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -39,14 +39,13 @@ impl QueueWithBackoff {
         let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap().as_millis();
 
         // We only need to check this once, as we won't be adding to the backoff queue
-        // as often as we pull from it. 
+        // as often as we pull from it.
         if let Some(item) = self.backoff.first_entry() {
             if *item.key() < since_the_epoch {
                 let v = item.remove();
                 self.queue.push_back(v);
             }
         }
-
 
         self.queue.pop_front()
     }
@@ -79,7 +78,7 @@ impl QueueWithBackoff {
         while self.backoff.contains_key(&time) {
             time = time + 1;
         }
-    
+
         self.backoff.insert(time, backoff_item);
         backoff_duration
     }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,7 +1,7 @@
 use rand::prelude::*;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::collections::LinkedList;
+use std::collections::VecDeque;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const BACKOFF_TIME_MAX_MS: f32 = 24f32 * 60f32 * 60f32 * 1000f32;
@@ -11,7 +11,7 @@ const BACKOFF_TIME_MS: f32 = 5f32 * 1000f32;
 #[napi]
 
 pub struct QueueWithBackoff {
-    queue: LinkedList<String>,
+    queue: VecDeque<String>,
     /**
      * A map of absolute backoff timestamps mapped to the value.
      */
@@ -33,7 +33,7 @@ impl QueueWithBackoff {
     #[napi(constructor)]
     pub fn new() -> Self {
         QueueWithBackoff {
-            queue: LinkedList::new(),
+            queue: VecDeque::new(),
             backoff: BTreeMap::new(),
             last_backoff_duration: HashMap::new(),
         }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -28,7 +28,11 @@ pub struct QueueWithBackoff {
 
 impl Default for QueueWithBackoff {
     fn default() -> Self {
-        Self::new(DEFAULT_BACKOFF_TIME_MS, DEFAULT_BACKOFF_POW, DEFAULT_BACKOFF_TIME_MAX_MS)
+        Self::new(
+            DEFAULT_BACKOFF_TIME_MS,
+            DEFAULT_BACKOFF_POW,
+            DEFAULT_BACKOFF_TIME_MAX_MS,
+        )
     }
 }
 #[napi]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -67,7 +67,7 @@ impl QueueWithBackoff {
         let last_backoff = (*self.last_backoff_duration.get(&item).unwrap_or(&0)) as f32;
 
         let mut rng = rand::thread_rng();
-        let y: f32 = rng.gen::<f32>() + 0.5f32; // generates a float between 0 and 1
+        let y: f32 = rng.gen::<f32>() + 0.5f32; // generates a float between 0.5 and 1.1
 
         let backoff_duration = ((y * BACKOFF_TIME_MS) + last_backoff.powf(BACKOFF_POW))
             .min(BACKOFF_TIME_MAX_MS) as u32;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,100 @@
+use std::collections::LinkedList;
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+use rand::prelude::*;
+
+const BACKOFF_TIME_MAX_MS: f32 = 24f32 * 60f32 * 60f32 * 1000f32;
+const BACKOFF_POW: f32 = 1.05f32;
+const BACKOFF_TIME_MS: f32 = 5f32 * 1000f32;
+
+#[napi]
+
+pub struct QueueWithBackoff {
+    queue: LinkedList<String>,
+    backoff: HashMap<String, u128>,
+    last_backoff: HashMap<String, u32>
+}
+
+#[napi]
+
+impl QueueWithBackoff {
+    #[napi(constructor)]
+    pub fn new() -> Self {
+        QueueWithBackoff {
+            queue: LinkedList::new(),
+            backoff: HashMap::new(),
+            last_backoff: HashMap::new(),
+        }
+    }
+
+
+    #[napi]
+    pub fn next(&mut self) -> Option<String> {
+        let start = SystemTime::now();
+        let since_the_epoch = start
+            .duration_since(UNIX_EPOCH).unwrap();
+
+        let mut items_to_rm: Vec<String> = vec![];
+        for item in self.backoff.iter() {
+            if *item.1 < since_the_epoch.as_millis() {
+                self.queue.push_back(item.0.clone());
+                items_to_rm.push(item.0.clone());
+            }
+        }
+
+        for item in items_to_rm {
+            self.backoff.remove(&item);
+        }
+
+        return self.queue.pop_front()
+    }
+
+
+    #[napi]
+    pub fn push(&mut self, item: String) {
+        self.last_backoff.remove(&item);
+        self.queue.push_back(item);
+    }
+
+
+    #[napi]
+    pub fn backoff(&mut self, item: String) -> u32 {
+        let last_backoff = (*self.last_backoff.get(&item).unwrap_or(&0)) as f32;
+
+        let mut rng = rand::thread_rng();
+        let y: f32 = rng.gen::<f32>() + 0.5f32; // generates a float between 0 and 1
+
+        let backoff_duration = ((y * BACKOFF_TIME_MS) + f32::from(last_backoff).powf(BACKOFF_POW)).min(BACKOFF_TIME_MAX_MS) as u32;
+        let backoff_item = item.clone();
+        self.last_backoff.insert(item, backoff_duration);
+
+        let start = SystemTime::now();
+        let since_the_epoch = start
+            .duration_since(UNIX_EPOCH).unwrap();
+
+        let time = since_the_epoch.as_millis() + backoff_duration as u128;
+
+        self.backoff.insert(backoff_item, time);
+        return backoff_duration;
+    }
+
+
+    #[napi]
+    pub fn length(&self) -> u32 {
+        self.queue.len() as u32
+    }
+
+    #[napi]
+    pub fn shuffle(&mut self) {
+        let mut rng = rand::thread_rng();
+        let old_queue = self.queue.clone();
+        self.queue.clear();
+        for item in old_queue {
+            if rng.gen_bool(0.5) {
+                self.queue.push_front(item);
+            } else {
+                self.queue.push_back(item);
+            }
+        }
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -97,14 +97,6 @@ impl QueueWithBackoff {
     #[napi]
     pub fn shuffle(&mut self) {
         let mut rng = rand::thread_rng();
-        let old_queue = self.queue.clone();
-        self.queue.clear();
-        for item in old_queue {
-            if rng.gen_bool(0.5) {
-                self.queue.push_front(item);
-            } else {
-                self.queue.push_back(item);
-            }
-        }
+        self.queue.make_contiguous().shuffle(&mut rng);
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -76,7 +76,7 @@ impl QueueWithBackoff {
         // If the backoff queue contains this time (unlikely, but we don't)
         // want to overwrite, then add an extra ms.
         while self.backoff.contains_key(&time) {
-            time = time + 1;
+            time += 1;
         }
 
         self.backoff.insert(time, backoff_item);

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -80,9 +80,9 @@ impl QueueWithBackoff {
         let mut time = since_the_epoch.as_millis() + backoff_duration as u128;
 
         // If the backoff queue contains this time (unlikely, but we don't)
-        // want to overwrite, then add an extra ms.
+        // want to overwrite, then add some variance.
         while self.backoff.contains_key(&time) {
-            time += 1;
+            time += (y * BACKOFF_TIME_MS) as u128;
         }
 
         self.backoff.insert(time, backoff_item);

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -89,7 +89,7 @@ impl QueueWithBackoff {
         }
         // Always remove the duration on removal.
         self.last_backoff_duration.remove(&item);
-        return false;
+        false
     }
 
     #[napi]

--- a/tests/connections/GithubRepoTest.ts
+++ b/tests/connections/GithubRepoTest.ts
@@ -23,6 +23,7 @@ const GITHUB_ISSUE = {
 	},
 	html_url: `https://github.com/${GITHUB_ORG_REPO.org}/${GITHUB_ORG_REPO.repo}/issues/1234`,
 	title: "My issue",
+	assignees: []
 };
 
 const GITHUB_ISSUE_CREATED_PAYLOAD = {
@@ -137,7 +138,7 @@ describe("GitHubRepoConnection", () => {
 			intent.expectEventBodyContains(GITHUB_ISSUE_CREATED_PAYLOAD.issue.html_url, 0);
 			intent.expectEventBodyContains(GITHUB_ISSUE_CREATED_PAYLOAD.issue.title, 0);
 		});
-		it.only("will handle assignees on issue creation", async () => {
+		it("will handle assignees on issue creation", async () => {
 			const { connection, intent } = createConnection();
 			await connection.onIssueCreated({
 				...GITHUB_ISSUE_CREATED_PAYLOAD,


### PR DESCRIPTION
This should generally help speed up working feeds, by backing off failing ones. This is useful for environments with 1000s of feeds, some of which may have rotted since they were set up. For instance, integrations.ems.host sees about a 5% failure rate at the HTTP level alone.

Leftovers from this PR:
 - Cache backoff times across restarts in Redis. We currently hit all feeds on startup and backoff again. We would need to provide a flush button though.
 - General CPU improvements, now that we're failing less, the CPU is working harder.