### PR TITLE
Retry E2E tests on failure if running in CI.

### DIFF
--- a/changelog.d/995.misc
+++ b/changelog.d/995.misc
@@ -1,0 +1,1 @@
+Retry e2e tests in CI due to container creation flakiness.

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,6 +9,7 @@ const config: Config = {
   // The root directory that Jest should scan for tests and modules within
   rootDir: "spec-lib",
   testTimeout: 60000,
+  setupFiles: ["<rootDir>/spec/setup-jest.js"],
 };
 
 export default config;

--- a/spec/setup-jest.ts
+++ b/spec/setup-jest.ts
@@ -1,0 +1,2 @@
+// In CI, the network creation for the homerunner containers can race (https://github.com/matrix-org/complement/issues/720).
+jest.retryTimes(process.env.CI ? 3 : 1);


### PR DESCRIPTION
We're seeing flakes due to https://github.com/matrix-org/complement/issues/720, so for now just retry a test if it fails in CI. We still want to fail locally so the error isn't entirely lost.

At some point this should be looked into on the complement side though.