### PR TITLE
Update setup.md - update location of helm chart in docs

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -53,9 +53,9 @@ Where `/etc/matrix-hookshot` would contain the configuration files `config.yml` 
 
 ## Installation via Helm
 
-There's now a basic chart defined in [helm/hookshot](/helm/hookshot/) that can be used to deploy the Hookshot Docker container in a Kubernetes-native way.
+There's now a basic chart defined in [helm/hookshot](https://github.com/matrix-org/matrix-hookshot/blob/main/helm/hookshot) that can be used to deploy the Hookshot Docker container in a Kubernetes-native way.
 
-More information on this method is available [here](https://github.com/matrix-org/matrix-hookshot/helm/hookshot/README.md)
+More information on this method is available [here](https://github.com/matrix-org/matrix-hookshot/blob/main/helm/hookshot/README.md)
 
 ## Configuration
 


### PR DESCRIPTION
<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->
This just updates the "Installation via Helm" section of the setup.md to include the correct URL to the helm chart, as before, both links in this section 404'd.

Let me know if anything needs changing and kind regards!