### PR TITLE
Fix redis default port in documentation

### DIFF
--- a/changelog.d/1246.misc
+++ b/changelog.d/1246.misc
@@ -1,0 +1,1 @@
+- Fix a typo in documentation (Redis port)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -259,7 +259,7 @@ To enable, simply set:
 
 ```yaml
 cache:
-  redisUri: "redis://redis-host:3679"
+  redisUri: "redis://redis-host:6379"
 ```
 
 ### Services configuration


### PR DESCRIPTION
Redis default port is 6379.

<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->
