### PR TITLE
Fix GitLab's ready for review hook

### DIFF
--- a/changelog.d/936.bugfix
+++ b/changelog.d/936.bugfix
@@ -1,0 +1,1 @@
+Fix GitLab's ready for review hook.

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -604,22 +604,18 @@ export class GitLabRepoConnection extends CommandConnection<GitLabRepoConnection
         log.info(`onMergeRequestUpdate ${this.roomId} ${this.instance}/${this.path} ${event.object_attributes.iid}`);
         this.validateMREvent(event);
         // Check if the MR changed to / from a draft
-        if (!event.changes.title) {
+        if (!event.changes.draft) {
             return;
         }
         const orgRepoName = event.project.path_with_namespace;
         let content: string;
-        const wasDraft = event.changes.title.before.startsWith('Draft: ');
-        const isDraft = event.changes.title.after.startsWith('Draft: ');
-        if (wasDraft && !isDraft) {
+        const isDraft = event.changes.draft.current;
+        if (!isDraft) {
             // Ready for review
             content = `**${event.user.username}** marked MR [${orgRepoName}#${event.object_attributes.iid}](${event.object_attributes.url}) as ready for review "${event.object_attributes.title}" `;
-        } else if (!wasDraft && isDraft) {
+        } else {
             // Back to draft.
             content = `**${event.user.username}** marked MR [${orgRepoName}#${event.object_attributes.iid}](${event.object_attributes.url}) as draft "${event.object_attributes.title}" `;
-        } else {
-            // Nothing changed, drop it.
-            return;
         }
         await this.intent.sendEvent(this.roomId, {
             msgtype: "m.notice",

--- a/src/Gitlab/WebhookTypes.ts
+++ b/src/Gitlab/WebhookTypes.ts
@@ -64,9 +64,9 @@ export interface IGitLabWebhookMREvent {
     object_attributes: IGitLabMergeRequestObjectAttributes;
     labels: IGitLabLabel[];
     changes: {
-        [key: string]: {
-            before: string;
-            after: string;
+        draft?: {
+            previous: boolean;
+            current: boolean;
         }
     }
 }


### PR DESCRIPTION
The code resulted on this error when there was a title change (rest of the stack trace omitted):

```
[Bridge] Connection GitLabRepo http://gitlab.local/group/website failed to handle gitlab.merge_request.update: TypeError: Cannot read properties of undefined (reading 'startsWith')
  at GitLabRepoConnection.onMergeRequestUpdate (~/Projets/matrix/hookshot/src/Connections/GitlabRepo.ts:630:53)
```

As far back as I could go in the docs (GitLab 14.10), the keys for changes have been `previous` and `current`. Besides, there is a `draft` change that we can use directly instead of guessing from the title.

I removed the `[key: string]` type declaration because the type of the value depends on the key of the change.

