### PR TITLE
Skip changelog if the PR is a task

### DIFF
--- a/.github/workflows/newsfile.yml
+++ b/.github/workflows/newsfile.yml
@@ -3,7 +3,7 @@ name: Newsfile
 on:
   pull_request:
     branches: [main]
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled]
 
 permissions: {}
 

--- a/.github/workflows/newsfile.yml
+++ b/.github/workflows/newsfile.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     # No newsfile required for tasks
-    if: ${{ contains( github.event.pull_request.labels.*.name, 'T-Task') }}
+    if: ${{ !contains( github.event.pull_request.labels.*.name, 'T-Task') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with: # Needed for comparison

--- a/.github/workflows/newsfile.yml
+++ b/.github/workflows/newsfile.yml
@@ -3,7 +3,6 @@ name: Newsfile
 on:
   pull_request:
     branches: [main]
-  merge_group:
 
 permissions: {}
 
@@ -12,8 +11,8 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    # No newsfile required for dependabot
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
+    # No newsfile required for tasks
+    if: ${{ contains( github.event.pull_request.labels.*.name, 'T-Task') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with: # Needed for comparison

--- a/.github/workflows/newsfile.yml
+++ b/.github/workflows/newsfile.yml
@@ -3,6 +3,7 @@ name: Newsfile
 on:
   pull_request:
     branches: [main]
+    types: [labeled]
 
 permissions: {}
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
+  "extends": ["config:recommended"],
+  "labels": ["T-Task"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
This should stop us from having to force merge dependency fixes which don't need a changelog.