### PR TITLE
Ping homeserver on startup and warn about configuration errors

### DIFF
--- a/changelog.d/1062.feature
+++ b/changelog.d/1062.feature
@@ -1,0 +1,1 @@
+Hookshot will now ping the homeserver on startup to ensure it can be reached.

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "jira-client": "^8.2.2",
     "markdown-it": "^14.0.0",
     "matrix-appservice-bridge": "^9.0.1",
-    "matrix-bot-sdk": "npm:@vector-im/matrix-bot-sdk@0.7.1-element.8",
+    "matrix-bot-sdk": "npm:@vector-im/matrix-bot-sdk@0.7.1-element.9",
     "matrix-widget-api": "^1.10.0",
     "micromatch": "^4.0.8",
     "mime": "^4.0.4",

--- a/spec/permissions.spec.ts
+++ b/spec/permissions.spec.ts
@@ -60,8 +60,7 @@ describe("Permissions test", () => {
       sender: testEnv.botMxid,
       roomId,
     });
-    // XXX: Missing type
-    expect((data.content as any)["reason"]).to.equal(
+    expect(data.content.reason).to.equal(
       "You do not have permission to invite this bot.",
     );
 

--- a/spec/util/e2e-test.ts
+++ b/spec/util/e2e-test.ts
@@ -377,7 +377,7 @@ export class E2ETestEnv<ML extends string = string> {
     }
 
     const registration: IAppserviceRegistration = {
-      id: 'hookshot',
+      id: "hookshot",
       as_token: homeserver.asToken,
       hs_token: homeserver.hsToken,
       sender_localpart: "hookshot",

--- a/spec/util/e2e-test.ts
+++ b/spec/util/e2e-test.ts
@@ -377,6 +377,7 @@ export class E2ETestEnv<ML extends string = string> {
     }
 
     const registration: IAppserviceRegistration = {
+      id: 'hookshot',
       as_token: homeserver.asToken,
       hs_token: homeserver.hsToken,
       sender_localpart: "hookshot",
@@ -474,11 +475,6 @@ export class E2ETestEnv<ML extends string = string> {
       // It looks like having the port forwarder setup before
       // we actually start the appservice sometimes causes issues
       await TestContainers.exposeHostPorts(config.bridge.port);
-
-      // Ask the HS to ping the appservice.
-      // TODO: Because of crypto reasons, the appservice bot client might not be a "true" appservice session
-      // but instead a crypto session. For this reason we need to do a raw request.
-      appService.pingHomeserver();
     };
   }
 

--- a/spec/util/e2e-test.ts
+++ b/spec/util/e2e-test.ts
@@ -462,10 +462,6 @@ export class E2ETestEnv<ML extends string = string> {
     private readonly dir: string,
   ) {
     const appService = app.appservice;
-    // Setup the appservice ping endpoint
-    appService.expressAppInstance.post("/_matrix/app/v1/ping", (_req, res) =>
-      res.status(200).send({}),
-    );
 
     // Patch the "begin" function to expose host ports, and ping the appservice
     // The reason we don't do this unconditionally, is that if we never start the appservice,
@@ -482,12 +478,7 @@ export class E2ETestEnv<ML extends string = string> {
       // Ask the HS to ping the appservice.
       // TODO: Because of crypto reasons, the appservice bot client might not be a "true" appservice session
       // but instead a crypto session. For this reason we need to do a raw request.
-      new MatrixClient(homeserver.url, homeserver.asToken).doRequest(
-        "POST",
-        `/_matrix/client/v1/appservice/hookshot/ping`,
-        null,
-        {},
-      );
+      appService.pingHomeserver();
     };
   }
 

--- a/spec/util/homerunner.ts
+++ b/spec/util/homerunner.ts
@@ -2,13 +2,11 @@ import {
   MatrixClient,
   MemoryStorageProvider,
   RustSdkCryptoStorageProvider,
-  RustSdkCryptoStoreType,
 } from "matrix-bot-sdk";
 import { createHash, createHmac } from "crypto";
 import { E2ETestMatrixClient, E2ETestMatrixClientOpts } from "./e2e-test";
 import path from "node:path";
 import { createContainers, TestContainerNetwork } from "./containers";
-import { TestContainers } from "testcontainers";
 
 export interface TestHomeServer {
   url: string;

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -11,6 +11,7 @@ import {
   EventKind,
   PowerLevelsEvent,
   Intent,
+  MatrixError,
 } from "matrix-bot-sdk";
 import BotUsersManager from "./managers/BotUsersManager";
 import {
@@ -1168,6 +1169,22 @@ export class Bridge {
     this.listener.bindResource("webhooks", webhookHandler.expressRouter);
 
     await this.as.begin();
+    log.info(`Pinging homeserver to validate connection`);
+    try {
+      await this.as.pingHomeserver();
+    } catch (ex) {
+      if (ex instanceof MatrixError && ex.errcode === "M_CONNECTION_FAILED") {
+        log.error(
+          "**WARNING**: The homeserver reports it is unable to contact Hookshot. This will render Hookshot unusable until fixed." +
+            "Verify that the bridge.port / bridge.bindAddress in the config is reachable. Consult your homeserver documentation for appservice configuration.",
+        );
+      } else {
+        log.warn(
+          "Homeserver was pinged but was unable to validate the connection. You may be running a unsupported configuration.",
+          ex,
+        );
+      }
+    }
     log.info(
       `Bridge is now ready. Found ${this.connectionManager.size} connections`,
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5919,10 +5919,10 @@ matrix-appservice@^2.0.0:
     js-yaml "^4.1.0"
     morgan "^1.10.0"
 
-"matrix-bot-sdk@npm:@vector-im/matrix-bot-sdk@0.7.1-element.8":
-  version "0.7.1-element.8"
-  resolved "https://registry.yarnpkg.com/@vector-im/matrix-bot-sdk/-/matrix-bot-sdk-0.7.1-element.8.tgz#fffbbd7044834ba1e35778200203977b6ee6f07d"
-  integrity sha512-dvQpkeit+RhbyiSUgOVLwqCaS1rVi0ScWt5JbqM0NrOkR0xWaMUF+Lu8/PdsV7vRgfgh09mprBSjIFvHdoQgcg==
+"matrix-bot-sdk@npm:@vector-im/matrix-bot-sdk@0.7.1-element.9":
+  version "0.7.1-element.9"
+  resolved "https://registry.yarnpkg.com/@vector-im/matrix-bot-sdk/-/matrix-bot-sdk-0.7.1-element.9.tgz#63c03b76e2330bc0c9faf6607bdce636eabac7ab"
+  integrity sha512-Jmvo85Z2waX64ZtoHHG6tfguAf1UA2adPKIGwxDKY+4zgLqQjo4WoirU0DTHbLR1P72nlMJ0uBdryNSnfg80ng==
   dependencies:
     "@matrix-org/matrix-sdk-crypto-nodejs" "0.3.0-beta.1"
     "@types/express" "^4.17.21"


### PR DESCRIPTION
Simple tweak to help users who might otherwise be stuck with messages going missing. When paired with https://github.com/element-hq/synapse/pull/18521, this will also speed up recovery times.