### PR TITLE
Remove unused disallowedIpRanges webhook config

### DIFF
--- a/changelog.d/950.misc
+++ b/changelog.d/950.misc
@@ -1,0 +1,1 @@
+Remove the unused "disallowedIpRanges" property from the generic webhook config object.

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -296,7 +296,6 @@ export interface BridgeGenericWebhooksConfigYAML {
     waitForComplete?: boolean;
     enableHttpGet?: boolean;
     outbound?: boolean;
-    disallowedIpRanges?: string[];
 }
 
 export class BridgeConfigGenericWebhooks {


### PR DESCRIPTION
This assumes the config is vestigial & isn't meant to be used.