### PR TITLE
Fix a bug where "webhooks" was accepted as a permissions service.

### DIFF
--- a/changelog.d/1281.bugfix
+++ b/changelog.d/1281.bugfix
@@ -1,0 +1,2 @@
+Fix a bug where hookshot would require both "webhooks" and "generic" service permissions to manage webhooks. This has now been corrected so that all
+webhook commands require "generic" service permissions. "webhooks" will continue to work, but may be removed at a future date.

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -37,7 +37,7 @@ listeners:
       - widgets
 
 #cache:
-#  # (Optional) Cache options for large scale deployments. 
+#  # (Optional) Cache options for large scale deployments.
 #  #    For encryption to work, this must be configured.
 #  redisUri: redis://localhost:6379
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -121,7 +121,7 @@ Each permission set can have a service. The `service` field can be:
 - `jira`
 - `feed`
 - `figma`
-- `webhooks`
+- `generic` (**NOTE**: This was incorrectly documented as `webhooks`. Either will work, but please migrate to `generic`. ).
 - `openproject`
 - `challengehound`
 - `*`, for any service.

--- a/spec/permissions.spec.ts
+++ b/spec/permissions.spec.ts
@@ -3,20 +3,21 @@ import { describe, test, beforeAll, afterAll, expect } from "vitest";
 import { MessageEventContent } from "matrix-bot-sdk";
 
 describe("Permissions test", () => {
-  let testEnv!: E2ETestEnv<"denied_user" | "allowed_user">;
+  let testEnv!: E2ETestEnv<"denied_user" | "allowed_user" | "legacy_user">;
 
   beforeAll(async () => {
     testEnv = await E2ETestEnv.createTestEnv({
-      matrixLocalparts: ["denied_user", "allowed_user"],
+      matrixLocalparts: ["denied_user", "allowed_user", "legacy_user"],
       permissionsRoom: {
         members: ["allowed_user"],
         permissions: [
           {
             level: "manageConnections",
-            service: "webhooks",
+            service: "generic",
           },
         ],
       },
+
       e2eClientOpts: {
         autoAcceptInvite: true,
       },
@@ -35,6 +36,17 @@ describe("Permissions test", () => {
           enabled: true,
           urlPrefix: `http://localhost`,
         },
+        permissions: [
+          {
+            actor: "legacy_user",
+            services: [
+              {
+                service: "webhooks",
+                level: "manageConnections",
+              },
+            ],
+          },
+        ],
       },
     });
     await testEnv.setUp();
@@ -76,7 +88,7 @@ describe("Permissions test", () => {
     });
     await user.waitForRoomJoin({ sender: testEnv.botMxid, roomId });
 
-    // Try to create a GitHub connection, should fail.
+    // Try to create a GitLab connection, should fail.
     const msgGitLab = user.waitForRoomEvent<MessageEventContent>({
       eventType: "m.room.message",
       sender: testEnv.botMxid,
@@ -91,25 +103,28 @@ describe("Permissions test", () => {
     );
   });
 
-  test("should allow users with permission to use a service", async () => {
-    const user = testEnv.getUser("allowed_user");
-    const roomId = await user.createRoom({
-      name: "Test room",
-      invite: [testEnv.botMxid],
-    });
-    await user.setUserPowerLevel(testEnv.botMxid, roomId, 50);
-    await user.waitForRoomJoin({ sender: testEnv.botMxid, roomId });
+  test.each(["allowed_user", "legacy_user"] as ["allowed_user", "legacy_user"])(
+    "should allow users with permission to use a service (%s)",
+    async (localpart) => {
+      const user = testEnv.getUser(localpart);
+      const roomId = await user.createRoom({
+        name: "Test room",
+        invite: [testEnv.botMxid],
+      });
+      await user.setUserPowerLevel(testEnv.botMxid, roomId, 50);
+      await user.waitForRoomJoin({ sender: testEnv.botMxid, roomId });
 
-    const msgWebhooks = user.waitForRoomEvent<MessageEventContent>({
-      eventType: "m.room.message",
-      sender: testEnv.botMxid,
-      roomId,
-    });
-    await user.sendText(roomId, "!hookshot webhook test");
-    expect((await msgWebhooks).data.content.body).to.include(
-      "Room configured to bridge webhooks. See admin room for secret url.",
-    );
-  });
+      const msgWebhooks = user.waitForRoomEvent<MessageEventContent>({
+        eventType: "m.room.message",
+        sender: testEnv.botMxid,
+        roomId,
+      });
+      await user.sendText(roomId, "!hookshot webhook test");
+      expect((await msgWebhooks).data.content.body).to.include(
+        "Room configured to bridge webhooks. See admin room for secret url.",
+      );
+    },
+  );
 
   test("should allow users with permission to use a service in a v12 room", async () => {
     const user = testEnv.getUser("allowed_user");

--- a/spec/util/e2e-test.ts
+++ b/spec/util/e2e-test.ts
@@ -435,6 +435,21 @@ export class E2ETestEnv<ML extends string = string> {
         },
       ];
     }
+
+    if (providedConfig?.permissions) {
+      permissions.push(
+        ...providedConfig.permissions.map((perm) => {
+          if (matrixLocalparts?.includes(perm.actor as ML)) {
+            return {
+              actor: `@${perm.actor}:${homeserver.domain}`,
+              services: perm.services,
+            };
+          }
+          return perm;
+        }),
+      );
+    }
+
     const config = new BridgeConfig({
       bridge: {
         domain: homeserver.domain,
@@ -466,8 +481,8 @@ export class E2ETestEnv<ML extends string = string> {
           }
         : undefined),
       cache: cacheConfig,
-      permissions,
       ...providedConfig,
+      permissions: permissions,
       connections: opts.config?.connections?.map((c) => ({
         ...c,
         roomId: connectionRooms[c.roomId],

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -398,7 +398,7 @@ export class SetupConnection extends CommandConnection {
 
     await this.checkUserPermissions(
       userId,
-      "webhooks",
+      GitHubRepoConnection.ServiceCategory,
       GitHubRepoConnection.CanonicalEventType,
     );
 
@@ -545,7 +545,7 @@ export class SetupConnection extends CommandConnection {
 
     await this.checkUserPermissions(
       userId,
-      "webhooks",
+      GitHubRepoConnection.ServiceCategory,
       GitHubRepoConnection.CanonicalEventType,
     );
 

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -398,8 +398,8 @@ export class SetupConnection extends CommandConnection {
 
     await this.checkUserPermissions(
       userId,
-      GitHubRepoConnection.ServiceCategory,
-      GitHubRepoConnection.CanonicalEventType,
+      GenericHookConnection.ServiceCategory,
+      GenericHookConnection.CanonicalEventType,
     );
 
     if (!name || name.length < 3 || name.length > 64) {
@@ -545,8 +545,8 @@ export class SetupConnection extends CommandConnection {
 
     await this.checkUserPermissions(
       userId,
-      GitHubRepoConnection.ServiceCategory,
-      GitHubRepoConnection.CanonicalEventType,
+      GenericHookConnection.ServiceCategory,
+      GenericHookConnection.CanonicalEventType,
     );
 
     const { connection } = await OutboundHookConnection.provisionConnection(

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -154,7 +154,7 @@ export class BridgeConfig {
   @configKey("Basic homeserver configuration")
   public readonly bridge: BridgeConfigBridge;
   @configKey(
-    `Cache options for large scale deployments. 
+    `Cache options for large scale deployments.
     For encryption to work, this must be configured.`,
     true,
   )
@@ -347,6 +347,14 @@ export class BridgeConfig {
     if (!configData.permissions) {
       log.warn(
         `You have not configured any permissions for the bridge, which by default means all users on ${this.bridge.domain} have admin levels of control. Please adjust your config.`,
+      );
+    } else if (
+      configData.permissions.some((rule) =>
+        rule.services.some((s) => s.service === "webhooks"),
+      )
+    ) {
+      log.warn(
+        `You have at least one permission rule with a service of "webhooks". This will continue to work, but should be renamed to "generic". Please adjust your config.`,
       );
     }
 

--- a/src/config/permissions.rs
+++ b/src/config/permissions.rs
@@ -41,13 +41,22 @@ impl BridgePermissions {
     #[napi(constructor)]
     pub fn new(config: Vec<BridgeConfigActorPermission>) -> Self {
         let mut room_membership = HashMap::new();
-        for entry in config.iter() {
+        let mut new_config = config.clone();
+        for entry in new_config.iter_mut() {
+            for perm in entry.services.iter_mut() {
+                // This is fixing a legacy mistake in that we used "webhooks"
+                // and "generic" interchangeably.
+                if perm.service.clone().is_some_and(|s| s == "webhooks") {
+                    perm.service = Some("generic".to_string())
+                }
+            }
             if entry.actor.starts_with('!') {
                 room_membership.insert(entry.actor.clone(), HashSet::new());
             }
         }
+
         BridgePermissions {
-            config,
+            config: new_config,
             room_membership,
         }
     }

--- a/tests/config/permissions.ts
+++ b/tests/config/permissions.ts
@@ -200,6 +200,22 @@ describe("Config/BridgePermissions", () => {
       expect(bridgePermissions.checkAction("@foo:bar", "my-service", "login"))
         .to.be.false;
     });
+
+    it("handles legacy 'webhooks' config field", () => {
+      const bridgePermissions = new BridgePermissions([
+        {
+          actor: "@foo:bar",
+          services: [{ service: "webhooks", level: "manageConnections" }],
+        },
+      ]);
+      expect(
+        bridgePermissions.checkAction(
+          "@foo:bar",
+          "generic",
+          "manageConnections",
+        ),
+      ).to.be.true;
+    });
   });
 
   describe("permissionsCheckActionAny", () => {


### PR DESCRIPTION
I've also checked the other commands and they actually do use the uniform ConnectionType.ServiceCategory system.

This is not a security issue, as the bug meant you actually needed to provide more permissive config than should be necessary.