### PR TITLE
Log encrypted device identity

### DIFF
--- a/changelog.d/1066.misc
+++ b/changelog.d/1066.misc
@@ -1,0 +1,1 @@
+Log encrypted device identities for consumption by third party tooling.

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "jira-client": "^8.2.2",
     "markdown-it": "^14.0.0",
     "matrix-appservice-bridge": "^9.0.1",
-    "matrix-bot-sdk": "npm:@vector-im/matrix-bot-sdk@0.7.1-element.9",
+    "matrix-bot-sdk": "npm:@vector-im/matrix-bot-sdk@0.7.1-element.11",
     "matrix-widget-api": "^1.10.0",
     "micromatch": "^4.0.8",
     "mime": "^4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5919,10 +5919,10 @@ matrix-appservice@^2.0.0:
     js-yaml "^4.1.0"
     morgan "^1.10.0"
 
-"matrix-bot-sdk@npm:@vector-im/matrix-bot-sdk@0.7.1-element.9":
-  version "0.7.1-element.9"
-  resolved "https://registry.yarnpkg.com/@vector-im/matrix-bot-sdk/-/matrix-bot-sdk-0.7.1-element.9.tgz#63c03b76e2330bc0c9faf6607bdce636eabac7ab"
-  integrity sha512-Jmvo85Z2waX64ZtoHHG6tfguAf1UA2adPKIGwxDKY+4zgLqQjo4WoirU0DTHbLR1P72nlMJ0uBdryNSnfg80ng==
+"matrix-bot-sdk@npm:@vector-im/matrix-bot-sdk@0.7.1-element.11":
+  version "0.7.1-element.11"
+  resolved "https://registry.yarnpkg.com/@vector-im/matrix-bot-sdk/-/matrix-bot-sdk-0.7.1-element.11.tgz#5827d9d381d0290d6f87039840584d5c2d61b403"
+  integrity sha512-+Btt441GaegnuGO4b2JaGHNu4FYxy1Zi8vJxMk9VsSkGvZENNQB84hzXqfpKAk5UF2S5uGchCzN9TsXdZkWrWg==
   dependencies:
     "@matrix-org/matrix-sdk-crypto-nodejs" "0.3.0-beta.1"
     "@types/express" "^4.17.21"


### PR DESCRIPTION
So that manually verifying the device is possible, if a bit cumbersome.