### PR TITLE
Add a maximum feed size

### DIFF
--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -312,7 +312,7 @@ export class SetupConnection extends CommandConnection {
 
         // provisionConnection will check it again, but won't give us a nice CommandError on failure
         try {
-            await FeedConnection.validateUrl(url);
+            await FeedConnection.validateUrl(url, this.config.feeds);
         } catch (err: unknown) {
             log.debug(`Feed URL '${url}' failed validation: ${err}`);
             if (err instanceof ApiError) {

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -251,6 +251,7 @@ export interface BridgeConfigFeedsYAML {
     pollIntervalSeconds?: number;
     pollConcurrency?: number;
     pollTimeoutSeconds?: number;
+    maximumFeedSizeMB?: number;
 }
 
 export class BridgeConfigFeeds {
@@ -259,6 +260,9 @@ export class BridgeConfigFeeds {
     public pollTimeoutSeconds: number;
     public pollConcurrency: number;
 
+    @configKey("The maximum response size of a feed on first load. Oversized responses will prevent a connection from being created.", true)
+    public maximumFeedSizeMB: number;
+
     constructor(yaml: BridgeConfigFeedsYAML) {
         this.enabled = yaml.enabled;
         this.pollConcurrency = yaml.pollConcurrency ?? 4;
@@ -266,6 +270,11 @@ export class BridgeConfigFeeds {
         assert.strictEqual(typeof this.pollIntervalSeconds, "number");
         this.pollTimeoutSeconds = yaml.pollTimeoutSeconds ?? 30;
         assert.strictEqual(typeof this.pollTimeoutSeconds, "number");
+        this.maximumFeedSizeMB = yaml.maximumFeedSizeMB ?? 25;
+        assert.strictEqual(typeof this.maximumFeedSizeMB, "number");
+        if (this.maximumFeedSizeMB < 1) {
+            throw new ConfigError('feeds.maximumFeedSizeMB', 'Must be at least 1MB or greater');
+        }
     }
 
     @hideKey()

--- a/src/config/Defaults.ts
+++ b/src/config/Defaults.ts
@@ -124,6 +124,7 @@ export const DefaultConfigRoot: BridgeConfigRoot = {
         pollIntervalSeconds: 600,
         pollTimeoutSeconds: 30,
         pollConcurrency: 4,
+        maximumFeedSizeMB: 25,
     },
     provisioning: {
         secret: "!secretToken"

--- a/src/feeds/FeedReader.ts
+++ b/src/feeds/FeedReader.ts
@@ -215,6 +215,7 @@ export class FeedReader {
                 etag,
                 lastModified,
                 userAgent: UserAgent,
+                maximumFeedSizeMb: this.config.maximumFeedSizeMB,
             });
 
             // Store any entity tags/cache times.


### PR DESCRIPTION
This prevents massive feeds from potentially clogging up Hookshot. Some RSS/ATOM feeds are horribly maintained and just list every entry ever, so we've set a "sensible limit" of 25MB. 