### PR TITLE
Migrate GitHub, GitLab, and JIRA webhook path from `/` to `/<service>/webhook`

### DIFF
--- a/changelog.d/1063.misc
+++ b/changelog.d/1063.misc
@@ -1,0 +1,1 @@
+GitHub and GitLab webhook requests should now be directed to /github and /gitlab respectively. `/` and `/oauth` is now deprecated and will be removed in a future release.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -28,7 +28,6 @@
 
 # 🥼 Advanced
 
-- [Provisioning](./advanced/provisioning.md)
 - [Workers](./advanced/workers.md)
 - [🔒 Encryption](./advanced/encryption.md)
 - [🪀 Widgets](./advanced/widgets.md)

--- a/docs/advanced/provisioning.md
+++ b/docs/advanced/provisioning.md
@@ -1,5 +1,0 @@
-# Provisioning
-
-This section is not complete yet for end users. For developers, you can read the documentation for the API below:
-
-{{#include ../../src/provisioning/api.md}}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -231,8 +231,15 @@ This will pass all requests at `/widgetapi` to Hookshot.
 
 In terms of API endpoints:
 
-- The `webhooks` resource handles resources under `/`, so it should be on its own listener.
-  Note that OAuth requests also go through this listener. Previous versions of the bridge listened for requests on `/` rather than `/webhook`. While this behaviour will continue to work, administators are advised to use `/webhook`.
+- The `webhooks` resource handles incoming webhooks for various services. Currently, these are:
+  - `/github` for GitHub
+  - `/gitlab` for GitLab
+  - `/jira` for JIRA
+  - `/webhooks` for Generic Webhooks
+  - `/openproject` for OpenProject
+  - `/figma` for Figma.
+  - `/openproject` for OpenProject.
+  
 - The `metrics` resource handles resources under `/metrics`.
 - The `provisioning` resource handles resources under `/v1/...`.
 - The `widgets` resource handles resources under `/widgetapi/v1...`. This may only be bound to **one** listener at present.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -239,7 +239,6 @@ In terms of API endpoints:
   - `/openproject` for OpenProject
   - `/figma` for Figma.
   - `/openproject` for OpenProject.
-  
 - The `metrics` resource handles resources under `/metrics`.
 - The `provisioning` resource handles resources under `/v1/...`.
 - The `widgets` resource handles resources under `/widgetapi/v1...`. This may only be bound to **one** listener at present.

--- a/docs/setup/github.md
+++ b/docs/setup/github.md
@@ -6,7 +6,11 @@ This bridge requires a [GitHub App](https://github.com/settings/apps/new). You w
 
 ### Webhook
 
-The **Webhook URL** should point to the public address of your hookshot instance, at the `/` path.
+<section class="notice">
+Previously Hookshot supported <code>/</code> as the public path for webhook delivery. This path is now deprecated and <code>/github/webhook</code> should be used wherever possible.
+</section>
+
+The **Webhook URL** should point to the public address of your hookshot instance, at the `/github/webhook` path.
 You **MUST** also provide a secret, which should match the `github.webhook.secret` value in your config.
 
 ### Permissions

--- a/docs/setup/gitlab.md
+++ b/docs/setup/gitlab.md
@@ -23,7 +23,11 @@ to specify an instance.
 You should generate a webhook `secret` (e.g. `pwgen -n 64 -s 1`) and then use this as your
 "Secret token" when adding webhooks.
 
-The `publicUrl` must be the URL where GitLab webhook events are received (i.e. the path to `/`
+<section class="notice">
+Previously Hookshot supported <code>/</code> as the public path for webhook delivery. This path is now deprecated and <code>/gitlab/webhook</code> should be used wherever possible.
+</section>
+
+The `publicUrl` must be the URL where GitLab webhook events are received (i.e. the path to `/gitlab/webhook`
 for your `webhooks` listener).
 
 <section class="warning">

--- a/docs/setup/jira.md
+++ b/docs/setup/jira.md
@@ -4,6 +4,11 @@
 
 This should be done for the JIRA instance you wish to bridge. The setup steps vary for Cloud and Enterprise (on-premise).
 
+<section class="notice">
+Previously Hookshot supported <code>/</code> as the public path for webhook delivery. This path is now deprecated and <code>/jira</code> should be used wherever possible.
+</section>
+
+
 ### Cloud
 
 See https://support.atlassian.com/jira-cloud-administration/docs/manage-webhooks/ for documentation on how to setup webhooks.
@@ -15,7 +20,7 @@ Hookshot **requires** that you use a secret. Please copy the generated secret va
 You need to go to the `WebHooks` configuration page under Settings > System.
 Note that this may require administrative access to the JIRA instance.
 
-Next, add a webhook that points to `/` on the public webhooks address for hookshot. You must also include a
+Next, add a webhook that points to `/jira/webhook` on the public webhooks address for hookshot. You must also include a
 secret value by appending `?secret=your-webhook-secret`. The secret value can be anything, but should
 be reasonably secure and should also be stored in the `config.yml` file.
 

--- a/docs/setup/jira.md
+++ b/docs/setup/jira.md
@@ -8,7 +8,6 @@ This should be done for the JIRA instance you wish to bridge. The setup steps va
 Previously Hookshot supported <code>/</code> as the public path for webhook delivery. This path is now deprecated and <code>/jira</code> should be used wherever possible.
 </section>
 
-
 ### Cloud
 
 See https://support.atlassian.com/jira-cloud-administration/docs/manage-webhooks/ for documentation on how to setup webhooks.

--- a/spec/github.spec.ts
+++ b/spec/github.spec.ts
@@ -71,7 +71,7 @@ describe("GitHub", () => {
     return testEnv?.tearDown();
   });
 
-  test.each(["/", "/github/"])(
+  test.each(["/", "/github/webhook"])(
     "should be able to handle a GitHub event  (on path %s)",
     async (path) => {
       const user = testEnv.getUser("user");

--- a/spec/github.spec.ts
+++ b/spec/github.spec.ts
@@ -71,95 +71,101 @@ describe("GitHub", () => {
     return testEnv?.tearDown();
   });
 
-  test("should be able to handle a GitHub event", async () => {
-    const user = testEnv.getUser("user");
-    const bridgeApi = await getBridgeApi(
-      testEnv.opts.config?.widgets?.publicUrl!,
-      user,
-    );
-    const testRoomId = await user.createRoom({
-      name: "Test room",
-      invite: [testEnv.botMxid],
-    });
-    await user.setUserPowerLevel(testEnv.botMxid, testRoomId, 50);
-    await user.waitForRoomJoin({ sender: testEnv.botMxid, roomId: testRoomId });
-    // Now hack in a GitHub connection.
-    await testEnv.app.appservice.botClient.sendStateEvent(
-      testRoomId,
-      GitHubRepoConnection.CanonicalEventType,
-      "my-test",
-      {
-        org: "my-org",
-        repo: "my-repo",
-      } satisfies GitHubRepoConnectionState,
-    );
+  test.each(["/", "/gitlab"])(
+    "should be able to handle a GitHub event",
+    async (path) => {
+      const user = testEnv.getUser("user");
+      const bridgeApi = await getBridgeApi(
+        testEnv.opts.config?.widgets?.publicUrl!,
+        user,
+      );
+      const testRoomId = await user.createRoom({
+        name: "Test room",
+        invite: [testEnv.botMxid],
+      });
+      await user.setUserPowerLevel(testEnv.botMxid, testRoomId, 50);
+      await user.waitForRoomJoin({
+        sender: testEnv.botMxid,
+        roomId: testRoomId,
+      });
+      // Now hack in a GitHub connection.
+      await testEnv.app.appservice.botClient.sendStateEvent(
+        testRoomId,
+        GitHubRepoConnection.CanonicalEventType,
+        "my-test",
+        {
+          org: "my-org",
+          repo: "my-repo",
+        } satisfies GitHubRepoConnectionState,
+      );
 
-    // Wait for connection to be accepted.
-    await waitFor(
-      async () =>
-        (await bridgeApi.getConnectionsForRoom(testRoomId)).length === 1,
-    );
+      // Wait for connection to be accepted.
+      await waitFor(
+        async () =>
+          (await bridgeApi.getConnectionsForRoom(testRoomId)).length === 1,
+      );
 
-    const webhookNotice = user.waitForRoomEvent<MessageEventContent>({
-      eventType: "m.room.message",
-      sender: testEnv.botMxid,
-      roomId: testRoomId,
-    });
+      const webhookNotice = user.waitForRoomEvent<MessageEventContent>({
+        eventType: "m.room.message",
+        sender: testEnv.botMxid,
+        roomId: testRoomId,
+      });
 
-    const webhookPayload = JSON.stringify({
-      action: "opened",
-      number: 1,
-      pull_request: {
-        id: 1,
-        url: "https://api.github.com/repos/my-org/my-repo/pulls/1",
-        html_url: "https://github.com/my-org/my-repo/pulls/1",
+      const webhookPayload = JSON.stringify({
+        action: "opened",
         number: 1,
-        state: "open",
-        locked: false,
-        title: "My test pull request",
-        user: {
+        pull_request: {
+          id: 1,
+          url: "https://api.github.com/repos/my-org/my-repo/pulls/1",
+          html_url: "https://github.com/my-org/my-repo/pulls/1",
+          number: 1,
+          state: "open",
+          locked: false,
+          title: "My test pull request",
+          user: {
+            login: "alice",
+          },
+        },
+        repository: {
+          id: 1,
+          html_url: "https://github.com/my-org/my-repo",
+          name: "my-repo",
+          full_name: "my-org/my-repo",
+          owner: {
+            login: "my-org",
+          },
+        },
+        sender: {
           login: "alice",
         },
-      },
-      repository: {
-        id: 1,
-        html_url: "https://github.com/my-org/my-repo",
-        name: "my-repo",
-        full_name: "my-org/my-repo",
-        owner: {
-          login: "my-org",
+      });
+
+      const hmac = createHmac(
+        "sha256",
+        testEnv.opts.config?.github?.webhook.secret!,
+      );
+      hmac.write(webhookPayload);
+      hmac.end();
+
+      // Send a webhook
+      const req = await fetch(`http://localhost:${webhooksPort}${path}`, {
+        method: "POST",
+        headers: {
+          "x-github-event": "pull_request",
+          "X-Hub-Signature-256": `sha256=${hmac.read().toString("hex")}`,
+          "X-GitHub-Delivery": randomUUID(),
+          "Content-Type": "application/json",
         },
-      },
-      sender: {
-        login: "alice",
-      },
-    });
+        body: webhookPayload,
+      });
+      expect(req.status).toBe(200);
+      expect(await req.text()).toBe("OK");
 
-    const hmac = createHmac(
-      "sha256",
-      testEnv.opts.config?.github?.webhook.secret!,
-    );
-    hmac.write(webhookPayload);
-    hmac.end();
-
-    // Send a webhook
-    const req = await fetch(`http://localhost:${webhooksPort}/`, {
-      method: "POST",
-      headers: {
-        "x-github-event": "pull_request",
-        "X-Hub-Signature-256": `sha256=${hmac.read().toString("hex")}`,
-        "X-GitHub-Delivery": randomUUID(),
-        "Content-Type": "application/json",
-      },
-      body: webhookPayload,
-    });
-    expect(req.status).toBe(200);
-    expect(await req.text()).toBe("OK");
-
-    // And await the notice.
-    const { body } = (await webhookNotice).data.content;
-    expect(body).toContain("**alice** opened a new PR");
-    expect(body).toContain("https://github.com/my-org/my-repo/pulls/1");
-    expect(body).toContain("My test pull request");
-  });
+      // And await the notice.
+      const { body } = (await webhookNotice).data.content;
+      expect(body).toContain("**alice** opened a new PR");
+      expect(body).toContain("https://github.com/my-org/my-repo/pulls/1");
+      expect(body).toContain("My test pull request");
+    },
+  );
 });

--- a/spec/github.spec.ts
+++ b/spec/github.spec.ts
@@ -72,7 +72,7 @@ describe("GitHub", () => {
   });
 
   test.each(["/", "/github/"])(
-    "should be able to handle a GitHub event on (path %s)",
+    "should be able to handle a GitHub event  (on path %s)",
     async (path) => {
       const user = testEnv.getUser("user");
       const bridgeApi = await getBridgeApi(

--- a/spec/github.spec.ts
+++ b/spec/github.spec.ts
@@ -71,8 +71,8 @@ describe("GitHub", () => {
     return testEnv?.tearDown();
   });
 
-  test.each(["/", "/gitlab"])(
-    "should be able to handle a GitHub event",
+  test.each(["/", "/github/"])(
+    "should be able to handle a GitHub event on (path %s)",
     async (path) => {
       const user = testEnv.getUser("user");
       const bridgeApi = await getBridgeApi(

--- a/spec/gitlab.spec.ts
+++ b/spec/gitlab.spec.ts
@@ -24,10 +24,10 @@ describe("GitLab", () => {
             secret: randomUUID(),
           },
           instances: {
-            'example.org': {
-              url: 'http://gitlab.example.org'
-            }
-          }
+            "example.org": {
+              url: "http://gitlab.example.org",
+            },
+          },
         },
         widgets: {
           publicUrl: `http://localhost:${webhooksPort}`,
@@ -50,7 +50,7 @@ describe("GitLab", () => {
   });
 
   test.each(["/", "/gitlab/"])(
-    "should be able to handle a GitLab event on (path %s)",
+    "should be able to handle a GitLab event (on path %s)",
     async (path) => {
       const user = testEnv.getUser("user");
       const bridgeApi = await getBridgeApi(
@@ -73,7 +73,7 @@ describe("GitLab", () => {
         "my-test",
         {
           instance: "example.org",
-          path: 'my-project',
+          path: "my-project",
         } satisfies GitLabRepoConnectionState,
       );
 
@@ -91,37 +91,35 @@ describe("GitLab", () => {
 
       const webhookPayload = JSON.stringify({
         object_kind: "merge_request",
-        event_type: 'any',
+        event_type: "any",
         user: {
-          username: 'alice',
-          name: 'Alice',
-          email: 'alice@example.org',
-          avatar_url: 'foobar'
+          username: "alice",
+          name: "Alice",
+          email: "alice@example.org",
+          avatar_url: "foobar",
         },
         project: {
-          path_with_namespace: 'my-project',
-          web_url: 'https://gilab.example.org/my-project',
-          homepage: 'foo',
+          path_with_namespace: "my-project",
+          web_url: "https://gilab.example.org/my-project",
+          homepage: "foo",
         },
         repository: {
-          name: 'example',
-          homepage: 'foo',
-          url: 'https://gilab.example.org',
-          description: 'https://gilab.example.org/my-project'
+          name: "example",
+          homepage: "foo",
+          url: "https://gilab.example.org",
+          description: "https://gilab.example.org/my-project",
         },
         object_attributes: {
-          action: 'open',
-          title: 'My test MR',
-          url: 'https://gilab.example.org/my-project/-/merge_requests/1',
+          action: "open",
+          title: "My test MR",
+          url: "https://gilab.example.org/my-project/-/merge_requests/1",
           iid: 0,
           author_id: 0,
           state: "opened",
-          labels: []
+          labels: [],
         },
         labels: [],
-        changes: {
-
-        }
+        changes: {},
       } satisfies IGitLabWebhookMREvent);
 
       // Send a webhook
@@ -139,7 +137,9 @@ describe("GitLab", () => {
       // And await the notice.
       const { body } = (await webhookNotice).data.content;
       expect(body).toContain("**alice** opened a new MR");
-      expect(body).toContain("https://gilab.example.org/my-project/-/merge_requests/1");
+      expect(body).toContain(
+        "https://gilab.example.org/my-project/-/merge_requests/1",
+      );
       expect(body).toContain("My test MR");
     },
   );

--- a/spec/gitlab.spec.ts
+++ b/spec/gitlab.spec.ts
@@ -49,7 +49,7 @@ describe("GitLab", () => {
     return testEnv?.tearDown();
   });
 
-  test.each(["/", "/gitlab/"])(
+  test.each(["/", "/gitlab/webhook"])(
     "should be able to handle a GitLab event (on path %s)",
     async (path) => {
       const user = testEnv.getUser("user");

--- a/spec/gitlab.spec.ts
+++ b/spec/gitlab.spec.ts
@@ -1,0 +1,146 @@
+import { E2ESetupTestTimeout, E2ETestEnv } from "./util/e2e-test";
+import { describe, test, beforeAll, afterAll, expect } from "vitest";
+
+import { createHmac, randomUUID } from "crypto";
+import {
+  GitLabRepoConnection,
+  GitLabRepoConnectionState,
+} from "../src/Connections";
+import { MessageEventContent } from "matrix-bot-sdk";
+import { getBridgeApi } from "./util/bridge-api";
+import { waitFor } from "./util/helpers";
+import { IGitLabWebhookMREvent } from "../src/gitlab/WebhookTypes";
+
+describe("GitLab", () => {
+  let testEnv: E2ETestEnv;
+  const webhooksPort = 9500 + E2ETestEnv.workerId;
+
+  beforeAll(async () => {
+    testEnv = await E2ETestEnv.createTestEnv({
+      matrixLocalparts: ["user"],
+      config: {
+        gitlab: {
+          webhook: {
+            secret: randomUUID(),
+          },
+          instances: {
+            'example.org': {
+              url: 'http://gitlab.example.org'
+            }
+          }
+        },
+        widgets: {
+          publicUrl: `http://localhost:${webhooksPort}`,
+        },
+        listeners: [
+          {
+            port: webhooksPort,
+            bindAddress: "0.0.0.0",
+            // Bind to the SAME listener to ensure we don't have conflicts.
+            resources: ["webhooks", "widgets"],
+          },
+        ],
+      },
+    });
+    await testEnv.setUp();
+  }, E2ESetupTestTimeout);
+
+  afterAll(() => {
+    return testEnv?.tearDown();
+  });
+
+  test.each(["/", "/gitlab/"])(
+    "should be able to handle a GitLab event on (path %s)",
+    async (path) => {
+      const user = testEnv.getUser("user");
+      const bridgeApi = await getBridgeApi(
+        testEnv.opts.config?.widgets?.publicUrl!,
+        user,
+      );
+      const testRoomId = await user.createRoom({
+        name: "Test room",
+        invite: [testEnv.botMxid],
+      });
+      await user.setUserPowerLevel(testEnv.botMxid, testRoomId, 50);
+      await user.waitForRoomJoin({
+        sender: testEnv.botMxid,
+        roomId: testRoomId,
+      });
+      // Now hack in a GitLab connection.
+      await testEnv.app.appservice.botClient.sendStateEvent(
+        testRoomId,
+        GitLabRepoConnection.CanonicalEventType,
+        "my-test",
+        {
+          instance: "example.org",
+          path: 'my-project',
+        } satisfies GitLabRepoConnectionState,
+      );
+
+      // Wait for connection to be accepted.
+      await waitFor(
+        async () =>
+          (await bridgeApi.getConnectionsForRoom(testRoomId)).length === 1,
+      );
+
+      const webhookNotice = user.waitForRoomEvent<MessageEventContent>({
+        eventType: "m.room.message",
+        sender: testEnv.botMxid,
+        roomId: testRoomId,
+      });
+
+      const webhookPayload = JSON.stringify({
+        object_kind: "merge_request",
+        event_type: 'any',
+        user: {
+          username: 'alice',
+          name: 'Alice',
+          email: 'alice@example.org',
+          avatar_url: 'foobar'
+        },
+        project: {
+          path_with_namespace: 'my-project',
+          web_url: 'https://gilab.example.org/my-project',
+          homepage: 'foo',
+        },
+        repository: {
+          name: 'example',
+          homepage: 'foo',
+          url: 'https://gilab.example.org',
+          description: 'https://gilab.example.org/my-project'
+        },
+        object_attributes: {
+          action: 'open',
+          title: 'My test MR',
+          url: 'https://gilab.example.org/my-project/-/merge_requests/1',
+          iid: 0,
+          author_id: 0,
+          state: "opened",
+          labels: []
+        },
+        labels: [],
+        changes: {
+
+        }
+      } satisfies IGitLabWebhookMREvent);
+
+      // Send a webhook
+      const req = await fetch(`http://localhost:${webhooksPort}${path}`, {
+        method: "POST",
+        headers: {
+          "x-gitlab-token": testEnv.opts.config?.gitlab?.webhook.secret!,
+          "Content-Type": "application/json",
+        },
+        body: webhookPayload,
+      });
+      expect(req.status).toBe(200);
+      expect(await req.text()).toBe("OK");
+
+      // And await the notice.
+      const { body } = (await webhookNotice).data.content;
+      expect(body).toContain("**alice** opened a new MR");
+      expect(body).toContain("https://gilab.example.org/my-project/-/merge_requests/1");
+      expect(body).toContain("My test MR");
+    },
+  );
+});

--- a/spec/jira.spec.ts
+++ b/spec/jira.spec.ts
@@ -113,7 +113,7 @@ describe("JIRA", () => {
     return testEnv?.tearDown();
   });
 
-  test.each(["/", "/jira"])(
+  test.each(["/", "/jira/webhook"])(
     "should be able to handle a JIRA event (on path %s)",
     async (path) => {
       const user = testEnv.getUser("user");

--- a/spec/jira.spec.ts
+++ b/spec/jira.spec.ts
@@ -113,72 +113,78 @@ describe("JIRA", () => {
     return testEnv?.tearDown();
   });
 
-  test("should be able to handle a JIRA event", async () => {
-    const user = testEnv.getUser("user");
-    const bridgeApi = await getBridgeApi(
-      testEnv.opts.config?.widgets?.publicUrl!,
-      user,
-    );
-    const testRoomId = await user.createRoom({
-      name: "Test room",
-      invite: [testEnv.botMxid],
-    });
-    await user.setUserPowerLevel(testEnv.botMxid, testRoomId, 50);
-    const jiraURL = JIRA_PAYLOAD.issue.fields.project.self;
-    // Pre-grant connection to allow us to bypass the oauth dance.
-    await user.waitForRoomJoin({ sender: testEnv.botMxid, roomId: testRoomId });
-    const granter = new JiraGrantChecker(testEnv.app.appservice, null as any);
-    await granter.grantConnection(testRoomId, {
-      url: jiraURL,
-    });
-
-    // "Create" a JIRA connection.
-    await testEnv.app.appservice.botClient.sendStateEvent(
-      testRoomId,
-      JiraProjectConnection.CanonicalEventType,
-      jiraURL,
-      {
+  test.each(["/", "/jira"])(
+    "should be able to handle a JIRA event (on path %s)",
+    async (path) => {
+      const user = testEnv.getUser("user");
+      const bridgeApi = await getBridgeApi(
+        testEnv.opts.config?.widgets?.publicUrl!,
+        user,
+      );
+      const testRoomId = await user.createRoom({
+        name: "Test room",
+        invite: [testEnv.botMxid],
+      });
+      await user.setUserPowerLevel(testEnv.botMxid, testRoomId, 50);
+      const jiraURL = JIRA_PAYLOAD.issue.fields.project.self;
+      // Pre-grant connection to allow us to bypass the oauth dance.
+      await user.waitForRoomJoin({
+        sender: testEnv.botMxid,
+        roomId: testRoomId,
+      });
+      const granter = new JiraGrantChecker(testEnv.app.appservice, null as any);
+      await granter.grantConnection(testRoomId, {
         url: jiraURL,
-      } satisfies JiraProjectConnectionState,
-    );
+      });
 
-    await waitFor(
-      async () =>
-        (await bridgeApi.getConnectionsForRoom(testRoomId)).length === 1,
-    );
+      // "Create" a JIRA connection.
+      await testEnv.app.appservice.botClient.sendStateEvent(
+        testRoomId,
+        JiraProjectConnection.CanonicalEventType,
+        jiraURL,
+        {
+          url: jiraURL,
+        } satisfies JiraProjectConnectionState,
+      );
 
-    const webhookNotice = user.waitForRoomEvent<MessageEventContent>({
-      eventType: "m.room.message",
-      sender: testEnv.botMxid,
-      roomId: testRoomId,
-    });
+      await waitFor(
+        async () =>
+          (await bridgeApi.getConnectionsForRoom(testRoomId)).length === 1,
+      );
 
-    const webhookPayload = JSON.stringify(JIRA_PAYLOAD);
+      const webhookNotice = user.waitForRoomEvent<MessageEventContent>({
+        eventType: "m.room.message",
+        sender: testEnv.botMxid,
+        roomId: testRoomId,
+      });
 
-    const hmac = createHmac(
-      "sha256",
-      testEnv.opts.config?.jira?.webhook.secret!,
-    );
-    hmac.write(webhookPayload);
-    hmac.end();
+      const webhookPayload = JSON.stringify(JIRA_PAYLOAD);
 
-    // Send a webhook
-    const req = await fetch(`http://localhost:${webhooksPort}/`, {
-      method: "POST",
-      headers: {
-        "X-Hub-Signature": `sha256=${hmac.read().toString("hex")}`,
-        "x-atlassian-webhook-identifier": randomUUID(),
-        "Content-Type": "application/json",
-      },
-      body: webhookPayload,
-    });
-    expect(req.status).toBe(200);
-    expect(await req.text()).toBe("OK");
+      const hmac = createHmac(
+        "sha256",
+        testEnv.opts.config?.jira?.webhook.secret!,
+      );
+      hmac.write(webhookPayload);
+      hmac.end();
 
-    // And await the notice.
-    const { body } = (await webhookNotice).data.content;
-    expect(body).toContain(
-      'Test User created a new JIRA issue [TP-8](https://example.org/browse/TP-8): "Test issue"',
-    );
-  });
+      // Send a webhook
+      const req = await fetch(`http://localhost:${webhooksPort}${path}`, {
+        method: "POST",
+        headers: {
+          "X-Hub-Signature": `sha256=${hmac.read().toString("hex")}`,
+          "x-atlassian-webhook-identifier": randomUUID(),
+          "Content-Type": "application/json",
+        },
+        body: webhookPayload,
+      });
+      expect(req.status).toBe(200);
+      expect(await req.text()).toBe("OK");
+
+      // And await the notice.
+      const { body } = (await webhookNotice).data.content;
+      expect(body).toContain(
+        'Test User created a new JIRA issue [TP-8](https://example.org/browse/TP-8): "Test issue"',
+      );
+    },
+  );
 });

--- a/src/Bridge.ts
+++ b/src/Bridge.ts
@@ -70,18 +70,18 @@ import {
   NotificationFilterStateContent,
 } from "./NotificationFilters";
 import { NotificationProcessor } from "./NotificationsProcessor";
-import {
-  NotificationsEnableEvent,
-  NotificationsDisableEvent,
-  Webhooks,
-} from "./Webhooks";
+import { Webhooks } from "./Webhooks";
 import {
   GitHubOAuthToken,
   GitHubOAuthTokenResponse,
   ProjectsGetResponseData,
 } from "./github/Types";
 import { retry } from "./PromiseUtil";
-import { UserNotificationsEvent } from "./notifications/UserNotificationWatcher";
+import {
+  NotificationsDisableEvent,
+  NotificationsEnableEvent,
+  UserNotificationsEvent,
+} from "./notifications/UserNotificationWatcher";
 import { UserTokenStore } from "./tokens/UserTokenStore";
 import * as GitHubWebhookTypes from "@octokit/webhooks-types";
 import { Logger } from "matrix-appservice-bridge";

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -41,7 +41,7 @@ export class Webhooks extends EventEmitter {
 
     if (this.config.gitlab) {
       this.gitlab = new GitLabWebhooksRouter(this.config.gitlab, this.queue);
-      this.expressRouter.use("/github", this.gitlab.getRouter());
+      this.expressRouter.use("/gitlab", this.gitlab.getRouter());
     }
 
     if (this.config.jira) {

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -1,33 +1,22 @@
-/* eslint-disable camelcase */
 import { BridgeConfig } from "./config/Config";
 import { Router, default as express, Request, Response } from "express";
 import { EventEmitter } from "events";
 import { MessageQueue, createMessageQueue } from "./messageQueue";
 import { Logger } from "matrix-appservice-bridge";
-import qs from "querystring";
-import axios from "axios";
 import {
   IGitLabWebhookEvent,
   IGitLabWebhookIssueStateEvent,
   IGitLabWebhookMREvent,
   IGitLabWebhookReleaseEvent,
 } from "./gitlab/WebhookTypes";
-import {
-  EmitterWebhookEvent,
-  Webhooks as OctokitWebhooks,
-} from "@octokit/webhooks";
 import { IJiraWebhookEvent } from "./jira/WebhookTypes";
 import { JiraWebhooksRouter } from "./jira/Router";
-import { GitHubOAuthTokenResponse } from "./github/Types";
 import Metrics from "./Metrics";
 import { FigmaWebhooksRouter } from "./figma/Router";
 import { GenericWebhooksRouter } from "./generic/Router";
-import { GithubInstance } from "./github/GithubInstance";
-import QuickLRU from "@alloc/quick-lru";
-import type { WebhookEventName } from "@octokit/webhooks-types";
 import { ApiError, ErrCode } from "./api";
 import { OpenProjectWebhooksRouter } from "./openproject/Router";
-import { OAuthRequest } from "./tokens/Oauth";
+import { GitHubWebhooksRouter } from "./github/Router";
 
 const log = new Logger("Webhooks");
 
@@ -47,48 +36,29 @@ export interface NotificationsDisableEvent {
   instanceUrl?: string;
 }
 
-export interface OAuthPageParams {
-  service?: string;
-  result?: string;
-  "oauth-kind"?: "account" | "organisation";
-  error?: string;
-  errcode?: ErrCode;
-}
-
-interface GitHubRequestData {
-  payload: string;
-  signature: string;
-}
-
-interface WebhooksExpressRequest extends Request {
-  github?: GitHubRequestData;
-}
-
 export class Webhooks extends EventEmitter {
   public readonly expressRouter = Router();
   private readonly queue: MessageQueue;
-  private readonly ghWebhooks?: OctokitWebhooks;
-  private readonly handledGuids = new QuickLRU<string, void>({
-    maxAge: 5000,
-    maxSize: 100,
-  });
   private readonly jira?: JiraWebhooksRouter;
+  private readonly github?: GitHubWebhooksRouter;
   constructor(private config: BridgeConfig) {
     super();
     this.expressRouter.use((req, _res, next) => {
       Metrics.webhooksHttpRequest.inc({ path: req.path, method: req.method });
       next();
     });
-    if (config.github?.webhook.secret) {
-      this.ghWebhooks = new OctokitWebhooks({
-        secret: config.github.webhook.secret,
-      });
-      this.ghWebhooks.onAny((e) => this.onGitHubPayload(e));
+
+    this.queue = createMessageQueue(config.queue);
+
+    if (this.config.github) {
+      this.github = new GitHubWebhooksRouter(
+        this.config.github,
+        this.queue,
+        this.config.widgets?.parsedPublicUrl,
+      );
+      this.expressRouter.use("/github", this.github.getRouter());
     }
 
-    // TODO: Move these
-    this.expressRouter.get("/oauth", this.onGitHubGetOauth.bind(this));
-    this.queue = createMessageQueue(config.queue);
     if (this.config.jira) {
       this.jira = new JiraWebhooksRouter(
         this.queue,
@@ -136,6 +106,10 @@ export class Webhooks extends EventEmitter {
       }),
     );
     this.expressRouter.post("/", this.onPayload.bind(this));
+    if (this.github) {
+      // Legacy path.
+      this.expressRouter.get("/oauth", this.github.onGetOAuth.bind(this));
+    }
   }
 
   public stop() {
@@ -193,54 +167,19 @@ export class Webhooks extends EventEmitter {
     return `jira.${body.webhookEvent}`;
   }
 
-  private async onGitHubPayload({ id, name, payload }: EmitterWebhookEvent) {
-    const action = (payload as unknown as { action: string | undefined })
-      .action;
-    const eventName = `github.${name}${action ? `.${action}` : ""}`;
-    log.debug(`Got GitHub webhook event ${id} ${eventName}`, payload);
-    try {
-      await this.queue.push({
-        eventName,
-        sender: "Webhooks",
-        data: payload,
-      });
-    } catch (err) {
-      log.error(`Failed to emit payload ${id}: ${err}`);
-    }
-  }
-
-  private onPayload(req: WebhooksExpressRequest, res: Response) {
+  private onPayload(req: Request, res: Response) {
     try {
       let eventName: string | null = null;
       const body = req.body;
-      const githubGuid = req.headers["x-github-delivery"] as string | undefined;
-      if (githubGuid) {
-        if (!this.ghWebhooks) {
+      if (GitHubWebhooksRouter.IsRequest(req)) {
+        if (!this.github) {
           log.warn(
             `Not configured for GitHub webhooks, but got a GitHub event`,
           );
           res.sendStatus(500);
           return;
         }
-        res.sendStatus(200);
-        if (this.handledGuids.has(githubGuid)) {
-          return;
-        }
-        this.handledGuids.set(githubGuid);
-        const githubData = req.github as GitHubRequestData;
-        if (!githubData) {
-          throw Error("Expected github data to be set on request");
-        }
-        this.ghWebhooks
-          .verifyAndReceive({
-            id: githubGuid as string,
-            name: req.headers["x-github-event"] as WebhookEventName,
-            payload: githubData.payload,
-            signature: githubData.signature,
-          })
-          .catch((err) => {
-            log.error(`Failed handle GitHubEvent: ${err}`);
-          });
+        this.github.onWebhook(req, res);
         return;
       } else if (req.headers["x-gitlab-token"]) {
         res.sendStatus(200);
@@ -275,146 +214,8 @@ export class Webhooks extends EventEmitter {
     }
   }
 
-  public async onGitHubGetOauth(
-    req: Request<
-      unknown,
-      unknown,
-      unknown,
-      {
-        error?: string;
-        error_description?: string;
-        code?: string;
-        state?: string;
-        setup_action?: "install";
-      }
-    >,
-    res: Response,
-  ) {
-    const oauthResultParams: OAuthPageParams = {
-      service: "github",
-    };
-
-    const { setup_action, state } = req.query;
-    log.info("Got new oauth request", { state, setup_action });
-    try {
-      if (!this.config.github || !this.config.github.oauth) {
-        throw new ApiError(
-          "Bridge is not configured with OAuth support",
-          ErrCode.DisabledFeature,
-        );
-      }
-      if (req.query.error) {
-        throw new ApiError(
-          `GitHub Error: ${req.query.error} ${req.query.error_description}`,
-          ErrCode.Unknown,
-        );
-      }
-      if (setup_action === "install") {
-        // GitHub App successful install.
-        oauthResultParams["oauth-kind"] = "organisation";
-        oauthResultParams.result = "success";
-      } else if (setup_action === "request") {
-        // GitHub App install is pending
-        oauthResultParams["oauth-kind"] = "organisation";
-        oauthResultParams.result = "pending";
-      } else if (setup_action) {
-        // GitHub App install is in another, unknown state.
-        oauthResultParams["oauth-kind"] = "organisation";
-        oauthResultParams.result = setup_action;
-      } else {
-        // This is a user account setup flow.
-        oauthResultParams["oauth-kind"] = "account";
-        if (!state) {
-          throw new ApiError(`Missing state`, ErrCode.BadValue);
-        }
-        if (!req.query.code) {
-          throw new ApiError(`Missing code`, ErrCode.BadValue);
-        }
-        const exists = await this.queue.pushWait<OAuthRequest, boolean>({
-          eventName: "github.oauth.response",
-          sender: "GithubWebhooks",
-          data: {
-            state,
-            code: req.query.code,
-          },
-        });
-        if (!exists) {
-          throw new ApiError(
-            `Could not find user which authorised this request. Has it timed out?`,
-            undefined,
-            404,
-          );
-        }
-        const accessTokenUrl = GithubInstance.generateOAuthUrl(
-          this.config.github.baseUrl,
-          "access_token",
-          {
-            client_id: this.config.github.oauth.client_id,
-            client_secret: this.config.github.oauth.client_secret,
-            code: req.query.code as string,
-            redirect_uri: this.config.github.oauth.redirect_uri,
-            state: req.query.state as string,
-          },
-        );
-        const accessTokenRes = await axios.post(accessTokenUrl);
-        const result = qs.parse(accessTokenRes.data) as
-          | GitHubOAuthTokenResponse
-          | { error: string; error_description: string; error_uri: string };
-        if ("error" in result) {
-          throw new ApiError(
-            `GitHub Error: ${result.error} ${result.error_description}`,
-            ErrCode.Unknown,
-          );
-        }
-        oauthResultParams.result = "success";
-        await this.queue.push<GitHubOAuthTokenResponse>({
-          eventName: "github.oauth.tokens",
-          sender: "GithubWebhooks",
-          data: { ...result, state: req.query.state as string },
-        });
-      }
-    } catch (ex) {
-      if (ex instanceof ApiError) {
-        oauthResultParams.result = "error";
-        oauthResultParams.error = ex.error;
-        oauthResultParams.errcode = ex.errcode;
-      } else {
-        log.error("Failed to handle oauth request:", ex);
-        return res.status(500).send("Failed to handle oauth request");
-      }
-    }
-    const oauthUrl =
-      this.config.widgets &&
-      new URL("oauth.html", this.config.widgets.parsedPublicUrl);
-    if (oauthUrl) {
-      // If we're serving widgets, do something prettier.
-      Object.entries(oauthResultParams).forEach(([key, value]) =>
-        oauthUrl.searchParams.set(key, value),
-      );
-      return res.redirect(oauthUrl.toString());
-    } else {
-      if (oauthResultParams.result === "success") {
-        return res.send(
-          `<p> Your ${oauthResultParams.service} ${oauthResultParams["oauth-kind"]} has been bridged </p>`,
-        );
-      } else if (oauthResultParams.result === "error") {
-        return res
-          .status(500)
-          .send(
-            `<p> There was an error bridging your ${oauthResultParams.service} ${oauthResultParams["oauth-kind"]}. ${oauthResultParams.error} ${oauthResultParams.errcode} </p>`,
-          );
-      } else {
-        return res
-          .status(500)
-          .send(
-            `<p> Your ${oauthResultParams.service} ${oauthResultParams["oauth-kind"]} is in state ${oauthResultParams.result} </p>`,
-          );
-      }
-    }
-  }
-
   private verifyRequest(
-    req: WebhooksExpressRequest,
+    req: Request,
     _res: Response,
     buffer: Buffer,
     encoding: BufferEncoding,
@@ -427,26 +228,9 @@ export class Webhooks extends EventEmitter {
         );
       }
       return;
-    } else if (this.ghWebhooks && req.headers["x-hub-signature-256"]) {
-      if (typeof req.headers["x-hub-signature-256"] !== "string") {
-        throw new ApiError(
-          "Could not handle GitHub request. Unexpected multiple headers for x-hub-signature-256",
-          ErrCode.BadValue,
-        );
-      }
-      try {
-        const jsonStr = buffer.toString(encoding);
-        req.github = {
-          payload: jsonStr,
-          signature: req.headers["x-hub-signature-256"],
-        };
-      } catch (ex) {
-        log.warn("GitHub signature could not be decoded", ex);
-        throw new ApiError(
-          "Could not handle GitHub request. Signature could not be decoded",
-          ErrCode.BadValue,
-        );
-      }
+    } else if (this.github && req.headers["x-hub-signature-256"]) {
+      // XXX: Legacy
+      this.github.verifyRequest(req, _res, buffer, encoding);
       return;
     } else if (this.jira && JiraWebhooksRouter.IsJIRARequest(req)) {
       this.jira.verifyWebhookRequest(req, buffer);

--- a/src/github/Router.ts
+++ b/src/github/Router.ts
@@ -292,7 +292,7 @@ export class GitHubWebhooksRouter {
   public getRouter() {
     const router = Router();
     router.use(json({ verify: this.verifyRequest.bind(this) }));
-    router.get("/", this.onWebhook.bind(this));
+    router.post("/", this.onWebhook.bind(this));
     router.get("/oauth", this.onGetOAuth.bind(this));
     return router;
   }

--- a/src/github/Router.ts
+++ b/src/github/Router.ts
@@ -41,10 +41,7 @@ export class GitHubWebhooksRouter {
     maxSize: 100,
   });
   public static IsRequest(req: Request): boolean {
-    if (req.headers["x-github-delivery"]) {
-      return true; // Cloud
-    }
-    return false;
+    return !!req.headers["x-github-delivery"];
   }
 
   constructor(

--- a/src/github/Router.ts
+++ b/src/github/Router.ts
@@ -292,7 +292,7 @@ export class GitHubWebhooksRouter {
   public getRouter() {
     const router = Router();
     router.use(json({ verify: this.verifyRequest.bind(this) }));
-    router.post("/", this.onWebhook.bind(this));
+    router.post("/webhook", this.onWebhook.bind(this));
     router.get("/oauth", this.onGetOAuth.bind(this));
     return router;
   }

--- a/src/github/Router.ts
+++ b/src/github/Router.ts
@@ -1,282 +1,302 @@
-import { Router, Request, Response, NextFunction } from "express";
-import { BridgeConfigGitHub } from "../config/Config";
+import { Request, Response, Router, json } from "express";
+import { MessageQueue } from "../messageQueue";
 import { ApiError, ErrCode } from "../api";
-import { UserTokenStore } from "../tokens/UserTokenStore";
 import { Logger } from "matrix-appservice-bridge";
+import { OAuthRequest } from "../tokens/Oauth";
+import { BridgeConfigGitHub } from "../config/Config";
+import {
+  EmitterWebhookEvent,
+  Webhooks as OctokitWebhooks,
+} from "@octokit/webhooks";
+import QuickLRU from "@alloc/quick-lru";
+import { WebhookEventName } from "@octokit/webhooks-types";
 import { GithubInstance } from "./GithubInstance";
-import { NAMELESS_ORG_PLACEHOLDER } from "./Types";
+import axios from "axios";
+import { GitHubOAuthTokenResponse } from "./Types";
+import qs from "querystring";
 
-const log = new Logger("GitHubProvisionerRouter");
-interface GitHubAccountStatus {
-  loggedIn: boolean;
-  username?: string;
-  organisations?: {
-    name: string;
-    avatarUrl?: string;
-  }[];
-}
-interface GitHubRepoItem {
-  name: string;
-  owner: string;
-  fullName: string;
-  description: string | null;
-  avatarUrl: string;
+const log = new Logger("GitHubWebhooksRouter");
+
+interface GitHubRequestData {
+  payload: string;
+  signature: string;
 }
 
-interface GitHubRepoResponse {
-  page: number;
-  repositories: GitHubRepoItem[];
-  changeSelectionUrl?: string;
+interface WebhooksExpressRequest extends Request {
+  github?: GitHubRequestData;
 }
 
-export class GitHubProvisionerRouter {
+export interface OAuthPageParams {
+  service?: string;
+  result?: string;
+  "oauth-kind"?: "account" | "organisation";
+  error?: string;
+  errcode?: ErrCode;
+}
+
+export class GitHubWebhooksRouter {
+  private readonly ghWebhooks: OctokitWebhooks<unknown>;
+  private readonly handledGuids = new QuickLRU<string, void>({
+    maxAge: 5000,
+    maxSize: 100,
+  });
+  public static IsRequest(req: Request): boolean {
+    if (req.headers["x-github-delivery"]) {
+      return true; // Cloud
+    }
+    return false;
+  }
+
   constructor(
     private readonly config: BridgeConfigGitHub,
-    private readonly tokenStore: UserTokenStore,
-    private readonly githubInstance: GithubInstance,
-  ) {}
+    private readonly queue: MessageQueue,
+    private readonly widgetsUrl?: URL,
+  ) {
+    this.ghWebhooks = new OctokitWebhooks({
+      secret: config.webhook.secret,
+    });
+    this.ghWebhooks.onAny((e) => this.payloadHandler(e));
+  }
+
+  private async payloadHandler({ id, name, payload }: EmitterWebhookEvent) {
+    const action = (payload as unknown as { action: string | undefined })
+      .action;
+    const eventName = `github.${name}${action ? `.${action}` : ""}`;
+    log.debug(`Got GitHub webhook event ${id} ${eventName}`, payload);
+    try {
+      await this.queue.push({
+        eventName,
+        sender: "Webhooks",
+        data: payload,
+      });
+    } catch (err) {
+      log.error(`Failed to emit payload ${id}: ${err}`);
+    }
+  }
+
+  public verifyRequest(
+    req: WebhooksExpressRequest,
+    _res: Response,
+    buffer: Buffer,
+    encoding: BufferEncoding,
+  ): void {
+    if (typeof req.headers["x-hub-signature-256"] !== "string") {
+      throw new ApiError(
+        "Could not handle GitHub request. Unexpected multiple headers for x-hub-signature-256",
+        ErrCode.BadValue,
+      );
+    }
+    try {
+      const jsonStr = buffer.toString(encoding);
+      req.github = {
+        payload: jsonStr,
+        signature: req.headers["x-hub-signature-256"],
+      };
+    } catch (ex) {
+      log.warn("GitHub signature could not be decoded", ex);
+      throw new ApiError(
+        "Could not handle GitHub request. Signature could not be decoded",
+        ErrCode.BadValue,
+      );
+    }
+  }
+
+  public onWebhook(
+    req: WebhooksExpressRequest,
+    res: Response<string | { error: string }>,
+  ) {
+    const githubGuid = req.headers["x-github-delivery"];
+    const githubEvent = req.headers["x-github-event"];
+    if (githubGuid === undefined) {
+      throw new ApiError(
+        "GitHub request did not have a x-github-delivery header",
+        ErrCode.BadValue,
+      );
+    }
+
+    if (typeof githubGuid !== "string") {
+      throw new ApiError(
+        "Header x-github-delivery was invalid",
+        ErrCode.BadValue,
+      );
+    }
+
+    if (githubEvent === undefined) {
+      throw new ApiError(
+        "GitHub request did not have a x-github-delivery header",
+        ErrCode.BadValue,
+      );
+    }
+
+    if (typeof githubEvent !== "string") {
+      throw new ApiError(
+        "Header x-github-delivery was invalid",
+        ErrCode.BadValue,
+      );
+    }
+    // Send response early.
+    res.sendStatus(200);
+    if (this.handledGuids.has(githubGuid)) {
+      return;
+    }
+    this.handledGuids.set(githubGuid);
+    const githubData = req.github as GitHubRequestData;
+    if (!githubData) {
+      throw Error("Expected github data to be set on request");
+    }
+    this.ghWebhooks
+      .verifyAndReceive({
+        id: githubGuid as string,
+        name: githubEvent as WebhookEventName,
+        payload: githubData.payload,
+        signature: githubData.signature,
+      })
+      .catch((err) => {
+        log.error(`Failed handle GitHubEvent: ${err}`);
+      });
+  }
+
+  public async onGetOAuth(
+    req: Request<
+      unknown,
+      unknown,
+      unknown,
+      {
+        error?: string;
+        error_description?: string;
+        code?: string;
+        state?: string;
+        setup_action?: "install";
+      }
+    >,
+    res: Response,
+  ) {
+    const oauthResultParams: OAuthPageParams = {
+      service: "github",
+    };
+
+    const { setup_action: setupAction, state } = req.query;
+    log.info("Got new oauth request", { state, setupAction });
+    try {
+      if (!this.config.oauth) {
+        throw new ApiError(
+          "Bridge is not configured with OAuth support",
+          ErrCode.DisabledFeature,
+        );
+      }
+      if (req.query.error) {
+        throw new ApiError(
+          `GitHub Error: ${req.query.error} ${req.query.error_description}`,
+          ErrCode.Unknown,
+        );
+      }
+      if (setupAction === "install") {
+        // GitHub App successful install.
+        oauthResultParams["oauth-kind"] = "organisation";
+        oauthResultParams.result = "success";
+      } else if (setupAction === "request") {
+        // GitHub App install is pending
+        oauthResultParams["oauth-kind"] = "organisation";
+        oauthResultParams.result = "pending";
+      } else if (setupAction) {
+        // GitHub App install is in another, unknown state.
+        oauthResultParams["oauth-kind"] = "organisation";
+        oauthResultParams.result = setupAction;
+      } else {
+        // This is a user account setup flow.
+        oauthResultParams["oauth-kind"] = "account";
+        if (!state) {
+          throw new ApiError(`Missing state`, ErrCode.BadValue);
+        }
+        if (!req.query.code) {
+          throw new ApiError(`Missing code`, ErrCode.BadValue);
+        }
+        const exists = await this.queue.pushWait<OAuthRequest, boolean>({
+          eventName: "github.oauth.response",
+          sender: "GithubWebhooks",
+          data: {
+            state,
+            code: req.query.code,
+          },
+        });
+        if (!exists) {
+          throw new ApiError(
+            `Could not find user which authorised this request. Has it timed out?`,
+            undefined,
+            404,
+          );
+        }
+        const accessTokenUrl = GithubInstance.generateOAuthUrl(
+          this.config.baseUrl,
+          "access_token",
+          {
+            client_id: this.config.oauth.client_id,
+            client_secret: this.config.oauth.client_secret,
+            code: req.query.code as string,
+            redirect_uri: this.config.oauth.redirect_uri,
+            state: req.query.state as string,
+          },
+        );
+        const accessTokenRes = await axios.post(accessTokenUrl);
+        const result = qs.parse(accessTokenRes.data) as
+          | GitHubOAuthTokenResponse
+          | { error: string; error_description: string; error_uri: string };
+        if ("error" in result) {
+          throw new ApiError(
+            `GitHub Error: ${result.error} ${result.error_description}`,
+            ErrCode.Unknown,
+          );
+        }
+        oauthResultParams.result = "success";
+        await this.queue.push<GitHubOAuthTokenResponse>({
+          eventName: "github.oauth.tokens",
+          sender: "GithubWebhooks",
+          data: { ...result, state: req.query.state as string },
+        });
+      }
+    } catch (ex) {
+      if (ex instanceof ApiError) {
+        oauthResultParams.result = "error";
+        oauthResultParams.error = ex.error;
+        oauthResultParams.errcode = ex.errcode;
+      } else {
+        log.error("Failed to handle oauth request:", ex);
+        return res.status(500).send("Failed to handle oauth request");
+      }
+    }
+    const oauthUrl = this.widgetsUrl && new URL("oauth.html", this.widgetsUrl);
+    if (oauthUrl) {
+      // If we're serving widgets, do something prettier.
+      Object.entries(oauthResultParams).forEach(([key, value]) =>
+        oauthUrl.searchParams.set(key, value),
+      );
+      return res.redirect(oauthUrl.toString());
+    } else {
+      if (oauthResultParams.result === "success") {
+        return res.send(
+          `<p> Your ${oauthResultParams.service} ${oauthResultParams["oauth-kind"]} has been bridged </p>`,
+        );
+      } else if (oauthResultParams.result === "error") {
+        return res
+          .status(500)
+          .send(
+            `<p> There was an error bridging your ${oauthResultParams.service} ${oauthResultParams["oauth-kind"]}. ${oauthResultParams.error} ${oauthResultParams.errcode} </p>`,
+          );
+      } else {
+        return res
+          .status(500)
+          .send(
+            `<p> Your ${oauthResultParams.service} ${oauthResultParams["oauth-kind"]} is in state ${oauthResultParams.result} </p>`,
+          );
+      }
+    }
+  }
 
   public getRouter() {
     const router = Router();
-    router.get("/oauth", this.onOAuth.bind(this));
-    router.get("/account", this.onGetAccount.bind(this));
-    router.get(
-      "/orgs/:orgName/repositories",
-      this.onGetOrgRepositories.bind(this),
-    );
-    router.get("/repositories", this.onGetRepositories.bind(this));
+    router.use(json({ verify: this.verifyRequest.bind(this) }));
+    router.get("/", this.onWebhook.bind(this));
+    router.get("/oauth", this.onGetOAuth.bind(this));
     return router;
-  }
-
-  private onOAuth(
-    req: Request<undefined, undefined, undefined, { userId: string }>,
-    res: Response<{ user_url: string; org_url: string }>,
-  ) {
-    if (!this.config.oauth) {
-      throw new ApiError(
-        "GitHub is not configured to support OAuth",
-        ErrCode.UnsupportedOperation,
-      );
-    }
-    const userUrl = GithubInstance.generateOAuthUrl(
-      this.config.baseUrl,
-      "authorize",
-      {
-        redirect_uri: this.config.oauth.redirect_uri,
-        client_id: this.config.oauth.client_id,
-        state: this.tokenStore.createStateForOAuth(req.query.userId),
-      },
-    );
-    res.send({
-      user_url: userUrl,
-      org_url: this.githubInstance.newInstallationUrl.toString(),
-    });
-  }
-
-  private async onGetAccount(
-    req: Request<
-      undefined,
-      undefined,
-      undefined,
-      { userId: string; page: string; perPage: string }
-    >,
-    res: Response<GitHubAccountStatus>,
-    next: NextFunction,
-  ) {
-    const octokit = await this.tokenStore.getOctokitForUser(req.query.userId);
-    if (!octokit) {
-      return res.send({
-        loggedIn: false,
-      });
-    }
-    const organisations = [];
-    const page = req.query.page ? parseInt(req.query.page) : 1;
-    const perPage = req.query.perPage ? parseInt(req.query.perPage) : 10;
-    try {
-      const installs = await octokit.apps.listInstallationsForAuthenticatedUser(
-        { page: page, per_page: perPage },
-      );
-      for (const install of installs.data.installations) {
-        if (install.account) {
-          const name =
-            "login" in install.account
-              ? install.account.login
-              : (install.account.name ?? NAMELESS_ORG_PLACEHOLDER);
-          organisations.push({
-            name, // org or user name
-            avatarUrl: install.account.avatar_url,
-          });
-        } else {
-          log.debug(`Skipping install ${install.id}, has no attached account`);
-        }
-      }
-    } catch (ex) {
-      log.warn(`Failed to fetch orgs for GitHub user ${req.query.userId}`, ex);
-      return next(
-        new ApiError(
-          "Could not fetch orgs for GitHub user",
-          ErrCode.AdditionalActionRequired,
-        ),
-      );
-    }
-    return res.send({
-      loggedIn: true,
-      username: await (await octokit.users.getAuthenticated()).data.login,
-      organisations,
-    });
-  }
-
-  private async onGetOrgRepositories(
-    req: Request<
-      { orgName: string },
-      undefined,
-      undefined,
-      { userId: string; page: string; perPage: string }
-    >,
-    res: Response<GitHubRepoResponse>,
-    next: NextFunction,
-  ) {
-    const octokit = await this.tokenStore.getOctokitForUser(req.query.userId);
-    if (!octokit) {
-      // TODO: Better error?
-      return next(new ApiError("Not logged in", ErrCode.ForbiddenUser));
-    }
-
-    const ownSelf = await octokit.users.getAuthenticated();
-
-    const repositories = [];
-    const page = req.query.page ? parseInt(req.query.page) : 1;
-    const perPage = req.query.perPage ? parseInt(req.query.perPage) : 10;
-    try {
-      let changeInstallUrl: URL | undefined = undefined;
-      let reposPromise;
-
-      if (ownSelf.data.login === req.params.orgName) {
-        const userInstallation =
-          await this.githubInstance.appOctokit.apps.getUserInstallation({
-            username: ownSelf.data.login,
-          });
-        reposPromise = octokit.apps.listInstallationReposForAuthenticatedUser({
-          page,
-          installation_id: userInstallation.data.id,
-          per_page: perPage,
-        });
-        if (userInstallation.data.repository_selection === "selected") {
-          changeInstallUrl = new URL(
-            `/settings/installations/${userInstallation.data.id}`,
-            this.config.baseUrl,
-          );
-        }
-      } else {
-        const orgInstallation =
-          await this.githubInstance.appOctokit.apps.getOrgInstallation({
-            org: req.params.orgName,
-          });
-
-        // Github will error if the authed user tries to list repos of a disallowed installation, even
-        // if we got the installation ID from the app's instance.
-        reposPromise = octokit.apps.listInstallationReposForAuthenticatedUser({
-          page,
-          installation_id: orgInstallation.data.id,
-          per_page: perPage,
-        });
-        if (orgInstallation.data.repository_selection === "selected") {
-          changeInstallUrl = new URL(
-            `/organizations/${req.params.orgName}/settings/installations/${orgInstallation.data.id}`,
-            this.config.baseUrl,
-          );
-        }
-      }
-      const reposRes = await reposPromise;
-      for (const repo of reposRes.data.repositories) {
-        repositories.push({
-          name: repo.name,
-          owner: repo.owner.login,
-          fullName: repo.full_name,
-          description: repo.description,
-          avatarUrl: repo.owner.avatar_url,
-        });
-      }
-
-      return res.send({
-        page,
-        repositories,
-        changeSelectionUrl: changeInstallUrl?.toString(),
-      });
-    } catch (ex) {
-      log.warn(
-        `Failed to fetch accessible repos for ${req.params.orgName} / ${req.query.userId}`,
-        ex,
-      );
-      return next(
-        new ApiError(
-          "Could not fetch accessible repos for GitHub org",
-          ErrCode.AdditionalActionRequired,
-        ),
-      );
-    }
-  }
-
-  private async onGetRepositories(
-    req: Request<
-      undefined,
-      undefined,
-      undefined,
-      { userId: string; page: string; perPage: string }
-    >,
-    res: Response<GitHubRepoResponse>,
-    next: NextFunction,
-  ) {
-    const octokit = await this.tokenStore.getOctokitForUser(req.query.userId);
-    if (!octokit) {
-      // TODO: Better error?
-      return next(new ApiError("Not logged in", ErrCode.ForbiddenUser));
-    }
-
-    const repositories = [];
-    const page = req.query.page ? parseInt(req.query.page) : 1;
-    const perPage = req.query.perPage ? parseInt(req.query.perPage) : 10;
-    try {
-      const userRes = await octokit.users.getAuthenticated();
-      const userInstallation =
-        await this.githubInstance.appOctokit.apps.getUserInstallation({
-          username: userRes.data.login,
-        });
-      const orgRes =
-        await octokit.apps.listInstallationReposForAuthenticatedUser({
-          page,
-          installation_id: userInstallation.data.id,
-          per_page: perPage,
-        });
-      for (const repo of orgRes.data.repositories) {
-        repositories.push({
-          name: repo.name,
-          owner: repo.owner.login,
-          fullName: repo.full_name,
-          description: repo.description,
-          avatarUrl: repo.owner.avatar_url,
-        });
-      }
-      const changeSelectionUrl = new URL(
-        `/settings/installations/${userInstallation.data.id}`,
-        this.config.baseUrl,
-      ).toString();
-
-      return res.send({
-        page,
-        repositories,
-        ...(orgRes.data.repository_selection === "selected" && {
-          changeSelectionUrl,
-        }),
-      });
-    } catch (ex) {
-      log.warn(`Failed to fetch accessible repos for ${req.query.userId}`, ex);
-      return next(
-        new ApiError(
-          "Could not fetch accessible repos for GitHub user",
-          ErrCode.AdditionalActionRequired,
-        ),
-      );
-    }
   }
 }

--- a/src/gitlab/Router.ts
+++ b/src/gitlab/Router.ts
@@ -1,0 +1,112 @@
+import { Request, Response, Router, json } from "express";
+import { MessageQueue } from "../messageQueue";
+import { ApiError, ErrCode } from "../api";
+import { Logger } from "matrix-appservice-bridge";
+import { BridgeConfigGitLab } from "../config/Config";
+import {
+  IGitLabWebhookEvent,
+  IGitLabWebhookIssueStateEvent,
+  IGitLabWebhookMREvent,
+  IGitLabWebhookReleaseEvent,
+} from "./WebhookTypes";
+
+const log = new Logger("GitLabWebhooksRouter");
+export interface OAuthPageParams {
+  service?: string;
+  result?: string;
+  "oauth-kind"?: "account" | "organisation";
+  error?: string;
+  errcode?: ErrCode;
+}
+
+export class GitLabWebhooksRouter {
+  public static IsRequest(req: Request): boolean {
+    return !!req.headers["x-gitlab-token"];
+  }
+
+  constructor(
+    private readonly config: BridgeConfigGitLab,
+    private readonly queue: MessageQueue,
+  ) {}
+
+  private payloadHandler(body: IGitLabWebhookEvent) {
+    if (body.object_kind === "merge_request") {
+      const action = (body as unknown as IGitLabWebhookMREvent)
+        .object_attributes.action;
+      if (!action) {
+        log.warn(
+          "Got gitlab.merge_request but no action field, which usually means someone pressed the test webhooks button.",
+        );
+        return null;
+      }
+      return `gitlab.merge_request.${action}`;
+    } else if (body.object_kind === "issue") {
+      const action = (body as unknown as IGitLabWebhookIssueStateEvent)
+        .object_attributes.action;
+      if (!action) {
+        log.warn(
+          "Got gitlab.issue but no action field, which usually means someone pressed the test webhooks button.",
+        );
+        return null;
+      }
+      return `gitlab.issue.${action}`;
+    } else if (body.object_kind === "note") {
+      return `gitlab.note.created`;
+    } else if (body.object_kind === "tag_push") {
+      return "gitlab.tag_push";
+    } else if (body.object_kind === "wiki_page") {
+      return "gitlab.wiki_page";
+    } else if (body.object_kind === "release") {
+      const action = (body as unknown as IGitLabWebhookReleaseEvent).action;
+      if (!action) {
+        log.warn(
+          "Got gitlab.release but no action field, which usually means someone pressed the test webhooks button.",
+        );
+        return null;
+      }
+      return `gitlab.release.${action}`;
+    } else if (body.object_kind === "push") {
+      return `gitlab.push`;
+    } else {
+      return null;
+    }
+  }
+
+  public verifyRequest(req: Request): void {
+    if (typeof req.headers["x-gitlab-token"] !== "string") {
+      throw new ApiError(
+        "Could not handle GitHub request. Unexpected multiple headers for x-hub-signature-256",
+        ErrCode.BadValue,
+      );
+    }
+    if (req.headers["x-gitlab-token"] !== this.config.webhook.secret) {
+      throw new ApiError(
+        "Could not handle GitLab request. Token did not match.",
+        ErrCode.BadValue,
+      );
+    }
+  }
+
+  public onWebhook(req: Request, res: Response) {
+    res.json({});
+    const eventName = this.payloadHandler(req.body);
+    if (eventName) {
+      this.queue
+        .push({
+          eventName,
+          sender: "GithubWebhooks",
+          data: req.body,
+        })
+        .catch((err) => {
+          log.error(`Failed to emit payload: ${err}`);
+        });
+    }
+  }
+
+  public getRouter() {
+    const router = Router();
+    router.use(json({ verify: this.verifyRequest.bind(this) }));
+    router.get("/", this.onWebhook.bind(this));
+    return router;
+  }
+}

--- a/src/gitlab/Router.ts
+++ b/src/gitlab/Router.ts
@@ -106,7 +106,7 @@ export class GitLabWebhooksRouter {
   public getRouter() {
     const router = Router();
     router.use(json({ verify: this.verifyRequest.bind(this) }));
-    router.post("/", this.onWebhook.bind(this));
+    router.post("/webhook", this.onWebhook.bind(this));
     return router;
   }
 }

--- a/src/gitlab/Router.ts
+++ b/src/gitlab/Router.ts
@@ -88,7 +88,7 @@ export class GitLabWebhooksRouter {
   }
 
   public onWebhook(req: Request, res: Response) {
-    res.json({});
+    res.send("OK");
     const eventName = this.payloadHandler(req.body);
     if (eventName) {
       this.queue
@@ -106,7 +106,7 @@ export class GitLabWebhooksRouter {
   public getRouter() {
     const router = Router();
     router.use(json({ verify: this.verifyRequest.bind(this) }));
-    router.get("/", this.onWebhook.bind(this));
+    router.post("/", this.onWebhook.bind(this));
     return router;
   }
 }

--- a/src/jira/Router.ts
+++ b/src/jira/Router.ts
@@ -197,7 +197,7 @@ export class JiraWebhooksRouter {
     const router = Router();
     router.get("/oauth", json(), this.onOAuth.bind(this));
     router.post(
-      "/",
+      "/webhook",
       json({ verify: this.verifyWebhookRequest.bind(this) }),
       this.onWebhook.bind(this),
     );

--- a/src/notifications/UserNotificationWatcher.ts
+++ b/src/notifications/UserNotificationWatcher.ts
@@ -1,7 +1,3 @@
-import {
-  NotificationsDisableEvent,
-  NotificationsEnableEvent,
-} from "../Webhooks";
 import { Logger } from "matrix-appservice-bridge";
 import {
   createMessageQueue,
@@ -23,6 +19,22 @@ export interface UserNotificationsEvent {
 
 const MIN_INTERVAL_MS = 15000;
 const FAILURE_THRESHOLD = 50;
+
+export interface NotificationsEnableEvent {
+  userId: string;
+  roomId: string;
+  since?: number;
+  token: string;
+  filterParticipating: boolean;
+  type: "github" | "gitlab";
+  instanceUrl?: string;
+}
+
+export interface NotificationsDisableEvent {
+  userId: string;
+  type: "github" | "gitlab";
+  instanceUrl?: string;
+}
 
 const log = new Logger("UserNotificationWatcher");
 

--- a/src/openproject/Router.ts
+++ b/src/openproject/Router.ts
@@ -9,15 +9,6 @@ import { OAuthRequest, OAuthRequestResult } from "../tokens/Oauth";
 
 const log = new Logger("OpenProjectWebhooksRouter");
 export class OpenProjectWebhooksRouter {
-  public static IsRequest(req: Request): boolean {
-    if (req.headers["x-atlassian-webhook-identifier"]) {
-      return true; // Cloud
-    } else if (req.headers["user-agent"]?.match(/JIRA/)) {
-      return true; // JIRA On-prem
-    }
-    return false;
-  }
-
   constructor(
     private readonly config: BridgeOpenProjectConfig,
     private readonly queue: MessageQueue,


### PR DESCRIPTION
This completes a longstanding task to move our older services to dedicated paths. The old paths will still work but may be removed in a future version.