### PR TITLE
Support building docker images for arm64 natively.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
   docker-clean-metadata:
     runs-on: ubuntu-latest
     outputs:
-      tags: ${{ steps.meta.outputs.tags }}
+      json: ${{ steps.meta.outputs.json }}
     steps:
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -97,7 +97,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-
   docker-manifest:
     needs: 
       - docker-build
@@ -106,7 +105,7 @@ jobs:
 
     strategy:
       matrix:
-        image: ${{ needs.docker-clean-metadata.outputs.tags }}
+        image: ${{ fromJson(needs.docker-clean-metadata.outputs.json).tags }}
 
     steps:
       - name: Log in to Docker Hub

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -82,6 +82,11 @@ jobs:
     needs: docker-build
     runs-on: ubuntu-latest
     steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Log in to the GitHub Container registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,30 +22,29 @@ concurrency:
 
 env:
   DOCKER_NAMESPACE: halfshot
-  PLATFORMS: linux/amd64
-  PLATFORMS_PUSH: linux/amd64,linux/arm64
-  # Only push if this is main, otherwise we just want to build
-  BUILD_FOR_ALL_PLATFORMS: ${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}
 
 jobs:
-  docker-latest:
-    runs-on: ubuntu-latest
-
+  docker-build:
     permissions:
       contents: read
       packages: write
       attestations: write
       id-token: write
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -55,7 +54,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -66,19 +64,29 @@ jobs:
             type=ref,event=pr
             type=raw,value=latest,enable={{is_default_branch}}
           images: |
-            ${{ env.DOCKER_NAMESPACE }}/matrix-hookshot
-            ghcr.io/matrix-org/matrix-hookshot
-  
+            ghcr.io/matrix-org/matrix-hookshot:${{ matrix.arch }}
+
       - name: Build and push Docker images
-        id: push
         uses: docker/build-push-action@v6
         with:
-          context: .
-          # arm64 builds OOM without the git fetch setting. c.f.
-          # https://github.com/rust-lang/cargo/issues/10583
-          build-args: |
-            CARGO_NET_GIT_FETCH_WITH_CLI=true
-          platforms: ${{ (env.BUILD_FOR_ALL_PLATFORMS == 'true' && env.PLATFORMS_PUSH) || env.PLATFORMS }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+
+  docker-manifest:
+    needs: docker-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push manifest
+        run: |
+            docker manifest create ghcr.io/matrix-org/matrix-hookshot ghcr.io/matrix-org/matrix-hookshot:amd64 ghcr.io/matrix-org/matrix-hookshot:arm64
+            docker manifest push ghcr.io/matrix-org/matrix-hookshot
+            docker manifest create ${{ env.DOCKER_NAMESPACE }}/matrix-hookshot ghcr.io/matrix-org/matrix-hookshot:amd64 ghcr.io/matrix-org/matrix-hookshot:arm64
+            docker manifest push ${{ env.DOCKER_NAMESPACE }}/matrix-hookshot

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,8 +63,12 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=raw,value=latest,enable={{is_default_branch}}
+          flavor: |
+            latest=auto
+            suffix=-${{ matrix.arch }},onlatest=true
           images: |
-            ghcr.io/matrix-org/matrix-hookshot:${{ matrix.arch }}
+            ${{ env.DOCKER_NAMESPACE }}/matrix-hookshot
+            ghcr.io/matrix-org/matrix-hookshot
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v6
@@ -84,9 +88,23 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=latest,enable={{is_default_branch}}
+          flavor: |
+            latest=auto
+          images: |
+            ${{ env.DOCKER_NAMESPACE }}/matrix-hookshot
+            ghcr.io/matrix-org/matrix-hookshot
       - name: Create and push manifest
         run: |
-            docker manifest create ghcr.io/matrix-org/matrix-hookshot ghcr.io/matrix-org/matrix-hookshot:amd64 ghcr.io/matrix-org/matrix-hookshot:arm64
-            docker manifest push ghcr.io/matrix-org/matrix-hookshot
-            docker manifest create ${{ env.DOCKER_NAMESPACE }}/matrix-hookshot ghcr.io/matrix-org/matrix-hookshot:amd64 ghcr.io/matrix-org/matrix-hookshot:arm64
-            docker manifest push ${{ env.DOCKER_NAMESPACE }}/matrix-hookshot
+          for tag in ${{ steps.meta.outputs.tags }}; do
+            docker manifest create $tag $tag-amd64 $tag-arm64
+            docker manifest push $tag
+          done

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,26 @@ env:
   DOCKER_NAMESPACE: halfshot
 
 jobs:
+  docker-clean-metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=latest,enable={{is_default_branch}}
+          flavor: |
+            latest=auto
+          images: |
+            ${{ env.DOCKER_NAMESPACE }}/matrix-hookshot
+            ghcr.io/matrix-org/matrix-hookshot
+
   docker-build:
     permissions:
       contents: read
@@ -79,37 +99,30 @@ jobs:
 
 
   docker-manifest:
-    needs: docker-build
+    needs: 
+      - docker-build
+      - docker-clean-metadata
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        image: ${{ needs.docker-clean-metadata.outputs.tags }}
+
     steps:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
       - name: Log in to the GitHub Container registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          tags: |
-            type=semver,pattern={{version}}
-            type=ref,event=branch
-            type=ref,event=pr
-            type=raw,value=latest,enable={{is_default_branch}}
-          flavor: |
-            latest=auto
-          images: |
-            ${{ env.DOCKER_NAMESPACE }}/matrix-hookshot
-            ghcr.io/matrix-org/matrix-hookshot
+
       - name: Create and push manifest
         run: |
-          for tag in ${{ steps.meta.outputs.tags }}; do
-            docker manifest create $tag $tag-amd64 $tag-arm64
-            docker manifest push $tag
-          done
+          docker manifest create ${{ matrix.image }} ${{ matrix.image }}-amd64 ${{ matrix.image }}-arm64
+          docker manifest push ${{ matrix.image }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/changelog.d/1008.misc
+++ b/changelog.d/1008.misc
@@ -1,0 +1,1 @@
+Switch to using GitHub Actions native arm runners for Docker builds, which will reduce build times.


### PR DESCRIPTION
If we can pull this off, it would unlock building arm versions of hookshot much faster, which means we can run them for PRs.