### PR TITLE
Drop dockerhub images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,9 +20,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  DOCKER_NAMESPACE: halfshot
-
 permissions: {}
 
 jobs:
@@ -43,7 +40,6 @@ jobs:
           flavor: |
             latest=auto
           images: |
-            ${{ env.DOCKER_NAMESPACE }}/matrix-hookshot
             ghcr.io/matrix-org/matrix-hookshot
 
   docker-build:
@@ -61,19 +57,12 @@ jobs:
             arch: arm64
 
     runs-on: ${{ matrix.os }}
-    environment: dockerhub
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - name: Log in to Docker Hub
-        if: github.actor != 'dependabot[bot]'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Log in to the GitHub Container registry
         if: github.actor != 'dependabot[bot]'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -94,7 +83,6 @@ jobs:
             latest=auto
             suffix=-${{ matrix.arch }},onlatest=true
           images: |
-            ${{ env.DOCKER_NAMESPACE }}/matrix-hookshot
             ghcr.io/matrix-org/matrix-hookshot
 
       - name: Build and push Docker images
@@ -117,18 +105,11 @@ jobs:
       attestations: write
       id-token: write
 
-    environment: dockerhub
     strategy:
       matrix:
         image: ${{ fromJson(needs.docker-clean-metadata.outputs.json).tags }}
 
     steps:
-      - name: Log in to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
       - name: Log in to the GitHub Container registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 ===============
 
 [![#hookshot:half-shot.uk](https://img.shields.io/matrix/hookshot:half-shot.uk.svg?server_fqdn=chaotic.half-shot.uk&label=%23hookshot:half-shot.uk&logo=matrix)](https://matrix.to/#/#hookshot:half-shot.uk)
-[![Docker Image Version (latest by date)](https://img.shields.io/docker/v/halfshot/matrix-hookshot?sort=semver)](https://hub.docker.com/r/halfshot/matrix-hookshot)
 
 ![screenshot](screenshot.png)
 

--- a/changelog.d/1272.removal
+++ b/changelog.d/1272.removal
@@ -1,0 +1,1 @@
+Images will no longer be pushed to `halfshot/matrix-hookshot` on DockerHub. Users should migrate to `ghcr.io/matrix-org/matrix-hookshot`.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -34,7 +34,7 @@ NODE_ENV=production yarn start
 
 ## Installation via Docker
 
-To get started quickly, you can use the Docker image [`halfshot/matrix-hookshot`](https://hub.docker.com/r/halfshot/matrix-hookshot).
+To get started quickly, you can use the Docker image [`ghcr.io/matrix-org/matrix-hookshot`](https://github.com/matrix-org/matrix-hookshot/pkgs/container/matrix-hookshot).
 
 ```bash
 docker run \
@@ -44,7 +44,7 @@ docker run \
     -p 9000:9000 \ # Webhook port
     -p 9002:9002 \ # Metrics port
     -v /etc/matrix-hookshot:/data \
-    halfshot/matrix-hookshot:latest
+    ghcr.io/matrix-org/matrix-hookshot:latest
 ```
 
 Where `/etc/matrix-hookshot` would contain the configuration files `config.yml` and `registration.yml`. The `passKey` file should also be stored alongside these files. In your config, you should use the path `/data/passkey.pem`.
@@ -63,7 +63,7 @@ Copy the `config.sample.yml` to a new file `config.yml`. The sample config is al
 You should read and fill this in as the bridge will not start without a complete config.
 
 You may validate your config without starting the service by running `yarn validate-config`.
-For Docker you can run `docker run --rm -v /absolute-path-to/config.yml:/config.yml halfshot/matrix-hookshot node config/Config.js /config.yml`
+For Docker you can run `docker run --rm -v /absolute-path-to/config.yml:/config.yml ghcr.io/matrix-org/matrix-hookshot node config/Config.js /config.yml`
 
 Copy `registration.sample.yml` into `registration.yml` and fill in:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -34,6 +34,10 @@ NODE_ENV=production yarn start
 
 ## Installation via Docker
 
+<section class="notice">
+    The docker image was previously available at docker.io under <code>halfshot/matrix-hookshot</code>, but this is no longer maintained. Please update to use the image below.
+</section>
+
 To get started quickly, you can use the Docker image [`ghcr.io/matrix-org/matrix-hookshot`](https://github.com/matrix-org/matrix-hookshot/pkgs/container/matrix-hookshot).
 
 ```bash

--- a/helm/hookshot/README.md
+++ b/helm/hookshot/README.md
@@ -86,7 +86,7 @@ You'll need to configure your Ingress connectivity according to your environment
 | hookshot.registration.sender_localpart | string | `"hookshot"` |  |
 | hookshot.registration.url | string | `"http://example.com"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for Hookshot image |
-| image.repository | string | `"halfshot/matrix-hookshot"` | Repository to pull hookshot image from |
+| image.repository | string | `"ghcr.io/matrix-org/matrix-hookshot"` | Repository to pull hookshot image from |
 | image.tag | string | `nil` | Image tag to pull. Defaults to chart's appVersion value as set in Chart.yaml |
 | imagePullSecrets | list | `[]` | List of names of k8s secrets to be used as ImagePullSecrets for the pod |
 | ingress.appservice.annotations | object | `{}` | Annotations for appservice ingress |

--- a/helm/hookshot/values.yaml
+++ b/helm/hookshot/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 image:
   # -- Repository to pull hookshot image from
-  repository: halfshot/matrix-hookshot
+  repository: ghcr.io/matrix-org/matrix-hookshot
   # -- Pull policy for Hookshot image
   pullPolicy: IfNotPresent
   # -- Image tag to pull. Defaults to chart's appVersion value as set in Chart.yaml
@@ -142,153 +142,153 @@ hookshot:
         resources:
           - widgets
   registration:
-  #github:
-  #  # (Optional) Configure this to enable GitHub support
-  #  auth:
-  #    # Authentication for the GitHub App.
-  #    id: 123
-  #    privateKeyFile: github-key.pem
-  #  webhook:
-  #    # Webhook settings for the GitHub app.
-  #    secret: secrettoken
-  #  oauth:
-  #    # (Optional) Settings for allowing users to sign in via OAuth.
-  #    client_id: foo
-  #    client_secret: bar
-  #    redirect_uri: https://example.com/oauth/
-  #  defaultOptions:
-  #    # (Optional) Default options for GitHub connections.
-  #    showIssueRoomLink: false
-  #    hotlinkIssues:
-  #      prefix: "#"
-  #  userIdPrefix:
-  #    # (Optional) Prefix used when creating ghost users for GitHub accounts.
-  #    _github_
+    #github:
+    #  # (Optional) Configure this to enable GitHub support
+    #  auth:
+    #    # Authentication for the GitHub App.
+    #    id: 123
+    #    privateKeyFile: github-key.pem
+    #  webhook:
+    #    # Webhook settings for the GitHub app.
+    #    secret: secrettoken
+    #  oauth:
+    #    # (Optional) Settings for allowing users to sign in via OAuth.
+    #    client_id: foo
+    #    client_secret: bar
+    #    redirect_uri: https://example.com/oauth/
+    #  defaultOptions:
+    #    # (Optional) Default options for GitHub connections.
+    #    showIssueRoomLink: false
+    #    hotlinkIssues:
+    #      prefix: "#"
+    #  userIdPrefix:
+    #    # (Optional) Prefix used when creating ghost users for GitHub accounts.
+    #    _github_
 
-  #gitlab:
-  #  # (Optional) Configure this to enable GitLab support
-  #  instances:
-  #    gitlab.com:
-  #      url: https://gitlab.com
-  #  webhook:
-  #    secret: secrettoken
-  #    publicUrl: https://example.com/hookshot/
-  #  userIdPrefix:
-  #    # (Optional) Prefix used when creating ghost users for GitLab accounts.
-  #    _gitlab_
-  #  commentDebounceMs:
-  #    # (Optional) Aggregate comments by waiting this many miliseconds before posting them to Matrix. Defaults to 5000 (5 seconds)
-  #    5000
+    #gitlab:
+    #  # (Optional) Configure this to enable GitLab support
+    #  instances:
+    #    gitlab.com:
+    #      url: https://gitlab.com
+    #  webhook:
+    #    secret: secrettoken
+    #    publicUrl: https://example.com/hookshot/
+    #  userIdPrefix:
+    #    # (Optional) Prefix used when creating ghost users for GitLab accounts.
+    #    _gitlab_
+    #  commentDebounceMs:
+    #    # (Optional) Aggregate comments by waiting this many miliseconds before posting them to Matrix. Defaults to 5000 (5 seconds)
+    #    5000
 
-  #figma:
-  #  # (Optional) Configure this to enable Figma support
-  #  publicUrl: https://example.com/hookshot/
-  #  instances:
-  #    your-instance:
-  #      teamId: your-team-id
-  #      accessToken: your-personal-access-token
-  #      passcode: your-webhook-passcode
+    #figma:
+    #  # (Optional) Configure this to enable Figma support
+    #  publicUrl: https://example.com/hookshot/
+    #  instances:
+    #    your-instance:
+    #      teamId: your-team-id
+    #      accessToken: your-personal-access-token
+    #      passcode: your-webhook-passcode
 
-  #jira:
-  #  # (Optional) Configure this to enable Jira support. Only specify `url` if you are using a On Premise install (i.e. not atlassian.com)
-  #  webhook:
-  #    # Webhook settings for JIRA
-  #    secret: secrettoken
-  #  oauth:
-  #    # (Optional) OAuth settings for connecting users to JIRA. See documentation for more information
-  #    client_id: foo
-  #    client_secret: bar
-  #    redirect_uri: https://example.com/oauth/
+    #jira:
+    #  # (Optional) Configure this to enable Jira support. Only specify `url` if you are using a On Premise install (i.e. not atlassian.com)
+    #  webhook:
+    #    # Webhook settings for JIRA
+    #    secret: secrettoken
+    #  oauth:
+    #    # (Optional) OAuth settings for connecting users to JIRA. See documentation for more information
+    #    client_id: foo
+    #    client_secret: bar
+    #    redirect_uri: https://example.com/oauth/
 
-  #generic:
-  #  # (Optional) Support for generic webhook events.
-  #  #'allowJsTransformationFunctions' will allow users to write short transformation snippets in code, and thus is unsafe in untrusted environments
+    #generic:
+    #  # (Optional) Support for generic webhook events.
+    #  #'allowJsTransformationFunctions' will allow users to write short transformation snippets in code, and thus is unsafe in untrusted environments
 
-  #  enabled: false
-  #  enableHttpGet: false
-  #  urlPrefix: https://example.com/webhook/
-  #  userIdPrefix: _webhooks_
-  #  allowJsTransformationFunctions: false
-  #  waitForComplete: false
+    #  enabled: false
+    #  enableHttpGet: false
+    #  urlPrefix: https://example.com/webhook/
+    #  userIdPrefix: _webhooks_
+    #  allowJsTransformationFunctions: false
+    #  waitForComplete: false
 
-  #feeds:
-  #  # (Optional) Configure this to enable RSS/Atom feed support
-  #  enabled: false
-  #  pollConcurrency: 4
-  #  pollIntervalSeconds: 600
-  #  pollTimeoutSeconds: 30
+    #feeds:
+    #  # (Optional) Configure this to enable RSS/Atom feed support
+    #  enabled: false
+    #  pollConcurrency: 4
+    #  pollIntervalSeconds: 600
+    #  pollTimeoutSeconds: 30
 
-  #provisioning:
-  #  # (Optional) Provisioning API for integration managers
-  #  secret: "!secretToken"
+    #provisioning:
+    #  # (Optional) Provisioning API for integration managers
+    #  secret: "!secretToken"
 
-  #bot:
-  #  # (Optional) Define profile information for the bot user
-  #  displayname: Hookshot Bot
-  #  avatar: mxc://half-shot.uk/2876e89ccade4cb615e210c458e2a7a6883fe17d
+    #bot:
+    #  # (Optional) Define profile information for the bot user
+    #  displayname: Hookshot Bot
+    #  avatar: mxc://half-shot.uk/2876e89ccade4cb615e210c458e2a7a6883fe17d
 
-  #serviceBots:
-  #  # (Optional) Define additional bot users for specific services
-  #  - localpart: feeds
-  #    displayname: Feeds
-  #    avatar: ./assets/feeds_avatar.png
-  #    prefix: "!feeds"
-  #    service: feeds
+    #serviceBots:
+    #  # (Optional) Define additional bot users for specific services
+    #  - localpart: feeds
+    #    displayname: Feeds
+    #    avatar: ./assets/feeds_avatar.png
+    #    prefix: "!feeds"
+    #    service: feeds
 
-  #metrics:
-  #  # (Optional) Prometheus metrics support
-  #  enabled: true
+    #metrics:
+    #  # (Optional) Prometheus metrics support
+    #  enabled: true
 
-  #cache:
-  #  # (Optional) Cache options for large scale deployments.
-  #  # For encryption to work, this must be configured.
-  #  redisUri: redis://localhost:6379
+    #cache:
+    #  # (Optional) Cache options for large scale deployments.
+    #  # For encryption to work, this must be configured.
+    #  redisUri: redis://localhost:6379
 
-  #queue:
-  #  # (Optional) Message queue configuration options for large scale deployments.
-  #  # For encryption to work, this must not be configured.
-  #  redisUri: redis://localhost:6379
+    #queue:
+    #  # (Optional) Message queue configuration options for large scale deployments.
+    #  # For encryption to work, this must not be configured.
+    #  redisUri: redis://localhost:6379
 
-  #widgets:
-  #  # (Optional) EXPERIMENTAL support for complimentary widgets
-  #  addToAdminRooms: false
-  #  disallowedIpRanges:
-  #    - 127.0.0.0/8
-  #    - 10.0.0.0/8
-  #    - 172.16.0.0/12
-  #    - 192.168.0.0/16
-  #    - 100.64.0.0/10
-  #    - 192.0.0.0/24
-  #    - 169.254.0.0/16
-  #    - 192.88.99.0/24
-  #    - 198.18.0.0/15
-  #    - 192.0.2.0/24
-  #    - 198.51.100.0/24
-  #    - 203.0.113.0/24
-  #    - 224.0.0.0/4
-  #    - ::1/128
-  #    - fe80::/10
-  #    - fc00::/7
-  #    - 2001:db8::/32
-  #    - ff00::/8
-  #    - fec0::/10
-  #  roomSetupWidget:
-  #    addOnInvite: false
-  #  publicUrl: https://example.com/widgetapi/v1/static/
-  #  branding:
-  #    widgetTitle: Hookshot Configuration
+    #widgets:
+    #  # (Optional) EXPERIMENTAL support for complimentary widgets
+    #  addToAdminRooms: false
+    #  disallowedIpRanges:
+    #    - 127.0.0.0/8
+    #    - 10.0.0.0/8
+    #    - 172.16.0.0/12
+    #    - 192.168.0.0/16
+    #    - 100.64.0.0/10
+    #    - 192.0.0.0/24
+    #    - 169.254.0.0/16
+    #    - 192.88.99.0/24
+    #    - 198.18.0.0/15
+    #    - 192.0.2.0/24
+    #    - 198.51.100.0/24
+    #    - 203.0.113.0/24
+    #    - 224.0.0.0/4
+    #    - ::1/128
+    #    - fe80::/10
+    #    - fc00::/7
+    #    - 2001:db8::/32
+    #    - ff00::/8
+    #    - fec0::/10
+    #  roomSetupWidget:
+    #    addOnInvite: false
+    #  publicUrl: https://example.com/widgetapi/v1/static/
+    #  branding:
+    #    widgetTitle: Hookshot Configuration
 
-  #sentry:
-  #  # (Optional) Configure Sentry error reporting
-  #  dsn: https://examplePublicKey@o0.ingest.sentry.io/0
-  #  environment: production
+    #sentry:
+    #  # (Optional) Configure Sentry error reporting
+    #  dsn: https://examplePublicKey@o0.ingest.sentry.io/0
+    #  environment: production
 
-  #permissions:
-  #  # (Optional) Permissions for using the bridge. See docs/setup.md#permissions for help
-  #  - actor: example.com
-  #    services:
-  #      - service: "*"
-  #        level: admin
+    #permissions:
+    #  # (Optional) Permissions for using the bridge. See docs/setup.md#permissions for help
+    #  - actor: example.com
+    #    services:
+    #      - service: "*"
+    #        level: admin
     id: matrix-hookshot
     as_token: ""
     hs_token: ""


### PR DESCRIPTION
https://hub.docker.com/r/halfshot/matrix-hookshot is an ancient relic from the time that this project was under my own domain, but it's now under gchr.io/matrix-org/matrix-hookshot.

We've given a few years for folks to migrate, let's call time on it.