### PR TITLE
Experimental new bucket-style queues for feeds.

### DIFF
--- a/src/Stores/StorageProvider.ts
+++ b/src/Stores/StorageProvider.ts
@@ -28,4 +28,8 @@ export interface IBridgeStorageProvider extends IAppserviceStorageProvider, ISto
     storeFeedGuids(url: string, ...guids: string[]): Promise<void>;
     hasSeenFeed(url: string): Promise<boolean>;
     hasSeenFeedGuids(url: string, ...guids: string[]): Promise<string[]>;
+    resetFeedQueryCount(): Promise<{
+        scores: Record<string, number>,
+        lastQueryTime: number
+    }>;
 }


### PR DESCRIPTION
This is more of a thought-experiment-as-code more than something I think works, but anyway. Off the back of #910, I was trying to think of why you'd want to set different refresh periods. It feels like Hookshot should have enough information to figure out an "optimal" refresh period, which in turn would reduce the need for user involvement. 

The ultimate goal being that feeds that are active refresh more often than ones that are not, making hookshot feel faster. Some thoughts remain thought:

 - If you end up in the very slow bucket, you may have to wait a really long time for Hookshot to get to you, which might cause it to feel broken.
 - In practice at the small scale, feeds kept flipping between the middle two buckets.
 - A lot of these values are hardcoded and should be configurable, it's also worth thinking about whether the linear scale is a sensible idea, or whether this should be logarithmic.