### PR TITLE
Fix bugs in handling server names that includes colons

### DIFF
--- a/changelog.d/999.bugfix
+++ b/changelog.d/999.bugfix
@@ -1,1 +1,1 @@
-Fix bug where generic hooks doesn't work when the server name has the port in it
+Fix bug where generic hooks doesn't work when the server name includes a colon

--- a/changelog.d/999.bugfix
+++ b/changelog.d/999.bugfix
@@ -1,1 +1,1 @@
-Fix bug where generic hooks doesn't work when the server name includes a colon
+Fix bugs in handling server names that includes colons

--- a/changelog.d/999.bugfix
+++ b/changelog.d/999.bugfix
@@ -1,0 +1,1 @@
+Fix bug where generic hooks doesn't work when the server name has the port in it

--- a/src/Connections/GenericHook.ts
+++ b/src/Connections/GenericHook.ts
@@ -334,7 +334,7 @@ export class GenericHookConnection extends BaseConnection implements IConnection
         if (!this.config.userIdPrefix) {
             return this.intent.userId;
         }
-        const [, domain] = this.intent.userId.split(':');
+        const domain = this.intent.userId.substring(this.intent.userId.indexOf(':')+1);
         const name = this.state.name &&
              this.state.name.replace(/[A-Z]/g, (s) => s.toLowerCase()).replace(/([^a-z0-9\-.=_]+)/g, '');
         return `@${this.config.userIdPrefix}${name || 'bot'}:${domain}`;

--- a/src/config/permissions.rs
+++ b/src/config/permissions.rs
@@ -100,12 +100,10 @@ impl BridgePermissions {
         service: String,
         permission: String,
     ) -> napi::Result<bool> {
-        let parts: Vec<&str> = mxid.split(':').collect();
         let permission_int = permission_level_to_int(permission)?;
-        let domain = if parts.len() > 1 {
-            parts[1].to_string()
-        } else {
-            parts[0].to_string()
+        let domain: String = match mxid.split_once(':') {
+            Some((.., d)) => d.to_string(),
+            None => return Ok(false),
         };
         for actor_permission in self.config.iter() {
             // Room_id
@@ -128,12 +126,10 @@ impl BridgePermissions {
 
     #[napi]
     pub fn check_action_any(&self, mxid: String, permission: String) -> napi::Result<bool> {
-        let parts: Vec<&str> = mxid.split(':').collect();
         let permission_int = permission_level_to_int(permission)?;
-        let domain = if parts.len() > 1 {
-            parts[1].to_string()
-        } else {
-            parts[0].to_string()
+        let domain: String = match mxid.split_once(':') {
+            Some((.., d)) => d.to_string(),
+            None => return Ok(false),
         };
         for actor_permission in self.config.iter() {
             if !self.match_actor(actor_permission, &domain, &mxid) {


### PR DESCRIPTION
I ran into this issue when testing something with generic hooks on Hookshot locally where the Synapse server name is `localhost:8448`

```log
INFO 12:16:27:794 [GenericHookConnection] onGenericHook !QrmxBsBKPajykCohPz:localhost:8448 7e789bf2-7b87-4b10-9438-a22a6f1090d2
ERROR 12:16:27:800 [Appservice] Error registering user: User ID is in use
ERROR 12:16:27:804 [MatrixHttpClient] (REQ-15) {
  errcode: 'M_FORBIDDEN',
  error: 'Application service cannot masquerade as this user (@_webhooks_hookname:localhost).'
}
WARN 12:16:27:804 [Bridge] Failed to handle generic webhook MatrixError: M_FORBIDDEN: Application service cannot masquerade as this user (@_webhooks_hookname:localhost).
    at Object.defaultErrorHandler [as errorHandler] (/usr/bin/matrix-hookshot/node_modules/matrix-bot-sdk/lib/http.js:10:9)
    at doHttpRequest (/usr/bin/matrix-hookshot/node_modules/matrix-bot-sdk/lib/http.js:98:31)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async descriptor.value (/usr/bin/matrix-hookshot/node_modules/matrix-bot-sdk/lib/metrics/decorators.js:19:32)
    at async descriptor.value (/usr/bin/matrix-hookshot/node_modules/matrix-bot-sdk/lib/metrics/decorators.js:19:32)
    at async GenericHookConnection.ensureDisplayname (/usr/bin/matrix-hookshot/Connections/GenericHook.js:271:13)
    at async GenericHookConnection.onGenericHook (/usr/bin/matrix-hookshot/Connections/GenericHook.js:478:13)
    at async /usr/bin/matrix-hookshot/Bridge.js:435:25
    at async Promise.all (index 0)
    at async LocalMQ.<anonymous> (/usr/bin/matrix-hookshot/Bridge.js:410:13) {
  body: {
    errcode: 'M_FORBIDDEN',
    error: 'Application service cannot masquerade as this user (@_webhooks_hookname:localhost).'
  },
  statusCode: 403,
  errcode: 'M_FORBIDDEN',
  error: 'Application service cannot masquerade as this user (@_webhooks_hookname:localhost).',
  retryAfterMs: undefined
}
```

Signed-off-by: Twilight Sparkle <19155609+Twi1ightSparkle@users.noreply.github.com>