### PR TITLE
Test formatting of various GitHub and GitLab webhook messages

### DIFF
--- a/changelog.d/1324.bugfix
+++ b/changelog.d/1324.bugfix
@@ -1,0 +1,1 @@
+Fix some messages from GitHub/GitLab ending up on one line.

--- a/src/Connections/CommandConnection.ts
+++ b/src/Connections/CommandConnection.ts
@@ -15,6 +15,9 @@ import { MatrixMessageContent, MatrixEvent } from "../MatrixEvent";
 import { BaseConnection } from "./BaseConnection";
 import { IConnectionState, PermissionCheckFn } from ".";
 import { IJsonType } from "matrix-bot-sdk/lib/helpers/Types";
+import { BridgeConfigMessaging } from "../config/sections";
+import markdownit from "markdown-it";
+const md = markdownit();
 const log = new Logger("CommandConnection");
 
 /**
@@ -32,6 +35,7 @@ export abstract class CommandConnection<
     canonicalStateType: string,
     protected state: ValidatedStateType,
     private readonly botClient: MatrixClient,
+    protected readonly msgConfig: BridgeConfigMessaging,
     private readonly botCommands: BotCommands,
     private readonly helpMessage: HelpFunction,
     protected readonly helpCategories: string[],
@@ -118,5 +122,25 @@ export abstract class CommandConnection<
         this.includeTitlesInHelp,
       ),
     );
+  }
+
+  protected sendEvent(
+    body: string,
+    extraContent: any = {},
+    opts = { inline: true },
+  ) {
+    const content = this.msgConfig.formatMatrixMessage(
+      {
+        msgtype: "m.notice",
+        body,
+        formatted_body: opts.inline ? md.renderInline(body) : md.render(body),
+        format: "org.matrix.custom.html",
+        ...extraContent,
+      },
+      {
+        allowUrlPreviews: this.state.showUrlPreviews,
+      },
+    );
+    return this.botClient.sendMessage(this.roomId, content);
   }
 }

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -108,7 +108,6 @@ export interface GitHubRepoConnectionOptions extends IConnectionState {
     includingWorkflows?: string[];
     excludingWorkflows?: string[];
   };
-  showUrlPreviews?: boolean;
 }
 
 export interface GitHubRepoConnectionState extends GitHubRepoConnectionOptions {
@@ -786,22 +785,6 @@ export class GitHubRepoConnection
     );
   }
 
-  public sendEvent(body: string, extraContent: any = {}) {
-    const content = this.msgConfig.formatMatrixMessage(
-      {
-        msgtype: "m.notice",
-        body,
-        formatted_body: md.renderInline(body),
-        format: "org.matrix.custom.html",
-        ...extraContent,
-      },
-      {
-        allowUrlPreviews: this.state.showUrlPreviews,
-      },
-    );
-    return this.intent.sendEvent(this.roomId, content);
-  }
-
   public async handleIssueHotlink(
     ev: MatrixEvent<MatrixMessageContent>,
   ): Promise<boolean> {
@@ -1432,7 +1415,7 @@ export class GitHubRepoConnection
           msgtype: "m.notice",
           body:
             content +
-            (labels.plain.length > 0 ? ` with labels ${labels}` : "") +
+            (labels.plain.length > 0 ? ` with labels ${labels.plain}` : "") +
             diffContent,
           formatted_body:
             md.renderInline(content) +
@@ -1493,7 +1476,7 @@ export class GitHubRepoConnection
       return;
     }
     log.info(
-      `onPRReadyForReview ${this.roomId} ${this.org}/${this.repo} #${event.pull_request.number}`,
+      `onPRReviewed ${this.roomId} ${this.org}/${this.repo} #${event.pull_request.number}`,
     );
     if (!event.pull_request) {
       throw Error("No pull_request content!");

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -709,7 +709,7 @@ export class GitHubRepoConnection
     stateKey: string,
     private readonly githubInstance: GithubInstance,
     private readonly config: BridgeConfigGitHub,
-    private readonly msgConfig: BridgeConfigMessaging,
+    msgConfig: BridgeConfigMessaging,
   ) {
     super(
       roomId,
@@ -717,6 +717,7 @@ export class GitHubRepoConnection
       GitHubRepoConnection.CanonicalEventType,
       state,
       intent.underlyingClient,
+      msgConfig,
       GitHubRepoConnection.botCommands,
       GitHubRepoConnection.helpMessage,
       ["github"],

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -2,7 +2,6 @@ import { UserTokenStore } from "../tokens/UserTokenStore";
 import { Appservice, Intent, StateEvent } from "matrix-bot-sdk";
 import { BotCommands, botCommand, compileBotCommands } from "../BotCommands";
 import { MatrixEvent, MatrixMessageContent } from "../MatrixEvent";
-import markdown from "markdown-it";
 import { Logger } from "matrix-appservice-bridge";
 import {
   IGitlabMergeRequest,
@@ -56,7 +55,6 @@ export interface GitLabRepoConnectionState extends IConnectionState {
   pushTagsRegex?: string;
   includingLabels?: string[];
   excludingLabels?: string[];
-  showUrlPreviews?: boolean;
 }
 
 interface ConnectionStateValidated extends GitLabRepoConnectionState {
@@ -79,8 +77,6 @@ export type GitLabRepoConnectionTarget =
   | GitLabRepoConnectionProjectTarget;
 
 const log = new Logger("GitLabRepoConnection");
-const md = new markdown();
-
 const PUSH_MAX_COMMITS = 5;
 
 export type GitLabRepoResponseItem =
@@ -581,7 +577,7 @@ export class GitLabRepoConnection
     private readonly tokenStore: UserTokenStore,
     private readonly instance: GitLabInstance,
     private readonly storage: IBridgeStorageProvider,
-    private readonly msgConfig: BridgeConfigMessaging,
+    msgConfig: BridgeConfigMessaging,
   ) {
     super(
       roomId,
@@ -589,6 +585,7 @@ export class GitLabRepoConnection
       GitLabRepoConnection.CanonicalEventType,
       state,
       intent.underlyingClient,
+      msgConfig,
       GitLabRepoConnection.botCommands,
       GitLabRepoConnection.helpMessage,
       ["gitlab"],
@@ -601,20 +598,6 @@ export class GitLabRepoConnection
     }
     this.hookFilter = new HookFilter(state.enableHooks ?? DefaultHooks);
     this.commentDebounceMs = config.commentDebounceMs;
-  }
-
-  private sendEvent(body: string, extraContent: Record<string, unknown> = {}) {
-    const content = this.msgConfig.formatMatrixMessage(
-      {
-        msgtype: "m.notice",
-        body,
-        formatted_body: md.renderInline(body),
-        format: "org.matrix.custom.html",
-        ...extraContent,
-      },
-      { allowUrlPreviews: this.state.showUrlPreviews },
-    );
-    return this.intent.sendEvent(this.roomId, content);
   }
 
   public get path() {
@@ -705,12 +688,7 @@ export class GitLabRepoConnection
     });
 
     const content = `Created issue #${res.iid}: [${res.web_url}](${res.web_url})`;
-    return this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.render(content),
-      format: "org.matrix.custom.html",
-    });
+    return this.sendEvent(content);
   }
 
   @botCommand(
@@ -736,12 +714,7 @@ export class GitLabRepoConnection
     });
 
     const content = `Created confidential issue #${res.iid}: [${res.web_url}](${res.web_url})`;
-    return this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.render(content),
-      format: "org.matrix.custom.html",
-    });
+    return this.sendEvent(content);
   }
 
   @botCommand("close", "Close an issue", ["number"], ["comment"], true)
@@ -777,12 +750,7 @@ export class GitLabRepoConnection
     this.validateMREvent(event);
     const orgRepoName = event.project.path_with_namespace;
     const content = `**${event.user.username}** opened a new MR [${orgRepoName}!${event.object_attributes.iid}](${event.object_attributes.url}): "${event.object_attributes.title}"`;
-    await this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.renderInline(content),
-      format: "org.matrix.custom.html",
-    });
+    await this.sendEvent(content);
   }
 
   public async onMergeRequestReopened(event: IGitLabWebhookMREvent) {
@@ -798,12 +766,7 @@ export class GitLabRepoConnection
     this.validateMREvent(event);
     const orgRepoName = event.project.path_with_namespace;
     const content = `**${event.user.username}** reopened MR [${orgRepoName}!${event.object_attributes.iid}](${event.object_attributes.url}): "${event.object_attributes.title}"`;
-    await this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.renderInline(content),
-      format: "org.matrix.custom.html",
-    });
+    await this.sendEvent(content);
   }
 
   public async onMergeRequestClosed(event: IGitLabWebhookMREvent) {
@@ -819,12 +782,7 @@ export class GitLabRepoConnection
     this.validateMREvent(event);
     const orgRepoName = event.project.path_with_namespace;
     const content = `**${event.user.username}** closed MR [${orgRepoName}!${event.object_attributes.iid}](${event.object_attributes.url}): "${event.object_attributes.title}"`;
-    await this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.renderInline(content),
-      format: "org.matrix.custom.html",
-    });
+    await this.sendEvent(content);
   }
 
   public async onMergeRequestMerged(event: IGitLabWebhookMREvent) {
@@ -840,12 +798,7 @@ export class GitLabRepoConnection
     this.validateMREvent(event);
     const orgRepoName = event.project.path_with_namespace;
     const content = `**${event.user.username}** merged MR [${orgRepoName}!${event.object_attributes.iid}](${event.object_attributes.url}): "${event.object_attributes.title}"`;
-    await this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.renderInline(content),
-      format: "org.matrix.custom.html",
-    });
+    await this.sendEvent(content);
   }
 
   public async onMergeRequestUpdate(event: IGitLabWebhookMREvent) {
@@ -875,12 +828,7 @@ export class GitLabRepoConnection
       // Back to draft.
       content = `**${event.user.username}** marked MR [${orgRepoName}!${event.object_attributes.iid}](${event.object_attributes.url}) as draft "${event.object_attributes.title}" `;
     }
-    await this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.renderInline(content),
-      format: "org.matrix.custom.html",
-    });
+    await this.sendEvent(content);
   }
 
   public async onGitLabTagPush(event: IGitLabWebhookTagPushEvent) {
@@ -896,12 +844,7 @@ export class GitLabRepoConnection
     }
     const url = `${event.project.homepage}/-/tree/${tagname}`;
     const content = `**${event.user_name}** pushed tag [\`${tagname}\`](${url}) for ${event.project.path_with_namespace}`;
-    await this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.renderInline(content),
-      format: "org.matrix.custom.html",
-    });
+    await this.sendEvent(content);
   }
 
   public async onGitLabPush(event: IGitLabWebhookPushEvent) {
@@ -945,12 +888,7 @@ export class GitLabRepoConnection
       }
     }
 
-    await this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.render(content),
-      format: "org.matrix.custom.html",
-    });
+    await this.sendEvent(content, {}, { inline: false });
   }
 
   public async onWikiPageEvent(data: IGitLabWebhookWikiPageEvent) {
@@ -972,29 +910,19 @@ export class GitLabRepoConnection
     const message = attributes.message && ` "${attributes.message}"`;
 
     const content = `**${data.user.username}** ${statement} "[${attributes.title}](${attributes.url})" for ${data.project.path_with_namespace} ${message}`;
-    await this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.renderInline(content),
-      format: "org.matrix.custom.html",
-    });
+    await this.sendEvent(content);
   }
 
   public async onRelease(data: IGitLabWebhookReleaseEvent) {
     if (this.hookFilter.shouldSkip("release", "release.created")) {
       return;
     }
-    log.info(`onReleaseCreated ${this.roomId} ${this.toString()} ${data.tag}`);
+    log.info(`onRelease ${this.roomId} ${this.toString()} ${data.tag}`);
     const orgRepoName = data.project.path_with_namespace;
     const content = `**${data.commit.author.name}** 🪄 released [${data.name}](${data.url}) for ${orgRepoName}
 
 ${data.description}`;
-    await this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.render(content),
-      format: "org.matrix.custom.html",
-    });
+    await this.sendEvent(content, {}, { inline: false });
   }
 
   private async renderDebouncedMergeRequest(
@@ -1041,7 +969,7 @@ ${data.description}`;
     if (result.approved === true) {
       action = "✅ approved";
     } else if (result.approved === false) {
-      action = "🔴 unapproved";
+      action = "🔴 requested changes";
     }
 
     const target = relation
@@ -1049,26 +977,16 @@ ${data.description}`;
       : ` MR [${orgRepoName}!${mergeRequest.iid}](${mergeRequest.url}): "${mergeRequest.title}"`;
     let content = `**${result.author}** ${action}${target} ${comments}`;
 
-    let formatted = "";
     if (result.commentNotes) {
       content += "\n\n> " + result.commentNotes.join("\n\n> ");
-      formatted = md.render(content);
-    } else {
-      formatted = md.renderInline(content);
     }
 
-    const eventPromise = this.intent
-      .sendEvent(this.roomId, {
-        msgtype: "m.notice",
-        body: content,
-        formatted_body: formatted,
-        format: "org.matrix.custom.html",
-        ...relation,
-      })
-      .catch((ex) => {
-        log.error("Failed to send MR review message", ex);
-        return undefined;
-      });
+    const eventPromise = this.sendEvent(content, relation, {
+      inline: !result.commentNotes,
+    }).catch((ex) => {
+      log.error("Failed to send MR review message", ex);
+      return undefined;
+    });
 
     for (const discussionId of result.discussions) {
       if (!this.discussionThreads.has(discussionId)) {
@@ -1149,7 +1067,7 @@ ${data.description}`;
       return;
     }
     log.info(
-      `onMergeRequestReviewed ${this.roomId} ${this.instance}/${this.path} !${event.object_attributes.iid}`,
+      `onMergeRequestReviewed ${this.roomId} ${event.project.path_with_namespace} !${event.object_attributes.iid}`,
     );
     this.validateMREvent(event);
     this.debounceMergeRequestReview(
@@ -1174,9 +1092,10 @@ ${data.description}`;
     ) {
       return;
     }
+    const orgRepoName = event.project.path_with_namespace;
 
     log.info(
-      `onMergeRequestReviewed ${this.roomId} ${this.instance}/${this.path} !${event.object_attributes.iid}`,
+      `onMergeRequestIndividualReview ${this.roomId} ${orgRepoName} !${event.object_attributes.iid}`,
     );
     this.validateMREvent(event);
     this.debounceMergeRequestReview(
@@ -1206,7 +1125,7 @@ ${data.description}`;
       return;
     }
     log.info(
-      `onCommentCreated ${this.roomId} ${this.toString()} !${event.merge_request?.iid} ${event.object_attributes.id}`,
+      `onMergeRequestCommentCreated ${this.roomId} ${this.toString()} !${event.merge_request?.iid} ${event.object_attributes.id}`,
     );
 
     this.debounceMergeRequestReview(

--- a/src/Connections/IConnection.ts
+++ b/src/Connections/IConnection.ts
@@ -26,6 +26,7 @@ export type PermissionCheckFn = (
 export interface IConnectionState {
   priority?: number;
   commandPrefix?: string;
+  showUrlPreviews?: boolean;
 }
 
 export interface IConnection {

--- a/src/Connections/JiraProject.ts
+++ b/src/Connections/JiraProject.ts
@@ -13,7 +13,6 @@ import {
   JiraVersionEvent,
 } from "../jira/WebhookTypes";
 import { FormatUtil } from "../FormatUtil";
-import markdownit from "markdown-it";
 import {
   generateJiraWebLinkFromIssue,
   generateJiraWebLinkFromVersion,
@@ -55,7 +54,6 @@ export interface JiraProjectConnectionState extends IConnectionState {
   id?: string;
   url: string;
   events?: JiraAllowedEventsNames[];
-  showUrlPreviews?: boolean;
 }
 
 export interface JiraProjectConnectionInstanceTarget {
@@ -81,7 +79,6 @@ export type JiraProjectResponseItem =
   GetConnectionsResponseItem<JiraProjectConnectionState>;
 
 const log = new Logger("JiraProjectConnection");
-const md = new markdownit();
 
 /**
  * Handles rooms connected to a Jira project.
@@ -322,7 +319,7 @@ export class JiraProjectConnection
     state: JiraProjectConnectionState,
     stateKey: string,
     private readonly tokenStore: UserTokenStore,
-    private readonly msgConfig: BridgeConfigMessaging,
+    msgConfig: BridgeConfigMessaging,
   ) {
     super(
       roomId,
@@ -330,6 +327,7 @@ export class JiraProjectConnection
       JiraProjectConnection.CanonicalEventType,
       state,
       intent.underlyingClient,
+      msgConfig,
       JiraProjectConnection.botCommands,
       JiraProjectConnection.helpMessage,
       ["jira"],
@@ -344,20 +342,6 @@ export class JiraProjectConnection
       throw Error("State is missing both id and url, cannot create connection");
     }
     this.grantChecker = new JiraGrantChecker(as, tokenStore);
-  }
-
-  private sendEvent(body: string, extraContent: Record<string, unknown> = {}) {
-    const content = this.msgConfig.formatMatrixMessage(
-      {
-        msgtype: "m.notice",
-        body,
-        formatted_body: md.renderInline(body),
-        format: "org.matrix.custom.html",
-        ...extraContent,
-      },
-      { allowUrlPreviews: this.state.showUrlPreviews },
-    );
-    return this.intent.sendEvent(this.roomId, content);
   }
 
   public isInterestedInStateEvent(eventType: string, stateKey: string) {
@@ -398,13 +382,10 @@ export class JiraProjectConnection
     }
     const url = generateJiraWebLinkFromIssue(data.issue);
     const content = `${creator.displayName} created a new JIRA issue [${data.issue.key}](${url}): "${data.issue.fields.summary}"`;
-    await this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.renderInline(content),
-      format: "org.matrix.custom.html",
-      ...FormatUtil.getPartialBodyForJiraIssue(data.issue),
-    });
+    await this.sendEvent(
+      content,
+      FormatUtil.getPartialBodyForJiraIssue(data.issue),
+    );
   }
 
   public static getProvisionerDetails(botUserId: string) {
@@ -531,13 +512,11 @@ export class JiraProjectConnection
       content += `\n - ` + changes.join(`\n  - `);
     }
 
-    await this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.renderInline(content),
-      format: "org.matrix.custom.html",
-      ...FormatUtil.getPartialBodyForJiraIssue(data.issue),
-    });
+    await this.sendEvent(
+      content,
+      FormatUtil.getPartialBodyForJiraIssue(data.issue),
+      { inline: false },
+    );
   }
 
   public async onJiraVersionEvent(data: JiraVersionEvent) {
@@ -559,12 +538,7 @@ export class JiraProjectConnection
         : "") +
       `: [${data.version.name}](${url}) (_${data.version.description}_)`;
 
-    await this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.renderInline(content),
-      format: "org.matrix.custom.html",
-    });
+    await this.sendEvent(content);
   }
 
   private async getUserClientForProject(userId: string) {
@@ -657,12 +631,7 @@ export class JiraProjectConnection
       key: result.key as string,
     });
     const content = `Created JIRA issue ${result.key}: [${link}](${link})`;
-    return this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.render(content),
-      format: "org.matrix.custom.html",
-    });
+    return this.sendEvent(content);
   }
 
   @botCommand("issue-types", "Get issue types for this project", [], [], true)
@@ -681,12 +650,7 @@ export class JiraProjectConnection
     }
 
     const content = `Issue types: ${(result.issueTypes || []).map((t) => t.name).join(", ")}`;
-    return this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.render(content),
-      format: "org.matrix.custom.html",
-    });
+    return this.sendEvent(content);
   }
 
   @botCommand(

--- a/src/Connections/OpenProjectConnection.ts
+++ b/src/Connections/OpenProjectConnection.ts
@@ -14,7 +14,6 @@ import {
   UserID,
 } from "matrix-bot-sdk";
 import { Logger } from "matrix-appservice-bridge";
-import markdownit from "markdown-it";
 import { botCommand, BotCommands, compileBotCommands } from "../BotCommands";
 import { MatrixMessageContent } from "../MatrixEvent";
 import { CommandConnection } from "./CommandConnection";
@@ -66,7 +65,6 @@ export interface OpenProjectConnectionState extends IConnectionState {
    */
   url: string;
   events: OpenProjectEventsNames[];
-  showUrlPreviews?: boolean;
 }
 
 export type OpenProjectResponseItem =
@@ -136,7 +134,6 @@ function validateOpenProjectConnectionState(
 }
 
 const log = new Logger("OpenProjectConnection");
-const md = new markdownit();
 
 /**
  * Handles rooms connected to a Jira project.
@@ -325,7 +322,7 @@ export class OpenProjectConnection
     stateKey: string,
     private readonly tokenStore: UserTokenStore,
     private readonly storage: IBridgeStorageProvider,
-    private readonly msgConfig: BridgeConfigMessaging,
+    msgConfig: BridgeConfigMessaging,
   ) {
     super(
       roomId,
@@ -333,6 +330,7 @@ export class OpenProjectConnection
       OpenProjectConnection.CanonicalEventType,
       state,
       intent.underlyingClient,
+      msgConfig,
       OpenProjectConnection.botCommands,
       OpenProjectConnection.helpMessage,
       ["openproject"],
@@ -342,20 +340,6 @@ export class OpenProjectConnection
     this.grantChecker = new OpenProjectGrantChecker(as, tokenStore);
     this.url = new URL(state.url);
     this.projectId = OpenProjectConnection.projectIdFromUrl(this.url);
-  }
-
-  private sendEvent(body: string, extraContent: Record<string, unknown> = {}) {
-    const content = this.msgConfig.formatMatrixMessage(
-      {
-        msgtype: "m.notice",
-        body,
-        formatted_body: md.renderInline(body),
-        format: "org.matrix.custom.html",
-        ...extraContent,
-      },
-      { allowUrlPreviews: this.state.showUrlPreviews },
-    );
-    return this.intent.sendEvent(this.roomId, content);
   }
 
   public isInterestedInStateEvent(eventType: string, stateKey: string) {
@@ -398,13 +382,7 @@ export class OpenProjectConnection
       this.config.baseURL,
     );
     const content = `${creator.name} created a new work package [${data.work_package.id}](${extraData["org.matrix.matrix-hookshot.openproject.work_package"].url}): "${data.work_package.subject}"`;
-    await this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.renderInline(content),
-      format: "org.matrix.custom.html",
-      ...extraData,
-    });
+    await this.sendEvent(content, extraData);
     await this.storage.setOpenProjectWorkPackageState(
       workPackageToCacheState(data.work_package),
       data.work_package.id,
@@ -459,13 +437,8 @@ export class OpenProjectConnection
     }
     const content = `**${creator.name}** ${changeStatement} for [${data.work_package.id}](${extraData["org.matrix.matrix-hookshot.openproject.work_package"].url}): "${data.work_package.subject}"`;
 
-    await this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content + (postfix ? postfix : ""),
-      formatted_body:
-        md.renderInline(content) + (postfix ? md.render(postfix) : ""),
-      format: "org.matrix.custom.html",
-      ...extraData,
+    await this.sendEvent(content + (postfix ?? ""), extraData, {
+      inline: false,
     });
   }
 
@@ -568,13 +541,7 @@ export class OpenProjectConnection
       this.config.baseURL,
     );
     const content = `${workPackage._embedded.author.name} created a new work package [${workPackage.id}](${extraData["org.matrix.matrix-hookshot.openproject.work_package"].url}): "${workPackage.subject}"`;
-    await this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.renderInline(content),
-      format: "org.matrix.custom.html",
-      ...extraData,
-    });
+    await this.sendEvent(content, extraData);
   }
 
   @botCommand("close", {
@@ -651,13 +618,7 @@ export class OpenProjectConnection
       this.config.baseURL,
     );
     const content = `${workPackage._embedded.author.name} closed work package [${workPackage.id}](${extraData["org.matrix.matrix-hookshot.openproject.work_package"].url}): "${workPackage.subject}"`;
-    await this.intent.sendEvent(this.roomId, {
-      msgtype: "m.notice",
-      body: content,
-      formatted_body: md.renderInline(content),
-      format: "org.matrix.custom.html",
-      ...extraData,
-    });
+    await this.sendEvent(content, extraData);
   }
 
   @botCommand("priority", {

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -89,6 +89,7 @@ export class SetupConnection extends CommandConnection {
       // TODO Consider storing room-specific config in state.
       {},
       provisionOpts.intent.underlyingClient,
+      provisionOpts.config.messaging,
       SetupConnection.botCommands,
       SetupConnection.helpMessage,
       helpCategories,

--- a/src/gitlab/WebhookTypes.ts
+++ b/src/gitlab/WebhookTypes.ts
@@ -101,22 +101,20 @@ export interface IGitLabWebhookPushEvent {
   user_email: string;
   project: IGitlabProject;
   repository: IGitlabRepository;
-  commits: [
-    {
-      id: string;
-      message: string;
-      title: string;
-      timestamp: string;
-      url: string;
-      author: {
-        name: string;
-        email: string;
-      };
-      added: string[];
-      modified: string[];
-      removed: string[];
-    },
-  ];
+  commits: {
+    id: string;
+    message: string;
+    title: string;
+    timestamp: string;
+    url: string;
+    author: {
+      name: string;
+      email: string;
+    };
+    added: string[];
+    modified: string[];
+    removed: string[];
+  }[];
   total_commits_count: number;
 }
 

--- a/tests/connections/GithubRepo.spec.ts
+++ b/tests/connections/GithubRepo.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   GitHubRepoConnection,
   GitHubRepoConnectionState,
@@ -27,6 +27,18 @@ const GITHUB_ISSUE = {
   html_url: `https://github.com/${GITHUB_ORG_REPO.org}/${GITHUB_ORG_REPO.repo}/issues/1234`,
   title: "My issue",
   assignees: [],
+};
+
+const GITHUB_PULL_REQUEST = {
+  id: 42,
+  number: 42,
+  user: { login: "alice" },
+  html_url: `https://github.com/${GITHUB_ORG_REPO.org}/${GITHUB_ORG_REPO.repo}/pull/42`,
+  title: "My pull request",
+  labels: [],
+  draft: false,
+  merged: false,
+  diff_url: `https://github.com/${GITHUB_ORG_REPO.org}/${GITHUB_ORG_REPO.repo}/pull/42.diff`,
 };
 
 const GITHUB_ISSUE_CREATED_PAYLOAD = {
@@ -252,6 +264,398 @@ describe("GitHubRepoConnection", () => {
         },
       } as never);
       intent.expectEventBodyContains("**alice** created new issue", 0);
+    });
+  });
+
+  describe("onIssueCommentCreated", () => {
+    it("will handle a comment on an issue", async () => {
+      const { connection, intent } = createConnection({
+        enableHooks: ["issue.comment.created"],
+      });
+      await connection.onIssueCommentCreated({
+        action: "created",
+        comment: { user: { login: "alice" }, body: "This is a test comment" },
+        issue: { ...GITHUB_ISSUE, labels: [] },
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+      } as never);
+      intent.expectEventBodyContains("**alice**", 0);
+      intent.expectEventBodyContains("This is a test comment", 0);
+      intent.expectEventBodyContains(GITHUB_ISSUE.html_url, 0);
+    });
+  });
+
+  describe("onIssueStateChange", () => {
+    it("will handle a closed issue", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onIssueStateChange({
+        action: "closed",
+        issue: { ...GITHUB_ISSUE, state: "closed", labels: [] },
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+      } as never);
+      intent.expectEventBodyContains("**alice**", 0);
+      intent.expectEventBodyContains("closed", 0);
+      intent.expectEventBodyContains(GITHUB_ISSUE.title, 0);
+    });
+
+    it("will handle a reopened issue", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onIssueStateChange({
+        action: "reopened",
+        issue: { ...GITHUB_ISSUE, state: "open", labels: [] },
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+      } as never);
+      intent.expectEventBodyContains("**alice**", 0);
+      intent.expectEventBodyContains("reopened", 0);
+    });
+  });
+
+  describe("onIssueEdited", () => {
+    it("will handle an edited issue", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onIssueEdited({
+        action: "edited",
+        issue: { ...GITHUB_ISSUE, state: "open", labels: [] },
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+        changes: {},
+      } as never);
+      intent.expectEventBodyContains("**alice**", 0);
+      intent.expectEventBodyContains("edited issue", 0);
+      intent.expectEventBodyContains(GITHUB_ISSUE.title, 0);
+    });
+  });
+
+  describe("onIssueLabeled", () => {
+    it("will send an event for a matching label after debounce", async () => {
+      const { connection, intent } = createConnection({
+        includingLabels: ["include-me"],
+      });
+      vi.useFakeTimers();
+      await connection.onIssueLabeled({
+        action: "labeled",
+        label: { name: "include-me" },
+        issue: {
+          ...GITHUB_ISSUE,
+          created_at: "2020-01-01T00:00:00Z",
+          labels: [{ name: "include-me", description: null, color: "#0000FF" }],
+        },
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+      } as never);
+      vi.runAllTimers();
+      vi.useRealTimers();
+      intent.expectEventBodyContains("**alice**", 0);
+      intent.expectEventBodyContains("labeled issue", 0);
+    });
+
+    it("will skip events when includingLabels is not configured", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onIssueLabeled({
+        action: "labeled",
+        label: { name: "any-label" },
+        issue: {
+          ...GITHUB_ISSUE,
+          created_at: "2020-01-01T00:00:00Z",
+          labels: [{ name: "any-label" }],
+        },
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+      } as never);
+      intent.expectNoEvent();
+    });
+  });
+
+  describe("onPROpened", () => {
+    it("will handle an opened PR", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onPROpened({
+        action: "opened",
+        pull_request: GITHUB_PULL_REQUEST,
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+      } as never);
+      intent.expectEventBodyContains("**alice**", 0);
+      intent.expectEventBodyContains("opened a new PR", 0);
+      intent.expectEventBodyContains(GITHUB_PULL_REQUEST.title, 0);
+      intent.expectEventBodyContains(GITHUB_PULL_REQUEST.html_url, 0);
+    });
+
+    it("will handle a draft PR", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onPROpened({
+        action: "opened",
+        pull_request: { ...GITHUB_PULL_REQUEST, draft: true },
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+      } as never);
+      intent.expectEventBodyContains("drafted", 0);
+    });
+
+    it("will include label names in the plain text body", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onPROpened({
+        action: "opened",
+        pull_request: {
+          ...GITHUB_PULL_REQUEST,
+          labels: [{ name: "bug", description: null, color: null }],
+        },
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+      } as never);
+      intent.expectEventBodyContains("bug", 0);
+    });
+  });
+
+  describe("onPRReadyForReview", () => {
+    it("will handle a PR marked as ready for review", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onPRReadyForReview({
+        action: "ready_for_review",
+        pull_request: GITHUB_PULL_REQUEST,
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+      } as never);
+      intent.expectEventBodyContains("**alice**", 0);
+      intent.expectEventBodyContains("ready to review", 0);
+      intent.expectEventBodyContains(GITHUB_PULL_REQUEST.title, 0);
+    });
+  });
+
+  describe("onPRReviewed", () => {
+    it("will handle an approved review", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onPRReviewed({
+        action: "submitted",
+        review: { state: "approved", user: { login: "bob" } },
+        pull_request: GITHUB_PULL_REQUEST,
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "bob" },
+      } as never);
+      intent.expectEventBodyContains("**bob**", 0);
+      intent.expectEventBodyContains("approved", 0);
+      intent.expectEventBodyContains(GITHUB_PULL_REQUEST.title, 0);
+    });
+
+    it("will handle a changes_requested review", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onPRReviewed({
+        action: "submitted",
+        review: { state: "changes_requested", user: { login: "bob" } },
+        pull_request: GITHUB_PULL_REQUEST,
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "bob" },
+      } as never);
+      intent.expectEventBodyContains("**bob**", 0);
+      intent.expectEventBodyContains("changes_requested", 0);
+    });
+
+    it("will skip unrecognised review states", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onPRReviewed({
+        action: "submitted",
+        review: { state: "commented", user: { login: "bob" } },
+        pull_request: GITHUB_PULL_REQUEST,
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "bob" },
+      } as never);
+      intent.expectNoEvent();
+    });
+  });
+
+  describe("onPRClosed", () => {
+    it("will handle a merged PR", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onPRClosed({
+        action: "closed",
+        pull_request: { ...GITHUB_PULL_REQUEST, merged: true },
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+      } as never);
+      intent.expectEventBodyContains("**alice**", 0);
+      intent.expectEventBodyContains("merged PR", 0);
+      intent.expectEventBodyContains(GITHUB_PULL_REQUEST.title, 0);
+    });
+
+    it("will handle a closed (not merged) PR", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onPRClosed({
+        action: "closed",
+        pull_request: { ...GITHUB_PULL_REQUEST, merged: false },
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+      } as never);
+      intent.expectEventBodyContains("**alice**", 0);
+      intent.expectEventBodyContains("closed PR", 0);
+    });
+  });
+
+  describe("onReleaseCreated", () => {
+    it("will handle a published release", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onReleaseCreated({
+        action: "published",
+        release: {
+          name: "v1.0.0",
+          tag_name: "v1.0.0",
+          html_url:
+            "https://github.com/a-fake-org/a-fake-repo/releases/tag/v1.0.0",
+          body: "Release notes here.",
+          draft: false,
+        },
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+      } as never);
+      intent.expectEventBodyContains("**alice**", 0);
+      intent.expectEventBodyContains("released", 0);
+      intent.expectEventBodyContains("v1.0.0", 0);
+    });
+  });
+
+  describe("onReleaseDrafted", () => {
+    it("will handle a drafted release", async () => {
+      const { connection, intent } = createConnection({
+        enableHooks: ["release.drafted"],
+      });
+      await connection.onReleaseDrafted({
+        action: "created",
+        release: {
+          name: "v2.0.0-draft",
+          tag_name: "v2.0.0",
+          html_url:
+            "https://github.com/a-fake-org/a-fake-repo/releases/tag/v2.0.0",
+          body: "Draft release notes.",
+          draft: true,
+        },
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+      } as never);
+      intent.expectEventBodyContains("**alice**", 0);
+      intent.expectEventBodyContains("drafted release", 0);
+      intent.expectEventBodyContains("v2.0.0-draft", 0);
+    });
+
+    it("will skip non-draft releases", async () => {
+      const { connection, intent } = createConnection({
+        enableHooks: ["release.drafted"],
+      });
+      await connection.onReleaseDrafted({
+        action: "created",
+        release: {
+          name: "v2.0.0",
+          tag_name: "v2.0.0",
+          html_url:
+            "https://github.com/a-fake-org/a-fake-repo/releases/tag/v2.0.0",
+          body: "",
+          draft: false,
+        },
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+      } as never);
+      intent.expectNoEvent();
+    });
+  });
+
+  describe("onWorkflowCompleted", () => {
+    it("will handle a successful workflow run", async () => {
+      const { connection, intent } = createConnection({
+        enableHooks: ["workflow"],
+      });
+      await connection.onWorkflowCompleted({
+        action: "completed",
+        workflow_run: {
+          id: 1,
+          name: "CI",
+          conclusion: "success",
+          html_url: "https://github.com/a-fake-org/a-fake-repo/actions/runs/1",
+          head_branch: "main",
+        },
+        workflow: { name: "CI" },
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+      } as never);
+      intent.expectEventBodyContains("CI", 0);
+      intent.expectEventBodyContains("completed successfully", 0);
+      intent.expectEventBodyContains("main", 0);
+    });
+
+    it("will handle a failed workflow run", async () => {
+      const { connection, intent } = createConnection({
+        enableHooks: ["workflow"],
+      });
+      await connection.onWorkflowCompleted({
+        action: "completed",
+        workflow_run: {
+          id: 1,
+          name: "CI",
+          conclusion: "failure",
+          html_url: "https://github.com/a-fake-org/a-fake-repo/actions/runs/1",
+          head_branch: "main",
+        },
+        workflow: { name: "CI" },
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+      } as never);
+      intent.expectEventBodyContains("failed", 0);
+    });
+
+    it("will filter out runs not matching matchingBranch", async () => {
+      const { connection, intent } = createConnection({
+        enableHooks: ["workflow"],
+        workflowRun: { matchingBranch: "^main$" },
+      });
+      await connection.onWorkflowCompleted({
+        action: "completed",
+        workflow_run: {
+          id: 1,
+          name: "CI",
+          conclusion: "success",
+          html_url: "https://github.com/a-fake-org/a-fake-repo/actions/runs/1",
+          head_branch: "feature/foo",
+        },
+        workflow: { name: "CI" },
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        sender: { login: "alice" },
+      } as never);
+      intent.expectNoEvent();
+    });
+  });
+
+  describe("onPush", () => {
+    it("will handle a push with multiple commits", async () => {
+      const { connection, intent } = createConnection({
+        enableHooks: ["push"],
+      });
+      await connection.onPush({
+        sender: { login: "alice" },
+        commits: [{ id: "abc123" }, { id: "def456" }],
+        compare: "https://github.com/a-fake-org/a-fake-repo/compare/abc..def",
+        ref: "refs/heads/main",
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        pusher: { name: "alice", email: "alice@example.com" },
+        base_ref: null,
+      } as never);
+      intent.expectEventBodyContains("**alice**", 0);
+      intent.expectEventBodyContains("2 commits", 0);
+      intent.expectEventBodyContains("refs/heads/main", 0);
+    });
+
+    it("will use singular form for a single-commit push", async () => {
+      const { connection, intent } = createConnection({
+        enableHooks: ["push"],
+      });
+      await connection.onPush({
+        sender: { login: "alice" },
+        commits: [{ id: "abc123" }],
+        compare: "https://github.com/a-fake-org/a-fake-repo/compare/abc..def",
+        ref: "refs/heads/main",
+        repository: GITHUB_ISSUE_CREATED_PAYLOAD.repository,
+        pusher: { name: "alice", email: "alice@example.com" },
+        base_ref: null,
+      } as never);
+      intent.expectEventBodyContains("1 commit", 0);
     });
   });
 });

--- a/tests/connections/GitlabRepo.spec.ts
+++ b/tests/connections/GitlabRepo.spec.ts
@@ -15,6 +15,11 @@ import {
   IGitlabProject,
   IGitlabUser,
   IGitLabWebhookNoteEvent,
+  IGitLabWebhookMREvent,
+  IGitLabWebhookTagPushEvent,
+  IGitLabWebhookPushEvent,
+  IGitLabWebhookWikiPageEvent,
+  IGitLabWebhookReleaseEvent,
 } from "../../src/gitlab/WebhookTypes";
 import { DefaultConfig } from "../../src/config/Defaults";
 
@@ -52,6 +57,25 @@ const GITLAB_ISSUE_CREATED_PAYLOAD = {
   user: GITLAB_USER,
   object_attributes: GITLAB_MR,
   project: GITLAB_PROJECT,
+};
+
+const GITLAB_MR_EVENT: IGitLabWebhookMREvent = {
+  object_kind: "merge_request",
+  event_type: "merge_request",
+  user: GITLAB_USER,
+  project: GITLAB_PROJECT,
+  repository: {
+    name: GITLAB_ORG_REPO.repo,
+    description: "",
+    homepage: GITLAB_PROJECT.web_url,
+    url: GITLAB_PROJECT.web_url,
+  },
+  object_attributes: {
+    ...GITLAB_MR,
+    action: "open",
+  },
+  labels: [],
+  changes: {},
 };
 
 const GITLAB_MR_COMMENT: IGitLabWebhookNoteEvent = {
@@ -217,6 +241,10 @@ describe("GitLabRepoConnection", () => {
         (ev: any) => ev.content.body.includes("**Alice** commented on MR"),
         "event body indicates MR comment",
       );
+      intent.expectEventBodyContains(
+        GITLAB_MR_COMMENT.project.path_with_namespace,
+        0,
+      );
     });
 
     it("will filter out issues not matching includingLabels.", async () => {
@@ -351,6 +379,10 @@ describe("GitLabRepoConnection", () => {
         GITLAB_ISSUE_CREATED_PAYLOAD.object_attributes.title,
         0,
       );
+      intent.expectEventBodyContains(
+        GITLAB_ISSUE_CREATED_PAYLOAD.project.path_with_namespace,
+        0,
+      );
     });
 
     it("will filter out issues not matching includingLabels.", async () => {
@@ -400,6 +432,402 @@ describe("GitLabRepoConnection", () => {
         ],
       } as never);
       intent.expectEventBodyContains("**alice** opened a new MR", 0);
+      intent.expectEventBodyContains(
+        GITLAB_ISSUE_CREATED_PAYLOAD.project.path_with_namespace,
+        0,
+      );
+    });
+  });
+
+  describe("onMergeRequestReopened", () => {
+    it("will handle a reopened MR", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onMergeRequestReopened({
+        ...GITLAB_MR_EVENT,
+        object_attributes: {
+          ...GITLAB_MR_EVENT.object_attributes,
+          action: "reopen",
+        },
+      });
+      intent.expectEventBodyContains("**alice** reopened MR", 0);
+      intent.expectEventBodyContains(GITLAB_MR.title, 0);
+      intent.expectEventBodyContains(GITLAB_MR.url, 0);
+      intent.expectEventBodyContains(
+        GITLAB_MR_EVENT.project.path_with_namespace,
+        0,
+      );
+    });
+
+    it("will filter out MRs matching excludingLabels", async () => {
+      const { connection, intent } = createConnection({
+        excludingLabels: ["blocked"],
+      });
+      await connection.onMergeRequestReopened({
+        ...GITLAB_MR_EVENT,
+        object_attributes: {
+          ...GITLAB_MR_EVENT.object_attributes,
+          action: "reopen",
+        },
+        labels: [{ title: "blocked" } as never],
+      });
+      intent.expectNoEvent();
+    });
+  });
+
+  describe("onMergeRequestClosed", () => {
+    it("will handle a closed MR", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onMergeRequestClosed({
+        ...GITLAB_MR_EVENT,
+        object_attributes: {
+          ...GITLAB_MR_EVENT.object_attributes,
+          action: "close",
+        },
+      });
+      intent.expectEventBodyContains("**alice** closed MR", 0);
+      intent.expectEventBodyContains(GITLAB_MR.title, 0);
+      intent.expectEventBodyContains(
+        GITLAB_MR_EVENT.project.path_with_namespace,
+        0,
+      );
+    });
+  });
+
+  describe("onMergeRequestMerged", () => {
+    it("will handle a merged MR", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onMergeRequestMerged({
+        ...GITLAB_MR_EVENT,
+        object_attributes: {
+          ...GITLAB_MR_EVENT.object_attributes,
+          action: "merge",
+        },
+      });
+      intent.expectEventBodyContains("**alice** merged MR", 0);
+      intent.expectEventBodyContains(GITLAB_MR.title, 0);
+      intent.expectEventBodyContains(
+        GITLAB_MR_EVENT.project.path_with_namespace,
+        0,
+      );
+    });
+  });
+
+  describe("onMergeRequestUpdate", () => {
+    it("will handle an MR marked as ready for review", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onMergeRequestUpdate({
+        ...GITLAB_MR_EVENT,
+        changes: { draft: { previous: true, current: false } },
+      });
+      intent.expectEventBodyContains("**alice**", 0);
+      intent.expectEventBodyContains("ready for review", 0);
+      intent.expectEventBodyContains(GITLAB_MR.title, 0);
+      intent.expectEventBodyContains(
+        GITLAB_MR_EVENT.project.path_with_namespace,
+        0,
+      );
+    });
+
+    it("will handle an MR converted back to draft", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onMergeRequestUpdate({
+        ...GITLAB_MR_EVENT,
+        changes: { draft: { previous: false, current: true } },
+      });
+      intent.expectEventBodyContains("**alice**", 0);
+      intent.expectEventBodyContains("as draft", 0);
+      intent.expectEventBodyContains(
+        GITLAB_MR_EVENT.project.path_with_namespace,
+        0,
+      );
+    });
+
+    it("will skip updates with no draft change", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onMergeRequestUpdate({
+        ...GITLAB_MR_EVENT,
+        changes: {},
+      });
+      intent.expectNoEvent();
+    });
+  });
+
+  describe("onGitLabTagPush", () => {
+    const GITLAB_TAG_PUSH_EVENT: IGitLabWebhookTagPushEvent = {
+      object_kind: "tag_push",
+      user_id: 1,
+      user_name: "Alice",
+      ref: "refs/tags/v1.0.0",
+      before: "0000000000000000000000000000000000000000",
+      after: "abc1234abc1234abc1234abc1234abc1234abc123",
+      project: GITLAB_PROJECT,
+      repository: {
+        name: GITLAB_ORG_REPO.repo,
+        description: "",
+        homepage: GITLAB_PROJECT.web_url,
+        url: GITLAB_PROJECT.web_url,
+      },
+    };
+
+    it("will handle a tag push", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onGitLabTagPush(GITLAB_TAG_PUSH_EVENT);
+      intent.expectEventBodyContains("**Alice**", 0);
+      intent.expectEventBodyContains("pushed tag", 0);
+      intent.expectEventBodyContains("v1.0.0", 0);
+      intent.expectEventBodyContains(
+        GITLAB_TAG_PUSH_EVENT.project.path_with_namespace,
+        0,
+      );
+    });
+
+    it("will filter tags not matching pushTagsRegex", async () => {
+      const { connection, intent } = createConnection({
+        pushTagsRegex: "^release-",
+      });
+      await connection.onGitLabTagPush(GITLAB_TAG_PUSH_EVENT);
+      intent.expectNoEvent();
+    });
+  });
+
+  describe("onGitLabPush", () => {
+    const GITLAB_PUSH_EVENT: IGitLabWebhookPushEvent = {
+      object_kind: "push",
+      before: "0000000000000000000000000000000000000000",
+      after: "abc1234abc1234abc1234abc1234abc1234abc123",
+      ref: "refs/heads/main",
+      user_id: 1,
+      user_name: "Alice",
+      user_email: "alice@example.org",
+      project: GITLAB_PROJECT,
+      repository: {
+        name: GITLAB_ORG_REPO.repo,
+        description: "",
+        homepage: GITLAB_PROJECT.web_url,
+        url: GITLAB_PROJECT.web_url,
+      },
+      commits: [
+        {
+          id: "abc1234abc1234abc1234abc1234abc1234abc123",
+          message: "Fix bug\n",
+          title: "Fix bug",
+          timestamp: "2024-01-01T00:00:00Z",
+          url: `${GITLAB_PROJECT.web_url}/-/commit/abc1234`,
+          author: { name: "Alice", email: "alice@example.org" },
+          added: [],
+          modified: ["README.md"],
+          removed: [],
+        },
+        {
+          id: "def5678def5678def5678def5678def5678def56",
+          message: "Add feature\n",
+          title: "Add feature",
+          timestamp: "2024-01-01T01:00:00Z",
+          url: `${GITLAB_PROJECT.web_url}/-/commit/def5678`,
+          author: { name: "Alice", email: "alice@example.org" },
+          added: ["src/feature.ts"],
+          modified: [],
+          removed: [],
+        },
+      ],
+      total_commits_count: 2,
+    } as IGitLabWebhookPushEvent;
+
+    it("will handle a push with multiple commits", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onGitLabPush(GITLAB_PUSH_EVENT);
+      intent.expectEventBodyContains("**Alice**", 0);
+      intent.expectEventBodyContains("2 commits", 0);
+      intent.expectEventBodyContains("main", 0);
+      intent.expectEventBodyContains(
+        GITLAB_PUSH_EVENT.project.path_with_namespace,
+        0,
+      );
+    });
+
+    it("will handle a push with a single commit", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onGitLabPush({
+        ...GITLAB_PUSH_EVENT,
+        commits: [
+          {
+            id: "aaa0000aaa0000aaa0000aaa0000aaa0000aaa00",
+            message: "Single change\n",
+            title: "Single change",
+            timestamp: "2024-01-01T00:00:00Z",
+            url: `${GITLAB_PROJECT.web_url}/-/commit/aaa0000`,
+            author: { name: "Alice", email: "alice@example.org" },
+            added: [],
+            modified: ["README.md"],
+            removed: [],
+          },
+        ],
+        total_commits_count: 1,
+      });
+      intent.expectEventBodyContains("1 commit", 0);
+      intent.expectEventBodyContains("Single change", 0);
+      intent.expectEventBodyContains(
+        GITLAB_PUSH_EVENT.project.path_with_namespace,
+        0,
+      );
+    });
+  });
+
+  describe("onWikiPageEvent", () => {
+    const baseWikiEvent: IGitLabWebhookWikiPageEvent = {
+      object_kind: "wiki_page",
+      user: GITLAB_USER,
+      project: GITLAB_PROJECT,
+      wiki: {
+        web_url: `${GITLAB_PROJECT.web_url}/-/wikis`,
+        path_with_namespace: `${GITLAB_ORG_REPO.org}/${GITLAB_ORG_REPO.repo}.wiki`,
+      },
+      object_attributes: {
+        title: "Home",
+        url: `${GITLAB_PROJECT.web_url}/-/wikis/home`,
+        message: "Initial commit",
+        format: "markdown",
+        content: "# Home",
+        action: "create",
+      },
+    };
+
+    it("will handle a wiki page creation", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onWikiPageEvent(baseWikiEvent);
+      intent.expectEventBodyContains("**alice**", 0);
+      intent.expectEventBodyContains("created new wiki page", 0);
+      intent.expectEventBodyContains("Home", 0);
+      intent.expectEventBodyContains(
+        GITLAB_MR_EVENT.project.path_with_namespace,
+        0,
+      );
+    });
+
+    it("will handle a wiki page update", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onWikiPageEvent({
+        ...baseWikiEvent,
+        object_attributes: {
+          ...baseWikiEvent.object_attributes,
+          action: "update",
+        },
+      });
+      intent.expectEventBodyContains("updated wiki page", 0);
+      intent.expectEventBodyContains(
+        GITLAB_MR_EVENT.project.path_with_namespace,
+        0,
+      );
+    });
+
+    it("will handle a wiki page deletion", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onWikiPageEvent({
+        ...baseWikiEvent,
+        object_attributes: {
+          ...baseWikiEvent.object_attributes,
+          action: "delete",
+        },
+      });
+      intent.expectEventBodyContains("deleted wiki page", 0);
+      intent.expectEventBodyContains(
+        GITLAB_MR_EVENT.project.path_with_namespace,
+        0,
+      );
+    });
+  });
+
+  describe("onRelease", () => {
+    const GITLAB_RELEASE_EVENT: IGitLabWebhookReleaseEvent = {
+      object_kind: "release",
+      description: "First stable release.",
+      name: "v1.0.0",
+      tag: "v1.0.0",
+      created_at: "2024-01-01T00:00:00Z",
+      released_at: "2024-01-01T00:00:00Z",
+      url: `${GITLAB_PROJECT.web_url}/-/releases/v1.0.0`,
+      action: "create",
+      project: GITLAB_PROJECT,
+      commit: {
+        id: "abc1234",
+        message: "Release v1.0.0",
+        title: "Release v1.0.0",
+        timestamp: "2024-01-01T00:00:00Z",
+        url: `${GITLAB_PROJECT.web_url}/-/commit/abc1234`,
+        author: { name: "Alice", email: "alice@example.org" },
+      },
+    } as IGitLabWebhookReleaseEvent;
+
+    it("will handle a release", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onRelease(GITLAB_RELEASE_EVENT);
+      intent.expectEventBodyContains("**Alice**", 0);
+      intent.expectEventBodyContains("released", 0);
+      intent.expectEventBodyContains("v1.0.0", 0);
+      intent.expectEventBodyContains("First stable release.", 0);
+      intent.expectEventBodyContains(
+        GITLAB_RELEASE_EVENT.project.path_with_namespace,
+        0,
+      );
+    });
+  });
+
+  describe("onMergeRequestReviewed", () => {
+    it("will handle an approved review", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onMergeRequestReviewed({
+        ...GITLAB_MR_EVENT,
+        object_attributes: {
+          ...GITLAB_MR_EVENT.object_attributes,
+          action: "approved",
+        },
+      });
+      await waitForDebouncing();
+      intent.expectEventBodyContains("**Alice**", 0);
+      intent.expectEventBodyContains("✅ approved", 0);
+      intent.expectEventBodyContains(GITLAB_MR.title, 0);
+      intent.expectEventBodyContains(
+        GITLAB_MR_EVENT.project.path_with_namespace,
+        0,
+      );
+    });
+
+    it("will handle an unapproved review", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onMergeRequestReviewed({
+        ...GITLAB_MR_EVENT,
+        object_attributes: {
+          ...GITLAB_MR_EVENT.object_attributes,
+          action: "unapproved",
+        },
+      });
+      await waitForDebouncing();
+      intent.expectEventBodyContains("🔴 requested changes", 0);
+      intent.expectEventBodyContains(
+        GITLAB_MR_EVENT.project.path_with_namespace,
+        0,
+      );
+    });
+  });
+
+  describe("onMergeRequestIndividualReview", () => {
+    it("will handle an individual review approval", async () => {
+      const { connection, intent } = createConnection();
+      await connection.onMergeRequestIndividualReview({
+        ...GITLAB_MR_EVENT,
+        object_attributes: {
+          ...GITLAB_MR_EVENT.object_attributes,
+          action: "approved",
+        },
+      });
+      await waitForDebouncing();
+      intent.expectEventBodyContains("**Alice**", 0);
+      intent.expectEventBodyContains("✅ approved", 0);
+      intent.expectEventBodyContains(GITLAB_MR.title, 0);
+      intent.expectEventBodyContains(
+        GITLAB_MR_EVENT.project.path_with_namespace,
+        0,
+      );
     });
   });
 });

--- a/tests/utils/IntentMock.ts
+++ b/tests/utils/IntentMock.ts
@@ -1,15 +1,20 @@
 import { expect } from "vitest";
 import { MatrixError } from "matrix-bot-sdk";
 import { MatrixCapabilities } from "matrix-bot-sdk/lib/models/Capabilities";
+
+type SentEvent = { roomId: string; content: Record<string, any> };
+
 export class MatrixClientMock {
   static create() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return new this() as any;
+    return new this([]) as any;
   }
 
   // map room Id → user Ids
   private joinedMembers: Map<string, string[]> = new Map();
   public readonly roomAccountData: Map<string, string> = new Map();
+
+  constructor(private readonly sentEvents: SentEvent[]) {}
 
   async setDisplayName() {
     return;
@@ -63,11 +68,23 @@ export class MatrixClientMock {
   ): Promise<void> {
     this.roomAccountData.set(roomId + key, value);
   }
+
+  async sendMessage(
+    roomId: string,
+    content: Record<string, unknown>,
+  ): Promise<string> {
+    this.sentEvents?.push({ roomId, content });
+    return `event_${this.sentEvents.length - 1}`;
+  }
+
+  async sendStateEvent(): Promise<string> {
+    return `$state_event_sent`;
+  }
 }
 
 export class IntentMock {
-  public readonly underlyingClient = new MatrixClientMock();
-  public sentEvents: { roomId: string; content: any }[] = [];
+  public sentEvents: SentEvent[] = [];
+  public readonly underlyingClient = new MatrixClientMock(this.sentEvents);
 
   constructor(readonly userId: string) {}
 
@@ -86,12 +103,8 @@ export class IntentMock {
     });
   }
 
-  sendEvent(roomId: string, content: any): Promise<string> {
-    this.sentEvents.push({
-      roomId,
-      content,
-    });
-    return Promise.resolve(`event_${this.sentEvents.length - 1}`);
+  sendEvent(roomId: string, content: Record<string, unknown>): Promise<string> {
+    return this.underlyingClient.sendMessage(roomId, content);
   }
 
   expectNoEvent() {
@@ -120,7 +133,7 @@ export class IntentMock {
   }
 
   expectEventMatches(
-    matcher: (content: any) => boolean,
+    matcher: (content: SentEvent) => boolean,
     description: string,
     eventIndex?: number,
   ) {


### PR DESCRIPTION
This does some general refactors and improvements to the connections code:
 - Put `sendEvent` into the abstract `CommandConnection` class.
 - Test the output of GitHub and GitLab connection classes to ensure they actually emit the right information
 - Fix a couple of cases where we emitted things inline that should not be inline.