### PR TITLE
Change GitLab messages to be more consistent with GitHub

### DIFF
--- a/src/Gitlab/WebhookTypes.ts
+++ b/src/Gitlab/WebhookTypes.ts
@@ -40,6 +40,7 @@ export interface IGitlabMergeRequest {
 
 export interface IGitLabMergeRequestObjectAttributes extends IGitlabMergeRequest {
     action: "open"|"close"|"reopen"|"approved"|"unapproved"|"merge";
+    draft: boolean;
 }
 
 export interface IGitLabLabel {


### PR DESCRIPTION
- Use the same `{icon} {author} {details}` format rather than `{author} {icon} {details}`
- Use the same emojis
- Emojify the content
- For `onMergeRequestOpened`, add support for draft state and labels.

Needs #939 for label colors to show correctly in Matrix clients.
