### PR TITLE
Remove prepare script, build explicitly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,8 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
-      - run: pnpm install --frozen-lockfile # Need to build scripts to get rust bindings
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build # Need to build scripts to get rust bindings
       - run: pnpm exec ts-node src/config/Defaults.ts --config | diff config.sample.yml -
 
   metrics-docs:
@@ -96,7 +97,8 @@ jobs:
         with:
           node-version-file: .node-version
           cache: "pnpm"
-      - run: pnpm install --frozen-lockfile # Need to build scripts to get rust bindings
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build # Need to build scripts to get rust bindings
       - run: pnpm exec ts-node ./scripts/build-metrics-docs.ts | diff docs/metrics.md -
 
   test:
@@ -124,6 +126,7 @@ jobs:
         with:
           shared-key: ubuntu-2204-rust-cache
       - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
       - run: pnpm run test:cover
 
   integration-test:
@@ -150,4 +153,5 @@ jobs:
         with:
           shared-key: ubuntu-2204-rust-cache
       - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
       - run: pnpm run test:e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ ENV CARGO_NET_GIT_FETCH_WITH_CLI=$CARGO_NET_GIT_FETCH_WITH_CLI
 
 WORKDIR /src
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN corepack enable pnpm
 RUN pnpm config set store-dir /cache/pnpm-store
-RUN pnpm install --frozen-lockfile --ignore-scripts
+RUN pnpm install --frozen-lockfile
 
 COPY . ./
 
@@ -34,12 +34,12 @@ WORKDIR /bin/matrix-hookshot
 
 RUN apt-get update && apt-get install -y openssl ca-certificates
 
-COPY --from=builder /src/pnpm-lock.yaml /src/package.json ./
+COPY --from=builder /src/pnpm-lock.yaml /src/package.json /src/pnpm-workspace.yaml ./
 COPY --from=builder /cache/pnpm-store /cache/pnpm-store
 RUN corepack enable pnpm
 RUN pnpm config set store-dir /cache/pnpm-store
 
-RUN NODE_ENV=production pnpm install --frozen-lockfile --ignore-scripts && pnpm store prune
+RUN NODE_ENV=production pnpm install --frozen-lockfile && pnpm store prune
 
 COPY --from=builder /src/lib ./
 COPY --from=builder /src/public ./public

--- a/changelog.d/1328.bugfix
+++ b/changelog.d/1328.bugfix
@@ -1,0 +1,1 @@
+Fix Hookshot not starting due to a module error.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -24,6 +24,7 @@ To clone and install, run:
 git clone https://github.com/matrix-org/matrix-hookshot.git
 cd matrix-hookshot
 pnpm install
+pnpm build
 ```
 
 Starting the bridge (after configuring it), is a matter of setting the `NODE_ENV` environment variable to `production` or `development`, depending if you want [better performance or more verbose logging](https://expressjs.com/en/advanced/best-practice-performance.html#set-node_env-to-production), and then running it:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "clean:app:rs": "rimraf src/libRs.d.ts target/",
     "clean:docs": "mdbook clean",
     "clean": "scripts/clean.sh",
-    "prepare": "pnpm run build",
     "start": "node --require source-map-support/register lib/App/BridgeApp.js",
     "start:app": "node --require source-map-support/register lib/App/BridgeApp.js",
     "start:webhooks": "node --require source-map-support/register lib/App/GithubWebhookApp.js",


### PR DESCRIPTION
Fixes #1327 

This annoyingly requires us to drop the prepare script so installs don't automatically build Hookshot, but it's a small price to pay for a working Docker image.

