### PR TITLE
Use `receive_ephemeral` for the registration file and remove old MSC flags

### DIFF
--- a/changelog.d/1357.misc
+++ b/changelog.d/1357.misc
@@ -1,0 +1,1 @@
+Fix e2e tests to use the modern `receive_ephemeral` registration field instead of legacy MSC ephemeral-event flags.

--- a/changelog.d/1357.misc
+++ b/changelog.d/1357.misc
@@ -1,1 +1,2 @@
-Fix e2e tests to use the modern `receive_ephemeral` registration field instead of legacy MSC ephemeral-event flags.
+Use the `receive_ephemeral` registration field instead of legacy MSC ephemeral-event flags. Please ensure your
+registration file is updated to match the new format.

--- a/registration.sample.yml
+++ b/registration.sample.yml
@@ -22,7 +22,4 @@ sender_localpart: hookshot
 url: "http://localhost:9993" # This should match the bridge.port in your config file
 rate_limited: false
 
-# If enabling encryption
-de.sorunome.msc2409.push_ephemeral: true
-push_ephemeral: true
-org.matrix.msc3202: true
+receive_ephemeral: true

--- a/spec/util/containers.ts
+++ b/spec/util/containers.ts
@@ -230,9 +230,7 @@ export async function createContainers(
       users: [{ regex: "@hookshot_.*:hookshot", exclusive: false }],
       aliases: [],
     },
-    "de.sorunome.msc2409.push_ephemeral": true,
-    push_ephemeral: true,
-    "org.matrix.msc3202": true,
+    receive_ephemeral: true,
   };
 
   const container = await new SynapseContainer(name, { crypto })

--- a/spec/util/e2e-test.ts
+++ b/spec/util/e2e-test.ts
@@ -382,24 +382,25 @@ export class E2ETestEnv<ML extends string = string> {
       };
     }
 
-    const registration: IAppserviceRegistration = {
-      id: "hookshot",
-      url: null,
-      as_token: homeserver.asToken,
-      hs_token: homeserver.hsToken,
-      sender_localpart: "hookshot",
-      namespaces: {
-        users: [
-          {
-            regex: `@hookshot:${homeserver.domain}`,
-            exclusive: true,
-          },
-        ],
-        rooms: [],
-        aliases: [],
-      },
-      receive_ephemeral: true,
-    } as any;
+    const registration: IAppserviceRegistration & { receive_ephemeral: true } =
+      {
+        id: "hookshot",
+        url: null,
+        as_token: homeserver.asToken,
+        hs_token: homeserver.hsToken,
+        sender_localpart: "hookshot",
+        namespaces: {
+          users: [
+            {
+              regex: `@hookshot:${homeserver.domain}`,
+              exclusive: true,
+            },
+          ],
+          rooms: [],
+          aliases: [],
+        },
+        receive_ephemeral: true,
+      };
 
     const connectionRooms: Record<string, string> = {};
 

--- a/spec/util/e2e-test.ts
+++ b/spec/util/e2e-test.ts
@@ -398,8 +398,8 @@ export class E2ETestEnv<ML extends string = string> {
         rooms: [],
         aliases: [],
       },
-      "de.sorunome.msc2409.push_ephemeral": true,
-    };
+      receive_ephemeral: true,
+    } as any;
 
     const connectionRooms: Record<string, string> = {};
 


### PR DESCRIPTION
Should fix the issues with the integration test.