### PR TITLE
Fix challengehound duplication bug.

### DIFF
--- a/changelog.d/982.bugfix
+++ b/changelog.d/982.bugfix
@@ -1,0 +1,1 @@
+Fix Challenge Hound activities being duplicated if the cache layer (e.g Redis) goes away.

--- a/src/Stores/MemoryStorageProvider.ts
+++ b/src/Stores/MemoryStorageProvider.ts
@@ -122,9 +122,14 @@ export class MemoryStorageProvider extends MSP implements IBridgeStorageProvider
             set.pop();
         } 
     }
+
     async hasSeenHoundActivity(challengeId: string, ...activityIds: string[]): Promise<string[]> {
         const existing = this.houndActivityIds.get(challengeId);
         return existing ? activityIds.filter((existingGuid) => existing.includes(existingGuid)) : [];
+    }
+
+    public async hasSeenHoundChallenge(challengeId: string): Promise<boolean> {
+        return this.houndActivityIds.has(challengeId);
     }
 
     public async storeHoundActivityEvent(challengeId: string, activityId: string, eventId: string): Promise<void> {

--- a/src/Stores/RedisStorageProvider.ts
+++ b/src/Stores/RedisStorageProvider.ts
@@ -250,6 +250,11 @@ export class RedisStorageProvider extends RedisStorageContextualProvider impleme
         await this.redis.ltrim(key, 0, MAX_FEED_ITEMS);
     }
 
+    public async hasSeenHoundChallenge(challengeId: string): Promise<boolean> {
+        const key = `${HOUND_GUIDS}${challengeId}`;
+        return (await this.redis.exists(key)) === 1;
+    }
+
     public async hasSeenHoundActivity(challengeId: string, ...activityHashes: string[]): Promise<string[]> {
         let multi = this.redis.multi();
         const key = `${HOUND_GUIDS}${challengeId}`;

--- a/src/Stores/RedisStorageProvider.ts
+++ b/src/Stores/RedisStorageProvider.ts
@@ -23,7 +23,7 @@ const STORED_FILES_EXPIRE_AFTER = 24 * 60 * 60; // 24 hours
 const COMPLETED_TRANSACTIONS_EXPIRE_AFTER = 24 * 60 * 60; // 24 hours
 const ISSUES_EXPIRE_AFTER = 7 * 24 * 60 * 60; // 7 days
 const ISSUES_LAST_COMMENT_EXPIRE_AFTER = 14 * 24 * 60 * 60; // 7 days
-const HOUND_EVENT_CACHE = 90 * 24 * 60 * 60; // 30 days
+const HOUND_EVENT_CACHE = 90 * 24 * 60 * 60; // 90 days
 
 
 const WIDGET_TOKENS = "widgets.tokens.";

--- a/src/Stores/RedisStorageProvider.ts
+++ b/src/Stores/RedisStorageProvider.ts
@@ -245,6 +245,9 @@ export class RedisStorageProvider extends RedisStorageContextualProvider impleme
     }
 
     public async storeHoundActivity(challengeId: string, ...activityHashes: string[]): Promise<void> {
+        if (activityHashes.length === 0) {
+            return;
+        }
         const key = `${HOUND_GUIDS}${challengeId}`;
         await this.redis.lpush(key, ...activityHashes);
         await this.redis.ltrim(key, 0, MAX_FEED_ITEMS);

--- a/src/Stores/StorageProvider.ts
+++ b/src/Stores/StorageProvider.ts
@@ -32,6 +32,7 @@ export interface IBridgeStorageProvider extends IAppserviceStorageProvider, ISto
     hasSeenFeedGuids(url: string, ...guids: string[]): Promise<string[]>;
 
     storeHoundActivity(challengeId: string, ...activityHashes: string[]): Promise<void>;
+    hasSeenHoundChallenge(challengeId: string): Promise<boolean>;
     hasSeenHoundActivity(challengeId: string, ...activityHashes: string[]): Promise<string[]>;
     storeHoundActivityEvent(challengeId: string, activityId: string, eventId: string): Promise<void>;
     getHoundActivity(challengeId: string, activityId: string): Promise<string|null>;

--- a/src/config/permissions.rs
+++ b/src/config/permissions.rs
@@ -113,13 +113,10 @@ impl BridgePermissions {
                 continue;
             }
             for actor_service in actor_permission.services.iter() {
-                match &actor_service.service {
-                    Some(actor_service_service) => {
-                        if actor_service_service != &service && actor_service_service != "*" {
-                            continue;
-                        }
+                if let Some(actor_service_service) = &actor_service.service {
+                    if actor_service_service != &service && actor_service_service != "*" {
+                        continue;
                     }
-                    None => {}
                 }
                 if permission_level_to_int(actor_service.level.clone())? >= permission_int {
                     return Ok(true);

--- a/src/format_util.rs
+++ b/src/format_util.rs
@@ -174,9 +174,9 @@ pub fn hash_id(id: String) -> Result<String> {
 
 #[napi(js_name = "sanitizeHtml")]
 pub fn hookshot_sanitize_html(html: String) -> String {
-    return sanitize_html(
+    sanitize_html(
         html.as_str(),
         HtmlSanitizerMode::Compat,
         RemoveReplyFallback::No,
-    );
+    )
 }


### PR DESCRIPTION
Fixes #981 

If we haven't got anything in storage for challengehound, then it defaults to emitting everything to the room. This is a problem for memory-storage bots or unreliable Redis stores. To fix this, simply do not emit anything on first poll.

This also fixes a problem where we were endlessly adding the same hashes to Redis, using up more storage than required.