### PR TITLE
Skip newsfile CI check for dependabot.

### DIFF
--- a/.github/workflows/newsfile.yml
+++ b/.github/workflows/newsfile.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   changelog:
     runs-on: ubuntu-latest
+    # No newsfile required for dependabot
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v3
         with: # Needed for comparison

--- a/changelog.d/987.misc
+++ b/changelog.d/987.misc
@@ -1,0 +1,1 @@
+Don't invoke newsfile CI check for dependabot.


### PR DESCRIPTION
We've been skipping this check for years, and tbh I don't see the need to report package updates in the changelog.