### PR TITLE
Split cache config from queue config.

### DIFF
--- a/src/MessageQueue/MessageQueue.ts
+++ b/src/MessageQueue/MessageQueue.ts
@@ -1,4 +1,4 @@
-import { BridgeConfigQueue } from "../config/Config";
+import { BridgeConfigQueue } from "../config/sections/index";
 import { LocalMQ } from "./LocalMQ";
 import { RedisMQ } from "./RedisQueue";
 import { MessageQueue } from "./Types";
@@ -6,8 +6,8 @@ import { MessageQueue } from "./Types";
 const staticLocalMq = new LocalMQ();
 let staticRedisMq: RedisMQ|null = null;
 
-export function createMessageQueue(config: BridgeConfigQueue): MessageQueue {
-    if (config.monolithic) {
+export function createMessageQueue(config?: BridgeConfigQueue): MessageQueue {
+    if (!config) {
         return staticLocalMq;
     }
     if (staticRedisMq === null) {

--- a/src/MessageQueue/RedisQueue.ts
+++ b/src/MessageQueue/RedisQueue.ts
@@ -1,7 +1,7 @@
 
 import { MessageQueue, MessageQueueMessage, DEFAULT_RES_TIMEOUT, MessageQueueMessageOut } from "./Types";
 import { Redis, default as redis } from "ioredis";
-import { BridgeConfigQueue } from "../config/Config";
+import { BridgeConfigQueue } from "../config/sections/queue";
 import { EventEmitter } from "events";
 import { Logger } from "matrix-appservice-bridge";
 import { randomUUID } from 'node:crypto';
@@ -22,9 +22,10 @@ export class RedisMQ extends EventEmitter implements MessageQueue {
     private myUuid: string;
     constructor(config: BridgeConfigQueue) {
         super();
-        this.redisSub = new redis(config.port ?? 6379, config.host ?? "localhost");
-        this.redisPub = new redis(config.port ?? 6379, config.host ?? "localhost");
-        this.redis = new redis(config.port ?? 6379, config.host ?? "localhost");
+        const uri = 'redisUri' in config ? config.redisUri : `redis://${config.host ?? 'localhost'}:${config.port ?? 6379}`;
+        this.redisSub = new redis(uri);
+        this.redisPub = new redis(uri);
+        this.redis = new redis(uri);
         this.myUuid = randomUUID();
         this.redisSub.on("pmessage", (_: string, channel: string, message: string) => {
             const msg = JSON.parse(message) as MessageQueueMessageOut<unknown>;

--- a/src/Stores/RedisStorageProvider.ts
+++ b/src/Stores/RedisStorageProvider.ts
@@ -6,6 +6,7 @@ import { IBridgeStorageProvider, MAX_FEED_ITEMS } from "./StorageProvider";
 import { IFilterInfo, IStorageProvider } from "matrix-bot-sdk";
 import { ProvisionSession } from "matrix-appservice-bridge";
 import { SerializedGitlabDiscussionThreads } from "../Gitlab/Types";
+import { BridgeConfigCache } from "../config/sections";
 
 const BOT_SYNC_TOKEN_KEY = "bot.sync_token.";
 const BOT_FILTER_KEY = "bot.filter.";
@@ -68,8 +69,8 @@ export class RedisStorageContextualProvider implements IStorageProvider {
 
 
 export class RedisStorageProvider extends RedisStorageContextualProvider implements IBridgeStorageProvider {
-    constructor(host: string, port: number, contextSuffix = '') {
-        super(new redis(port, host), contextSuffix);
+    constructor(cacheConfig: BridgeConfigCache, contextSuffix = '') {
+        super(new redis(cacheConfig.redisUri), contextSuffix);
         this.redis.expire(COMPLETED_TRANSACTIONS_KEY, COMPLETED_TRANSACTIONS_EXPIRE_AFTER).catch((ex) => {
             log.warn("Failed to set expiry time on as.completed_transactions", ex);
         });

--- a/src/appservice.ts
+++ b/src/appservice.ts
@@ -9,9 +9,9 @@ const log = new Logger("Appservice");
 
 export function getAppservice(config: BridgeConfig, registration: IAppserviceRegistration) {
     let storage: IBridgeStorageProvider;
-    if (config.queue.host && config.queue.port) {
-        log.info(`Initialising Redis storage (on ${config.queue.host}:${config.queue.port})`);
-        storage = new RedisStorageProvider(config.queue.host, config.queue.port);
+    if (config.cache) {
+        log.info(`Initialising Redis storage`);
+        storage = new RedisStorageProvider(config.cache);
     } else {
         log.info('Initialising memory storage');
         storage = new MemoryStorageProvider();

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -10,6 +10,8 @@ import { ConfigError } from "../errors";
 import { ApiError, ErrCode } from "../api";
 import { GithubInstance, GITHUB_CLOUD_URL } from "../github/GithubInstance";
 import { Logger } from "matrix-appservice-bridge";
+import { BridgeConfigCache } from "./sections/cache";
+import { BridgeConfigQueue } from "./sections";
 
 const log = new Logger("Config");
 
@@ -407,12 +409,6 @@ interface BridgeConfigWebhook {
     bindAddress?: string;
 }
 
-export interface BridgeConfigQueue {
-    monolithic: boolean;
-    port?: number;
-    host?: string;
-}
-
 export interface BridgeConfigLogging {
     level: "debug"|"info"|"warn"|"error"|"trace";
     json?: boolean;
@@ -454,6 +450,7 @@ export interface BridgeConfigSentry {
     environment?: string;
 }
 
+
 export interface BridgeConfigRoot {
     bot?: BridgeConfigBot;
     serviceBots?: BridgeConfigServiceBot[];
@@ -475,19 +472,23 @@ export interface BridgeConfigRoot {
     metrics?: BridgeConfigMetrics;
     listeners?: BridgeConfigListener[];
     sentry?: BridgeConfigSentry;
+    cache: BridgeConfigCache;
 }
 
 export class BridgeConfig {
     @configKey("Basic homeserver configuration")
     public readonly bridge: BridgeConfigBridge;
+    @configKey(`Cache options for large scale deployments.
+ For encryption to work, this must be configured.`, true)
+    public readonly cache?: BridgeConfigCache;
     @configKey(`Configuration for encryption support in the bridge.
  If omitted, encryption support will be disabled.
  This feature is HIGHLY EXPERIMENTAL AND SUBJECT TO CHANGE.
  For more details, see https://github.com/matrix-org/matrix-hookshot/issues/594.`, true)
     public readonly encryption?: BridgeConfigEncryption;
-    @configKey(`Message queue / cache configuration options for large scale deployments.
+    @configKey(`Message queue configuration options for large scale deployments.
  For encryption to work, must be set to monolithic mode and have a host & port specified.`, true)
-    public readonly queue: BridgeConfigQueue;
+    public readonly queue?: Omit<BridgeConfigQueue, "monolithic">;
     @configKey("Logging settings. You can have a severity debug,info,warn,error")
     public readonly logging: BridgeConfigLogging;
     @configKey(`Permissions for using the bridge. See docs/setup.md#permissions for help`, true)
@@ -553,9 +554,34 @@ export class BridgeConfig {
         this.bot = configData.bot;
         this.serviceBots = configData.serviceBots;
         this.metrics = configData.metrics;
-        this.queue = configData.queue || {
-            monolithic: true,
-        };
+
+        // TODO: Formalize env support
+        if (env?.CFG_QUEUE_MONOLITHIC && ["false", "off", "no"].includes(env.CFG_QUEUE_MONOLITHIC)) {
+            if (!env?.CFG_QUEUE_HOST) {
+                throw new ConfigError("env:CFG_QUEUE_HOST", "CFG_QUEUE_MONOLITHIC was defined but host was not");
+            }
+            configData.queue = {
+                monolithic: false,
+                host: env?.CFG_QUEUE_HOST,
+                port: env?.CFG_QUEUE_POST ? parseInt(env?.CFG_QUEUE_POST, 10) : undefined,
+            }
+        }
+
+        this.cache = configData.cache;
+        this.queue = configData.queue;
+
+
+        if (configData.queue.monolithic !== undefined) {
+            log.warn("The `queue.monolithic` config option is deprecated. Instead, configure the `cache` section.");
+            this.cache = {
+                redisUri: 'redisUri' in configData.queue ? configData.queue.redisUri : `redis://${configData.queue.host}:${configData.queue.port ?? 6379}`
+            };
+            // If monolithic, disable the redis queue.
+            if (configData.queue.monolithic === true) {
+                this.queue = undefined;
+            }
+        }
+
         this.encryption = configData.experimentalEncryption;
 
 
@@ -587,13 +613,6 @@ export class BridgeConfig {
 
         if (!this.github && !this.gitlab && !this.jira && !this.generic && !this.figma && !this.feeds) {
             throw Error("Config is not valid: At least one of GitHub, GitLab, JIRA, Figma, feeds or generic hooks must be configured");
-        }
-
-        // TODO: Formalize env support
-        if (env?.CFG_QUEUE_MONOLITHIC && ["false", "off", "no"].includes(env.CFG_QUEUE_MONOLITHIC)) {
-            this.queue.monolithic = false;
-            this.queue.host = env?.CFG_QUEUE_HOST;
-            this.queue.port = env?.CFG_QUEUE_POST ? parseInt(env?.CFG_QUEUE_POST, 10) : undefined;
         }
 
         if ('goNebMigrator' in configData) {
@@ -677,12 +696,12 @@ Please back up your crypto store at ${this.encryption.storagePath},
 remove "useLegacySledStore" from your configuration file, and restart Hookshot.
                 `);
             }
-            if (!this.queue.monolithic) {
-                throw new ConfigError("queue.monolithic", "Encryption is not supported in worker mode yet.");
+            if (!this.cache) {
+                throw new ConfigError("cache", "Encryption requires the Redis cache to be enabled.");
             }
 
-            if (!this.queue.port) {
-                throw new ConfigError("queue.port", "You must enable redis support for encryption to work.");
+            if (this.queue) {
+                throw new ConfigError("queue", "Encryption does not support message queues.");
             }
         }
 

--- a/src/config/sections/cache.ts
+++ b/src/config/sections/cache.ts
@@ -1,0 +1,7 @@
+export interface BridgeConfigCache {
+    /**
+     * A redis URI string
+     * @example `redis://user:password@host:port/dbnum`
+     */
+   redisUri: string;    
+}

--- a/src/config/sections/index.ts
+++ b/src/config/sections/index.ts
@@ -1,0 +1,2 @@
+export * from "./cache";
+export * from "./queue";

--- a/src/config/sections/queue.ts
+++ b/src/config/sections/queue.ts
@@ -1,0 +1,22 @@
+/**
+ * Configuration for the message queue.
+ */
+interface BridgeConfigQueueBase {
+    /**
+     * Controls whether the queue config is used just for the cache (monolithic),
+     * or the message queue as well.
+     * @deprecated Use the `cache` config instead to control this seperately.
+     */
+    monolithic?: boolean;
+}
+
+interface BridgeConfigQueueUri extends BridgeConfigQueueBase {
+   redisUri: string;
+}
+
+interface BridgeConfigQueueLegacyOptions extends BridgeConfigQueueBase {
+    port?: number;
+    host?: string;
+}
+
+export type BridgeConfigQueue = BridgeConfigQueueUri|BridgeConfigQueueLegacyOptions


### PR DESCRIPTION
The reason these were conjoined is because we originally wanted a Redis for worker mode, and eventually started using it as a cache. These days we recommend using Redis as a cache, but not for message queueing. This is really confusing, and to be honest could easily be seperated into two configs.

This changes does just that. We're also going to move towards `redisUri` because frankly it allows more options for less work.