### PR TITLE
Use production mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ COPY --from=builder /src/lib ./
 COPY --from=builder /src/public ./public
 COPY --from=builder /src/assets ./assets
 
+ENV NODE_ENV="production"
+
 VOLUME /data
 EXPOSE 9993
 EXPOSE 7775

--- a/changelog.d/904.misc
+++ b/changelog.d/904.misc
@@ -1,0 +1,1 @@
+Switch expressjs to production mode for improved performance.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -27,7 +27,8 @@ cd matrix-hookshot
 yarn # or npm i
 ```
 
-Starting the bridge (after configuring it), is a matter of setting the `NODE_ENV` environment variable to `production` or `development` and then running it:
+Starting the bridge (after configuring it), is a matter of setting the `NODE_ENV` environment variable to `production` or `development`, depending if you want [better performance or more verbose logging](https://expressjs.com/en/advanced/best-practice-performance.html#set-node_env-to-production), and then running it:
+
 
 ```bash
 NODE_ENV=production yarn start

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -27,7 +27,11 @@ cd matrix-hookshot
 yarn # or npm i
 ```
 
-Starting the bridge (after configuring it), is a matter of running `yarn start`.
+Starting the bridge (after configuring it), is a matter of setting the `NODE_ENV` environment variable to `production` or `development` and then running it:
+
+```bash
+NODE_ENV=production yarn start
+```
 
 ## Installation via Docker
 

--- a/src/ListenerService.ts
+++ b/src/ListenerService.ts
@@ -30,6 +30,7 @@ export class ListenerService {
         }
         for (const listenerConfig of config) {
             const app = expressApp();
+            app.set('x-powered-by', false);
             app.use(Handlers.requestHandler());
             this.listeners.push({
                 config: listenerConfig,


### PR DESCRIPTION
<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->

Set `NODE_ENV` to production to [increase performance](https://expressjs.com/en/advanced/best-practice-performance.html#set-node_env-to-production) and document it.

This also disabled the `X-Powered-By` header to avoid false positives by bad quality security scanners.
