### PR TITLE
Add parameter for setting generic body size to something other than E…

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -119,6 +119,9 @@ listeners:
 #  requireExpiryTime: false
 #  maxExpiryTime: 30d
 #  includeHookBody: true
+#
+#  # (Optional) Maximum size for webhook payloads. Defaults to '1mb'. Examples: '500kb', '5mb', '10mb'
+#  payloadSizeLimit: 1mb
 
 #figma:
 #  # (Optional) Configure this to enable Figma support

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -63,6 +63,7 @@ export class Webhooks extends EventEmitter {
           this.queue,
           false,
           this.config.generic.enableHttpGet,
+          this.config.generic.payloadSizeLimit,
         ).getRouter(),
       );
       // TODO: Remove old deprecated endpoint
@@ -71,6 +72,7 @@ export class Webhooks extends EventEmitter {
           this.queue,
           true,
           this.config.generic.enableHttpGet,
+          this.config.generic.payloadSizeLimit,
         ).getRouter(),
       );
     }


### PR DESCRIPTION
When using Hookshot Generic webhooks and Alertmanager, grouped alerts can easily overwhelm the 100kb (according to the [docs](https://expressjs.com/en/resources/middleware/body-parser.html)) limit and cause errors / missed alerts.

```
monitoring-hookshot-cff69fc99-294jt hookshot INFO 18:27:40:211 [ListenerService] POST /432e961a-f639-4ddf-8983-afe2a28f573e 500 - HS_UNKNOWN - An internal error occurred
monitoring-hookshot-cff69fc99-294jt hookshot DEBUG 18:27:40:211 [ListenerService] PayloadTooLargeError: request entity too large
monitoring-hookshot-cff69fc99-294jt hookshot     at readStream (/usr/bin/matrix-hookshot/node_modules/raw-body/index.js:163:17)
monitoring-hookshot-cff69fc99-294jt hookshot     at getRawBody (/usr/bin/matrix-hookshot/node_modules/raw-body/index.js:116:12)
monitoring-hookshot-cff69fc99-294jt hookshot     at read (/usr/bin/matrix-hookshot/node_modules/body-parser/lib/read.js:79:3)
monitoring-hookshot-cff69fc99-294jt hookshot     at jsonParser (/usr/bin/matrix-hookshot/node_modules/body-parser/lib/types/json.js:138:5)
monitoring-hookshot-cff69fc99-294jt hookshot     at Layer.handle [as handle_request] (/usr/bin/matrix-hookshot/node_modules/express/lib/router/layer.js:95:5)
monitoring-hookshot-cff69fc99-294jt hookshot     at next (/usr/bin/matrix-hookshot/node_modules/express/lib/router/route.js:149:13)
monitoring-hookshot-cff69fc99-294jt hookshot     at urlencodedParser (/usr/bin/matrix-hookshot/node_modules/body-parser/lib/types/urlencoded.js:103:7)
monitoring-hookshot-cff69fc99-294jt hookshot     at Layer.handle [as handle_request] (/usr/bin/matrix-hookshot/node_modules/express/lib/router/layer.js:95:5)
monitoring-hookshot-cff69fc99-294jt hookshot     at next (/usr/bin/matrix-hookshot/node_modules/express/lib/router/route.js:149:13)
monitoring-hookshot-cff69fc99-294jt hookshot     at /usr/bin/matrix-hookshot/generic/Router.js:112:17
monitoring-hookshot-cff69fc99-294jt hookshot     at textParser (/usr/bin/matrix-hookshot/node_modules/body-parser/lib/types/text.js:78:7)
monitoring-hookshot-cff69fc99-294jt hookshot     at xmlHandler (/usr/bin/matrix-hookshot/generic/Router.js:106:60)
monitoring-hookshot-cff69fc99-294jt hookshot     at Layer.handle [as handle_request] (/usr/bin/matrix-hookshot/node_modules/express/lib/router/layer.js:95:5)
monitoring-hookshot-cff69fc99-294jt hookshot     at next (/usr/bin/matrix-hookshot/node_modules/express/lib/router/route.js:149:13)
monitoring-hookshot-cff69fc99-294jt hookshot     at internalNext (/usr/bin/matrix-hookshot/node_modules/helmet/index.cjs:537:6)
monitoring-hookshot-cff69fc99-294jt hookshot     at xXssProtectionMiddleware (/usr/bin/matrix-hookshot/node_modules/helmet/index.cjs:315:3) {
monitoring-hookshot-cff69fc99-294jt hookshot   expected: 149274,
monitoring-hookshot-cff69fc99-294jt hookshot   length: 149274,
monitoring-hookshot-cff69fc99-294jt hookshot   limit: 102400,
monitoring-hookshot-cff69fc99-294jt hookshot   type: 'entity.too.large'
monitoring-hookshot-cff69fc99-294jt hookshot }
```

I'm not a JS pro, so if there's a smarter way to go about this do chime in