### PR TITLE
Fix incorrect usage of securityContext

### DIFF
--- a/helm/hookshot/templates/_pod.tpl
+++ b/helm/hookshot/templates/_pod.tpl
@@ -4,9 +4,9 @@ schedulerName: "{{ .Values.schedulerName }}"
 {{- end }}
 serviceAccountName: {{ template "hookshot.serviceAccountName" . }}
 automountServiceAccountToken: {{ .Values.serviceAccount.autoMount }}
-{{- if .Values.securityContext }}
+{{- if .Values.podSecurityContext }}
 securityContext:
-{{ toYaml .Values.securityContext | indent 2 }}
+{{ toYaml .Values.podSecurityContext | indent 2 }}
 {{- end }}
 {{- if .Values.hostAliases }}
 hostAliases:
@@ -38,9 +38,9 @@ containers:
       - {{ . }}
     {{- end }}
   {{- end}}
-{{- if .Values.containerSecurityContext }}
+{{- if .Values.securityContext }}
     securityContext:
-{{- toYaml .Values.containerSecurityContext | nindent 6 }}
+{{- toYaml .Values.securityContext | nindent 6 }}
 {{- end }}
     volumeMounts:
 {{- if or (and (not .Values.hookshot.existingConfigMap) (.Values.hookshot.config)) (.Values.hookshot.existingConfigMap) }}


### PR DESCRIPTION
Fix a few issues:

*  `containerSecurityContext` does not exist in values.yaml or README.md
*  `securityContext` should be used for container-specific security contexts
*  `podSecurityContext` should be used for contexts that apply to all containers