### PR TITLE
fix: fix security issue in Router.ts

### DIFF
--- a/src/github/Router.ts
+++ b/src/github/Router.ts
@@ -1,4 +1,5 @@
 import { Request, Response, Router, json } from "express";
+import { createHmac, timingSafeEqual } from "crypto";
 import { MessageQueue } from "../messageQueue";
 import { ApiError, ErrCode, wrapAsyncRequestHandler } from "../api";
 import { Logger } from "matrix-appservice-bridge";
@@ -83,16 +84,30 @@ export class GitHubWebhooksRouter {
         ErrCode.BadValue,
       );
     }
+    const signature = req.headers["x-hub-signature-256"];
     try {
       const jsonStr = buffer.toString(encoding);
+      const expectedSignature =
+        "sha256=" +
+        createHmac("sha256", this.config.webhook.secret)
+          .update(jsonStr)
+          .digest("hex");
+      const expected = Buffer.from(expectedSignature);
+      const actual = Buffer.from(signature);
+      if (
+        expected.length !== actual.length ||
+        !timingSafeEqual(expected, actual)
+      ) {
+        throw new Error("Signature did not match");
+      }
       req.github = {
         payload: jsonStr,
-        signature: req.headers["x-hub-signature-256"],
+        signature,
       };
     } catch (ex) {
-      log.warn("GitHub signature could not be decoded", ex);
+      log.warn("GitHub signature could not be verified", ex);
       throw new ApiError(
-        "Could not handle GitHub request. Signature could not be decoded",
+        "Could not handle GitHub request. Signature could not be verified",
         ErrCode.BadValue,
       );
     }


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `src/github/Router.ts`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src/github/Router.ts:115` |
| **Assessment** | Likely exploitable |

**Description**: The GitHub webhook endpoint stores the X-Hub-Signature-256 header without validating it against the payload using HMAC-SHA256. The verifyRequest() method only persists the signature, while verifyAndReceive() is called asynchronously after the HTTP 200 response is sent. Verification failures are merely logged, allowing forged webhooks to be processed as legitimate events.

## Evidence

**Exploitation scenario**: Send POST request to /github/webhook with arbitrary JSON payload and any valid-looking X-Hub-Signature-256 header.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `src/github/Router.ts`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

## Security Invariant
> **Property**: The security boundary is maintained under adversarial input

<details>
<summary>Regression test</summary>

```typescript
import { describe, test, expect } from "vitest";
import { Router } from "../src/github/Router";

describe("webhook signature verification must reject forged or missing signatures", () => {
  const testCases = [
    { name: "forged signature", signature: "sha256=forged123", payload: '{"action":"test"}' },
    { name: "missing signature", signature: undefined, payload: '{"action":"test"}' },
    { name: "empty signature", signature: "", payload: '{"action":"test"}' },
  ];

  test.each(testCases)("rejects $name", ({ signature, payload }) => {
    const router = new Router({ secret: "valid-secret" });
    const req = { headers: { "x-hub-signature-256": signature } };
    const buffer = Buffer.from(payload);

    expect(() => router.verifyRequest(req, {}, buffer, "utf8")).toThrow();
    expect(req.github).toBeUndefined();
  });
});
```

</details>

This test guards against regressions — it's useful independent of the code change above.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
