### PR TITLE
Allow configuration of widgets.allowedIpRanges

### DIFF
--- a/changelog.d/1209.feature.md
+++ b/changelog.d/1209.feature.md
@@ -1,0 +1,1 @@
+Allow configuration of `widgets.allowedIpRanges` to allow-list specific ranges within `widgets.disallowedIpRanges`.

--- a/docs/advanced/widgets.md
+++ b/docs/advanced/widgets.md
@@ -54,6 +54,9 @@ When `addOnInvite` is true, the bridge will add a widget to rooms when the bot i
 `disallowedIpRanges` describes which IP ranges should be disallowed when resolving homeserver IP addresses (for security reasons).
 Unless you know what you are doing, it is recommended to not include this key. The default blocked IPs are listed above for your convenience.
 
+`allowedIpRanges` describes which IP ranges within `disallowedIpRanges` are explicitly allow-listed.
+This removes the need to override `disallowedIpRanges` to remove or adjust specific IP ranges.
+
 `publicUrl` should be set to the publicly reachable address for the widget `public` content. By default, Hookshot hosts this content on the
 `widgets` listener under `/widgetapi/v1/static`.
 

--- a/src/config/Defaults.ts
+++ b/src/config/Defaults.ts
@@ -45,6 +45,7 @@ export const DefaultConfigRoot: BridgeConfigRoot = {
       addOnInvite: false,
     },
     disallowedIpRanges: DefaultDisallowedIpRanges,
+    // Don't set allowedIpRanges as overriding any of DefaultDisallowedIpRanges by default doesn't make sense
     branding: {
       widgetTitle: "Hookshot Configuration",
     },

--- a/src/config/sections/Widgets.ts
+++ b/src/config/sections/Widgets.ts
@@ -16,6 +16,7 @@ export interface BridgeWidgetConfigYAML {
     addOnInvite?: boolean;
   };
   disallowedIpRanges?: string[];
+  allowedIpRanges?: string[];
   branding?: {
     widgetTitle: string;
   };
@@ -33,6 +34,7 @@ export class BridgeWidgetConfig {
     addOnInvite?: boolean;
   };
   public readonly disallowedIpRanges?: string[];
+  public readonly allowedIpRanges?: string[];
   public readonly branding: {
     widgetTitle: string;
   };
@@ -42,6 +44,7 @@ export class BridgeWidgetConfig {
   constructor(yaml: BridgeWidgetConfigYAML) {
     this.addToAdminRooms = yaml.addToAdminRooms || false;
     this.disallowedIpRanges = yaml.disallowedIpRanges;
+    this.allowedIpRanges = yaml.allowedIpRanges;
     this.roomSetupWidget = yaml.roomSetupWidget;
     if (
       yaml.disallowedIpRanges !== undefined &&
@@ -50,6 +53,16 @@ export class BridgeWidgetConfig {
     ) {
       throw new ConfigError(
         "widgets.disallowedIpRanges",
+        "must be a string array",
+      );
+    }
+    if (
+      yaml.allowedIpRanges !== undefined &&
+      (!Array.isArray(yaml.allowedIpRanges) ||
+        !yaml.allowedIpRanges.every((s) => typeof s === "string"))
+    ) {
+      throw new ConfigError(
+        "widgets.allowedIpRanges",
         "must be a string array",
       );
     }

--- a/src/widgets/BridgeWidgetApi.ts
+++ b/src/widgets/BridgeWidgetApi.ts
@@ -44,6 +44,7 @@ export class BridgeWidgetApi extends ProvisioningApi {
       expressApp,
       widgetTokenPrefix: "hookshot_",
       disallowedIpRanges: config.widgets?.disallowedIpRanges,
+      allowedIpRanges: config.widgets?.allowedIpRanges,
       openIdOverride: config.widgets?.openIdOverrides,
     });
 


### PR DESCRIPTION
Finish work I started in https://github.com/matrix-org/matrix-appservice-bridge/pull/443 3+ years ago to expose an allow-list of IP Ranges to add specific exceptions to `widgets.disallowedIpRanges`