### PR TITLE
Fix docker workflow stopping builds when running a release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: false
 
 permissions: {}


### PR DESCRIPTION
The concurrency group also needs to hash on the event_name or we won't be able to do a release and a push to main at the same time.