### PR TITLE
Speedup startup by caching rooms with active connections

### DIFF
--- a/src/Stores/MemoryStorageProvider.ts
+++ b/src/Stores/MemoryStorageProvider.ts
@@ -107,4 +107,14 @@ export class MemoryStorageProvider extends MSP implements IBridgeStorageProvider
     public async setGitlabDiscussionThreads(connectionId: string, value: SerializedGitlabDiscussionThreads): Promise<void> {
         this.gitlabDiscussionThreads.set(connectionId, value);
     }
+    public addRoomHasActiveConnections(): void {
+        // no-op: only used for startup speedups
+    }
+    public removeRoomHasActiveConnections(): void {
+        // no-op: only used for startup speedups
+    }
+    public async getAllRoomsWithActiveConnections(): Promise<string[]> {
+        // no-op: only used for startup speedups
+        return [];
+    }
 }

--- a/src/Stores/RedisStorageProvider.ts
+++ b/src/Stores/RedisStorageProvider.ts
@@ -18,18 +18,14 @@ const GH_ISSUES_REVIEW_DATA_KEY = "gh.issues.review_data";
 const FIGMA_EVENT_COMMENT_ID = "figma.comment_event_id";
 const STORED_FILES_KEY = "storedfiles.";
 const GL_DISCUSSIONTHREADS_KEY = "gl.discussion-threads";
+const ACTIVE_ROOMS = "cache.active_rooms";
 const STORED_FILES_EXPIRE_AFTER = 24 * 60 * 60; // 24 hours
 const COMPLETED_TRANSACTIONS_EXPIRE_AFTER = 24 * 60 * 60; // 24 hours
 const ISSUES_EXPIRE_AFTER = 7 * 24 * 60 * 60; // 7 days
 const ISSUES_LAST_COMMENT_EXPIRE_AFTER = 14 * 24 * 60 * 60; // 7 days
-
-
 const WIDGET_TOKENS = "widgets.tokens.";
 const WIDGET_USER_TOKENS = "widgets.user-tokens.";
-
 const FEED_GUIDS = "feeds.guids.";
-
-
 
 const log = new Logger("RedisASProvider");
 
@@ -228,5 +224,21 @@ export class RedisStorageProvider extends RedisStorageContextualProvider impleme
 
     public async hasSeenFeedGuid(url: string, guid: string): Promise<boolean> {
         return (await this.redis.lpos(`${FEED_GUIDS}${url}`, guid)) != null;
+    }
+
+    public addRoomHasActiveConnections(roomId: string): void {
+        this.redis.sadd(ACTIVE_ROOMS, roomId).catch((ex) => {
+            log.warn(`Failed to add ${roomId} to active rooms`, ex);
+        });
+    }
+
+    public removeRoomHasActiveConnections(roomId: string): void {
+        this.redis.srem(ACTIVE_ROOMS, roomId).catch((ex) => {
+            log.warn(`Failed to remove ${roomId} from active rooms`, ex);
+        });
+    }
+
+    public getAllRoomsWithActiveConnections(): Promise<string[]> {
+        return this.redis.smembers(ACTIVE_ROOMS);
     }
 }

--- a/src/Stores/StorageProvider.ts
+++ b/src/Stores/StorageProvider.ts
@@ -28,4 +28,7 @@ export interface IBridgeStorageProvider extends IAppserviceStorageProvider, ISto
     storeFeedGuids(url: string, ...guid: string[]): Promise<void>;
     hasSeenFeed(url: string, ...guid: string[]): Promise<boolean>;
     hasSeenFeedGuid(url: string, guid: string): Promise<boolean>;
+    addRoomHasActiveConnections(roomId: string): void;
+    removeRoomHasActiveConnections(roomId: string): void;
+    getAllRoomsWithActiveConnections(): Promise<string[]>;
 }


### PR DESCRIPTION
When we start up, we currently fetch all state across all rooms that we are joined to. This is ludicrously expensive, but reasonably safe to do. On large deployments this effectively means there is a noticeable gap between restarts. We can do some tinkering around the edges here by caching the rooms which are "active", and do fewer state requests as a result.