### PR TITLE
fix(openproject): preserve URL protocol in getOpenProjectSafeUrl

### DIFF
--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -874,7 +874,7 @@ export class SetupConnection extends CommandConnection {
         `The project url you entered was not valid. It should be part of ${expectedOrigin}`,
       );
     }
-    return `http://${url.host}/projects/${projectId}`;
+    return `${url.protocol}://${url.host}/projects/${projectId}`;
   }
 
   @botCommand("openproject add", {

--- a/src/Connections/SetupConnection.ts
+++ b/src/Connections/SetupConnection.ts
@@ -874,7 +874,7 @@ export class SetupConnection extends CommandConnection {
         `The project url you entered was not valid. It should be part of ${expectedOrigin}`,
       );
     }
-    return `${url.protocol}://${url.host}/projects/${projectId}`;
+    return new URL(`/projects/${projectId}`, url).toString();
   }
 
   @botCommand("openproject add", {


### PR DESCRIPTION
Related to #1353 

## Fix: OpenProject `getOpenProjectSafeUrl` hardcodes `http://` causing HTTPS origin mismatch

### Problem

When a user runs `!hookshot openproject add https://op-instance/projects/<id>` against an OpenProject instance served over HTTPS, the command always fails with:

```
Failed to handle command: Expected 'url' to match the origin 'https://op-instance'
```

### Root cause

In `src/Connections/SetupConnection.ts`, `getOpenProjectSafeUrl` sanitises the user-provided URL and returns a normalised form to pass to `provisionConnection`. However, it hardcodes the `http://` scheme regardless of the input:

```ts
return `http://${url.host}/projects/${projectId}`;
```

So a user input of `https://op.example.com/projects/42` produces `http://op.example.com/projects/42`.

`provisionConnection` then calls `validateOpenProjectConnectionState`, which asserts:

```ts
if (parsedUrl.origin !== baseUrl.origin) {
    throw new ApiError(`Expected 'url' to match the origin '${baseUrl.origin}'`, ErrCode.BadValue);
}
```

Since `config.openProject.baseURL.origin` is `https://op.example.com` but the safe URL origin is `http://op.example.com`, the check always fails on HTTPS instances.

### Testing

- Deployed Hookshot 7.3.2 against a self-hosted OpenProject 17.5 instance over HTTPS
- Without the fix: `!hookshot openproject add https://op.example.com/projects/8` fails with origin mismatch
- With the fix: command succeeds and the room is bridged correctly
