### PR TITLE
Add support for crypto store PVC to helm chart

### DIFF
--- a/helm/hookshot/README.md
+++ b/helm/hookshot/README.md
@@ -105,6 +105,7 @@ You'll need to configure your Ingress connectivity according to your environment
 | podSecurityContext | object | `{}` | Pod security context settings |
 | replicaCount | int | `1` | Number of replicas to deploy. Consequences of using multiple Hookshot replicas currently unknown. |
 | resources | object | `{}` | Pod resource requests / limits |
+| persistence | object | `{}` | Config for persistent encryption store in /persistent |
 | securityContext | object | `{}` | Security context settings |
 | service.annotations | object | `{}` | Extra annotations for service |
 | service.appservice.port | int | `9002` | Appservice port as configured in container |

--- a/helm/hookshot/templates/_pod.tpl
+++ b/helm/hookshot/templates/_pod.tpl
@@ -47,6 +47,8 @@ containers:
       - name: config
         mountPath: "/data"
 {{- end }}
+      - name: data
+        mountPath: "/persistent"
     ports:
       - name: webhook
         containerPort: 9000
@@ -119,6 +121,13 @@ volumes:
       {{- if .items }}
       items: {{ toYaml .items | nindent 6 }}
       {{- end }}
+{{- end }}
+  - name: data
+{{- if or .Values.persistence.enabled .Values.persistence.existingClaim }}
+    persistentVolumeClaim:
+      claimName: {{ .Values.persistence.existingClaim | default (include "hookshot.fullname" .) }}
+{{- else }}
+    emptyDir: {}
 {{- end }}
 
 {{- range .Values.extraSecretMounts }}

--- a/helm/hookshot/templates/pvc.yaml
+++ b/helm/hookshot/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "hookshot.fullname" . }}
+  labels:
+    {{- include "hookshot.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/helm/hookshot/values.yaml
+++ b/helm/hookshot/values.yaml
@@ -92,6 +92,15 @@ resources: {}
 #   cpu: 100m
 #   memory: 128Mi
 
+# Persistent volume for encryption store, mounted in the pod as /persistent.
+# Can be disabled if encryption is not used.
+persistence:
+  enabled: true
+  # existingClaim: hookshot
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+  size: 8Gi
+
 autoscaling:
   enabled: false
 # -- Node selector parameters


### PR DESCRIPTION
<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->
Adds a persistence section to the Helm chart so that the encryption crypto store can persist through restarts/updates.