### PR TITLE
Change example Openid Connect callback url's to be correct.

### DIFF
--- a/changelog.d/899.doc
+++ b/changelog.d/899.doc
@@ -1,0 +1,1 @@
+Fixes the OpenID Connect call back URI in the config defaults and docs.

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -50,7 +50,7 @@ listeners:
 #    # (Optional) Settings for allowing users to sign in via OAuth.
 #    client_id: foo
 #    client_secret: bar
-#    redirect_uri: https://example.com/bridge_oauth/
+#    redirect_uri: https://example.com/oauth/
 #  defaultOptions:
 #    # (Optional) Default options for GitHub connections.
 #    showIssueRoomLink: false
@@ -93,7 +93,7 @@ listeners:
 #    # (Optional) OAuth settings for connecting users to JIRA. See documentation for more information
 #    client_id: foo
 #    client_secret: bar
-#    redirect_uri: https://example.com/bridge_oauth/
+#    redirect_uri: https://example.com/oauth/
 
 #generic:
 #  # (Optional) Support for generic webhook events.

--- a/docs/setup/github.md
+++ b/docs/setup/github.md
@@ -63,7 +63,7 @@ github:
   oauth:
     client_id: foo
     client_secret: bar
-    redirect_uri: https://example.com/bridge_oauth/
+    redirect_uri: https://example.com/oauth/
   defaultOptions:
     showIssueRoomLink: false
 ```

--- a/src/config/Defaults.ts
+++ b/src/config/Defaults.ts
@@ -66,7 +66,7 @@ export const DefaultConfigRoot: BridgeConfigRoot = {
         oauth: {
             client_id: "foo",
             client_secret: "bar",
-            redirect_uri: `${hookshotWebhooksUrl}/bridge_oauth/`,
+            redirect_uri: `${hookshotWebhooksUrl}/oauth/`,
         },
         webhook: {
             secret: "secrettoken",
@@ -98,7 +98,7 @@ export const DefaultConfigRoot: BridgeConfigRoot = {
         oauth: {
             client_id: "foo",
             client_secret: "bar",
-            redirect_uri: `${hookshotWebhooksUrl}/bridge_oauth/`,
+            redirect_uri: `${hookshotWebhooksUrl}/oauth/`,
         },
     },
     generic: {


### PR DESCRIPTION
<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->
The docs suggested that the Openid Connect callback url's should be at `/bridge_oauth`, but it should actually point to `/oauth

Resolves https://matrix.to/#/!TlZdPIYrhwNvXlBiEk:half-shot.uk/$surQW-4XHEJ8wgzzOClOF0QoWM-jjA1V5X3BlNQfQaw?via=half-shot.uk&via=matrix.org&via=element.io`