### PR TITLE
Apply CSPs to generic hook responses.

### DIFF
--- a/changelog.d/926.bugfix
+++ b/changelog.d/926.bugfix
@@ -1,0 +1,1 @@
+Ensure generic webhooks have appropriate Content-Security-Policy headers.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "figma-js": "^1.14.0",
+    "helmet": "^7.1.0",
     "http-status-codes": "^2.2.0",
     "ioredis": "^5.2.3",
     "jira-client": "^8.2.2",

--- a/src/generic/Router.ts
+++ b/src/generic/Router.ts
@@ -4,6 +4,7 @@ import { Logger } from "matrix-appservice-bridge";
 import { ApiError, ErrCode } from "../api";
 import { GenericWebhookEvent, GenericWebhookEventResult } from "./types";
 import * as xml from "xml2js";
+import helmet, { crossOriginOpenerPolicy } from "helmet";
 
 const WEBHOOK_RESPONSE_TIMEOUT = 5000;
 
@@ -83,6 +84,17 @@ export class GenericWebhooksRouter {
         const router = Router();
         router.all(
             '/:hookId',
+            helmet({
+                contentSecurityPolicy: {
+                    useDefaults: true,
+                    directives: {
+                        default: 'self',
+                        sandbox: ''
+                    }
+                },
+                frameguard: { action: 'deny'},
+                crossOriginResourcePolicy: { policy: 'same-site'} ,
+            }),
             GenericWebhooksRouter.xmlHandler,
             express.urlencoded({ extended: false }),
             express.json(),

--- a/src/generic/Router.ts
+++ b/src/generic/Router.ts
@@ -88,11 +88,11 @@ export class GenericWebhooksRouter {
                 contentSecurityPolicy: {
                     useDefaults: true,
                     directives: {
-                        default: 'self',
+                        defaultSrc: "'self'",
                         sandbox: ''
                     }
                 },
-                frameguard: { action: 'deny'},
+                xFrameOptions: { action: 'deny'},
                 crossOriginResourcePolicy: { policy: 'same-site'} ,
             }),
             GenericWebhooksRouter.xmlHandler,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4490,6 +4490,11 @@ he@1.2.0, he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+helmet@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-7.1.0.tgz#287279e00f8a3763d5dccbaf1e5ee39b8c3784ca"
+  integrity sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg==
+
 homerunner-client@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/homerunner-client/-/homerunner-client-1.0.0.tgz#fa535d7aa5d84ff5b1c0e9b116bd3a6bc12bf4df"


### PR DESCRIPTION
A generic hook could potentially return a valid HTML document provided both `enableHttpGet` and JS functions are enabled. This isn't bad in itself but being able to execute JS is not really a useful feature.